### PR TITLE
    exec/util: introduce DestDir type for influencing file/dir creates

### DIFF
--- a/exec/util/destdir.go
+++ b/exec/util/destdir.go
@@ -1,0 +1,28 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"path/filepath"
+)
+
+// DestDir is used to influence the creation of files and directories
+// This path is applied at the point of interfacing with the filesystem.
+type DestDir string // directory prefix to use in applying fs paths
+
+// JoinPath returns a path into the context ala filepath.Join(d.root, args)
+func (d *DestDir) JoinPath(path ...string) string {
+	return filepath.Join(string(*d), filepath.Join(path...))
+}

--- a/exec/util/file.go
+++ b/exec/util/file.go
@@ -32,16 +32,19 @@ type File struct {
 	config.File
 }
 
-func WriteFile(f *File) error {
+// WriteFile creates and writes the file described by f using the provided context
+func (d *DestDir) WriteFile(f *File) error {
 	var err error
 
-	if err := MkdirForFile(f.Path); err != nil {
+	path := d.JoinPath(f.Path)
+
+	if err := mkdirForFile(path); err != nil {
 		return err
 	}
 
 	// Create a temporary file in the same directory to ensure it's on the same filesystem
 	var tmp *os.File
-	if tmp, err = ioutil.TempFile(filepath.Dir(f.Path), "tmp"); err != nil {
+	if tmp, err = ioutil.TempFile(filepath.Dir(path), "tmp"); err != nil {
 		return err
 	}
 	tmp.Close()
@@ -67,13 +70,14 @@ func WriteFile(f *File) error {
 		return err
 	}
 
-	if err := os.Rename(tmp.Name(), f.Path); err != nil {
+	if err := os.Rename(tmp.Name(), path); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func MkdirForFile(path string) error {
+// mkdirForFile helper creates the directory components of path
+func mkdirForFile(path string) error {
 	return os.MkdirAll(filepath.Dir(path), os.FileMode(DefaultDirectoryPermissions))
 }

--- a/exec/util/file.go
+++ b/exec/util/file.go
@@ -27,13 +27,8 @@ const (
 	DefaultFilePermissions      config.FileMode = 0644
 )
 
-// in-memory representation of a file
-type File struct {
-	config.File
-}
-
 // WriteFile creates and writes the file described by f using the provided context
-func (d *DestDir) WriteFile(f *File) error {
+func (d *DestDir) WriteFile(f *config.File) error {
 	var err error
 
 	path := d.JoinPath(f.Path)

--- a/exec/util/unit.go
+++ b/exec/util/unit.go
@@ -26,10 +26,10 @@ const (
 	presetPath = "/etc/systemd/system-preset/20-ignition.preset"
 )
 
-func FileFromUnit(root string, unit config.Unit) *File {
+func FileFromUnit(unit config.Unit) *File {
 	return &File{
 		config.File{
-			Path:     filepath.Join(root, SystemdUnitsPath(), string(unit.Name)),
+			Path:     filepath.Join(SystemdUnitsPath(), string(unit.Name)),
 			Contents: unit.Contents,
 			Mode:     DefaultFilePermissions,
 			Uid:      0,
@@ -38,10 +38,10 @@ func FileFromUnit(root string, unit config.Unit) *File {
 	}
 }
 
-func FileFromUnitDropin(root string, unit config.Unit, dropin config.UnitDropIn) *File {
+func FileFromUnitDropin(unit config.Unit, dropin config.UnitDropIn) *File {
 	return &File{
 		config.File{
-			Path:     filepath.Join(root, SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
+			Path:     filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
 			Contents: dropin.Contents,
 			Mode:     DefaultFilePermissions,
 			Uid:      0,
@@ -50,20 +50,20 @@ func FileFromUnitDropin(root string, unit config.Unit, dropin config.UnitDropIn)
 	}
 }
 
-func MaskUnit(root string, unit config.Unit) error {
-	path := filepath.Join(root, SystemdUnitsPath(), string(unit.Name))
-	if err := MkdirForFile(path); err != nil {
+func (d *DestDir) MaskUnit(unit config.Unit) error {
+	path := d.JoinPath(SystemdUnitsPath(), string(unit.Name))
+	if err := mkdirForFile(path); err != nil {
 		return err
 	}
 	return os.Symlink("/dev/null", path)
 }
 
-func EnableUnit(root string, unit config.Unit) error {
-	preset := filepath.Join(root, presetPath)
-	if err := MkdirForFile(preset); err != nil {
+func (d *DestDir) EnableUnit(unit config.Unit) error {
+	path := d.JoinPath(presetPath)
+	if err := mkdirForFile(path); err != nil {
 		return err
 	}
-	file, err := os.OpenFile(preset, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0444)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0444)
 	if err != nil {
 		return err
 	}

--- a/exec/util/unit.go
+++ b/exec/util/unit.go
@@ -26,27 +26,23 @@ const (
 	presetPath = "/etc/systemd/system-preset/20-ignition.preset"
 )
 
-func FileFromUnit(unit config.Unit) *File {
-	return &File{
-		config.File{
-			Path:     filepath.Join(SystemdUnitsPath(), string(unit.Name)),
-			Contents: unit.Contents,
-			Mode:     DefaultFilePermissions,
-			Uid:      0,
-			Gid:      0,
-		},
+func FileFromUnit(unit config.Unit) *config.File {
+	return &config.File{
+		Path:     filepath.Join(SystemdUnitsPath(), string(unit.Name)),
+		Contents: unit.Contents,
+		Mode:     DefaultFilePermissions,
+		Uid:      0,
+		Gid:      0,
 	}
 }
 
-func FileFromUnitDropin(unit config.Unit, dropin config.UnitDropIn) *File {
-	return &File{
-		config.File{
-			Path:     filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
-			Contents: dropin.Contents,
-			Mode:     DefaultFilePermissions,
-			Uid:      0,
-			Gid:      0,
-		},
+func FileFromUnitDropin(unit config.Unit, dropin config.UnitDropIn) *config.File {
+	return &config.File{
+		Path:     filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
+		Contents: dropin.Contents,
+		Mode:     DefaultFilePermissions,
+		Uid:      0,
+		Gid:      0,
 	}
 }
 


### PR DESCRIPTION
    Introduces a type to represent the root path diversion to prefix in
    file/directory creates which we can hang such methods off of rather
    than passing a root string all over the place and having some pieces
    construct paths with the root prefixed while others don't.