### PR TITLE
config/storage: specify raid spares as an integer

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -33,8 +33,8 @@ storage:
       devices:
         - "/dev/disk/by-partlabel/raid.1.1"
         - "/dev/disk/by-partlabel/raid.1.2"
-      spares:
         - "/dev/disk/by-partlabel/raid.1.3"
+      spares: 1
 
   filesystems:
     - device: "/dev/disk/by-partlabel/ROOT" # switch coreos' ext4 root to btrfs

--- a/src/config/raid.go
+++ b/src/config/raid.go
@@ -18,5 +18,5 @@ type Raid struct {
 	Name    string       `json:"name"              yaml:"name"`
 	Level   string       `json:"level"             yaml:"level"`
 	Devices []DevicePath `json:"devices,omitempty" yaml:"devices"`
-	Spares  []DevicePath `json:"spares,omitempty"  yaml:"spares"`
+	Spares  int          `json:"spares,omitempty"  yaml:"spares"`
 }


### PR DESCRIPTION
mdadm --create doesn't accept spares as explicit devices, this tweaks
the config to better fit mdadm and changes the mdadm integration
accordingly.