### PR TITLE
config: introduce "allocate" structure for files

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -61,6 +61,20 @@ storage:
 
             sed -i -e "/^${VARIABLE}=/d" "${FILE}"
             echo "${VARIABLE}=${ip}" >> "${FILE}"
+    - device: "/dev/md0"
+      name: "vms"
+      format: ext4
+      files:
+        - path: "/images/sparse.img"
+          permissions: 0640
+          allocate:
+            - type: sparse
+            - size: 10GB
+    - device: "vms:/images/sparse.img"
+      format: ext4
+      format-options:
+        - "-E"
+        - "lazy_itable_init=0,lazy_journal_init=0"
 
 systemd:
   units:


### PR DESCRIPTION
The "allocate" structure can be used to pre-allocate (fallocate(2)) or
sparse-create (truncate(2)) files.

allocate:
  - type: (sparse|allocate|allocate-empty)
  - size: 10GB

This may be used with or without content.

type=allocate		= fallocate $file
type=allocate-empty	= fallocate --keep-size $file
type=sparse		= truncate -s $size $file

I've also introduced a "name" field for filesystems, this serves to
identify one filesystem from another's device path:

    - device: "/dev/md0"
      name: "vms"
      format: ext4
      files:
        - path: "/images/sparse.img"
          permissions: 0640
          allocate:
            - type: sparse
            - size: 10GB
    - device: "vms:/images/sparse.img"
      format: ext4