### PR TITLE
doc: introduce wipe-table for disks

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -4,6 +4,7 @@ This is a brain dump of a configuration file.
 storage:
   disks:
     - device: "/dev/sda"
+      wipe-table: true
       partitions:
         - label: "raid.1.1"
           number: 1
@@ -14,10 +15,12 @@ storage:
             guid:
           size: 10GB
     - device: "/dev/sdb"
+      wipe-table: true
       partitions:
         - name: "raid.1.2"
           size: 10GB
     - device: "/dev/sdc"
+      wipe-table: true
       partitions:
         - name: "raid.1.3"
           size: 10GB


### PR DESCRIPTION
The wipe-table directive can be used to effectively "force" the partition
create to succeed by first clearing any existing partition table.

It may also be used to simply clear the partition table of the respective
disk if no partitions are defined.

Without first wiping, a partition create may fail if it collides with
existing partitions, which should cause ignition to fail.