### PR TITLE
config: Introduce Filesystem.Initialize toggle

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -39,6 +39,7 @@ storage:
   filesystems:
     - device: "/dev/disk/by-partlabel/ROOT" # switch coreos' ext4 root to btrfs
       format: btrfs
+      initialize: true
       format-options:
         - "--force"
         - "--label=ROOT"

--- a/src/config/filesystem.go
+++ b/src/config/filesystem.go
@@ -25,10 +25,11 @@ var (
 )
 
 type Filesystem struct {
-	Device  DevicePath       `json:"device,omitempty"  yaml:"device"`
-	Format  FilesystemFormat `json:"format,omitempty"  yaml:"format"`
-	Options MkfsOptions      `json:"options,omitempty" yaml:"options"`
-	Files   []File           `json:"files,omitempty"   yaml:"files"`
+	Device     DevicePath       `json:"device,omitempty"     yaml:"device"`
+	Initialize bool             `json:"initialize,omitempty" yaml:"initialize"`
+	Format     FilesystemFormat `json:"format,omitempty"     yaml:"format"`
+	Options    MkfsOptions      `json:"options,omitempty"    yaml:"options"`
+	Files      []File           `json:"files,omitempty"      yaml:"files"`
 }
 
 type FilesystemFormat string

--- a/src/exec/stages/storage/storage.go
+++ b/src/exec/stages/storage/storage.go
@@ -200,25 +200,27 @@ func (s stage) createFilesystems(config config.Config) error {
 	}
 
 	for _, fs := range config.Storage.Filesystems {
-		mkfs := ""
-		args := []string(fs.Options)
-		switch fs.Format {
-		case "btrfs":
-			mkfs = "/sbin/mkfs.btrfs"
-			args = append(args, "--force")
-		case "ext4":
-			mkfs = "/sbin/mkfs.ext4"
-			args = append(args, "-F")
-		default:
-			return fmt.Errorf("unsupported filesystem format: %q", fs.Format)
-		}
+		if fs.Initialize {
+			mkfs := ""
+			args := []string(fs.Options)
+			switch fs.Format {
+			case "btrfs":
+				mkfs = "/sbin/mkfs.btrfs"
+				args = append(args, "--force")
+			case "ext4":
+				mkfs = "/sbin/mkfs.ext4"
+				args = append(args, "-F")
+			default:
+				return fmt.Errorf("unsupported filesystem format: %q", fs.Format)
+			}
 
-		args = append(args, string(fs.Device))
-		cmd := exec.Command(mkfs, args...)
+			args = append(args, string(fs.Device))
+			cmd := exec.Command(mkfs, args...)
 
-		err := s.logger.LogOp(cmd.Run, "creating %q filesystem on %q", fs.Format, string(fs.Device))
-		if err != nil {
-			return fmt.Errorf("failed to run %q: %v %v", mkfs, err, args)
+			err := s.logger.LogOp(cmd.Run, "creating %q filesystem on %q", fs.Format, string(fs.Device))
+			if err != nil {
+				return fmt.Errorf("failed to run %q: %v %v", mkfs, err, args)
+			}
 		}
 
 		if err := s.createFiles(fs); err != nil {


### PR DESCRIPTION
One must explicitly enable intialization of a filesystem, if omitted or
set to false then no mkfs will be performed, but the Files section of the
filesystem may still be populated and applied to a preexisting filesystem
on the named device.