### PR TITLE
providers: privatize MockProvider and MockProviderCreator members

### DIFF
--- a/exec/engine_test.go
+++ b/exec/engine_test.go
@@ -34,8 +34,8 @@ func TestAddProvider(t *testing.T) {
 		providers map[string]providers.Provider
 	}
 
-	a := test.MockProvider{Name_: "a"}
-	b := test.MockProvider{Name_: "b"}
+	a := test.MockProvider{name: "a"}
+	b := test.MockProvider{name: "b"}
 
 	tests := []struct {
 		in  in
@@ -81,8 +81,8 @@ func TestProviders(t *testing.T) {
 		providers []providers.Provider
 	}
 
-	a := test.MockProvider{Name_: "a"}
-	b := test.MockProvider{Name_: "b"}
+	a := test.MockProvider{name: "a"}
+	b := test.MockProvider{name: "b"}
 
 	tests := []struct {
 		in  in

--- a/providers/mock_provider.go
+++ b/providers/mock_provider.go
@@ -22,26 +22,24 @@ import (
 )
 
 type MockProvider struct {
-	// Go is a poorly thought-out language, resulting in hacks like 'Name_'
-	// littered throughout the codebase.
-	Name_   string
-	Config  config.Config
-	Err     error
-	Online  bool
-	Retry   bool
-	Backoff time.Duration
+	name    string
+	config  config.Config
+	err     error
+	online  bool
+	retry   bool
+	backoff time.Duration
 }
 
-func (p MockProvider) Name() string                        { return p.Name_ }
-func (p MockProvider) FetchConfig() (config.Config, error) { return p.Config, p.Err }
-func (p MockProvider) IsOnline() bool                      { return p.Online }
-func (p MockProvider) ShouldRetry() bool                   { return p.Retry }
-func (p MockProvider) BackoffDuration() time.Duration      { return p.Backoff }
+func (p MockProvider) Name() string                        { return p.name }
+func (p MockProvider) FetchConfig() (config.Config, error) { return p.config, p.err }
+func (p MockProvider) IsOnline() bool                      { return p.online }
+func (p MockProvider) ShouldRetry() bool                   { return p.retry }
+func (p MockProvider) BackoffDuration() time.Duration      { return p.backoff }
 
 type MockProviderCreator struct {
-	Name_    string
-	Provider Provider
+	name     string
+	provider Provider
 }
 
-func (c MockProviderCreator) Name() string                 { return c.Name_ }
-func (c MockProviderCreator) Create(_ log.Logger) Provider { return c.Provider }
+func (c MockProviderCreator) Name() string                 { return c.name }
+func (c MockProviderCreator) Create(_ log.Logger) Provider { return c.provider }

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -15,8 +15,8 @@
 package providers
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 )
 
 func TestRegister(t *testing.T) {
@@ -27,9 +27,9 @@ func TestRegister(t *testing.T) {
 		providers map[string]ProviderCreator
 	}
 
-	a := MockProviderCreator{Name_: "a"}
-	b := MockProviderCreator{Name_: "b"}
-	c := MockProviderCreator{Name_: "c"}
+	a := MockProviderCreator{name: "a"}
+	b := MockProviderCreator{name: "b"}
+	c := MockProviderCreator{name: "c"}
 
 	tests := []struct {
 		in  in
@@ -47,7 +47,7 @@ func TestRegister(t *testing.T) {
 
 	for i, test := range tests {
 		providers = map[string]ProviderCreator{}
-		for _, p := range test.in.providers{
+		for _, p := range test.in.providers {
 			Register(p)
 		}
 		if !reflect.DeepEqual(test.out.providers, providers) {
@@ -59,15 +59,15 @@ func TestRegister(t *testing.T) {
 func TestGet(t *testing.T) {
 	type in struct {
 		providers map[string]ProviderCreator
-		name string
+		name      string
 	}
 	type out struct {
 		creator ProviderCreator
 	}
 
-	a := MockProviderCreator{Name_: "a"}
-	b := MockProviderCreator{Name_: "b"}
-	c := MockProviderCreator{Name_: "c"}
+	a := MockProviderCreator{name: "a"}
+	b := MockProviderCreator{name: "b"}
+	c := MockProviderCreator{name: "c"}
 
 	tests := []struct {
 		in  in


### PR DESCRIPTION
There's no need for these to be public, and it's their public form
which conflicts with the interface function names.

They _should_ be private if the interface is of any value.

Gets rid of the Name_ jank.