### PR TITLE
storage: support partition type GUID

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -10,22 +10,21 @@ storage:
       partitions:
         - label: "raid.1.1"
           number: 1
-          first-sector: 1
-          last-sector:
-          type:
-            hex-code:
-            guid:
-          size: 10GB
+          type-guid: "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7"
+          start: 1MiB
+          size: 10GiB
     - device: "/dev/sdb"
       wipe-table: true
       partitions:
         - label: "raid.1.2"
-          size: 10GB
+          number: 1
+          size: 10GiB
     - device: "/dev/sdc"
       wipe-table: true
       partitions:
         - label: "raid.1.3"
-          size: 10GB
+          number: 1
+          size: 10GiB
 
   raid:
     - name: "md0"

--- a/src/exec/storage.go
+++ b/src/exec/storage.go
@@ -100,10 +100,11 @@ func (s storage) createPartitions(config config.Config) error {
 
 			for _, part := range dev.Partitions {
 				op.CreatePartition(sgdisk.Partition{
-					Number: part.Number,
-					Length: uint64(part.Size),
-					Offset: uint64(part.Start),
-					Label:  string(part.Label),
+					Number:   part.Number,
+					Length:   uint64(part.Size),
+					Offset:   uint64(part.Start),
+					Label:    string(part.Label),
+					TypeGUID: string(part.TypeGUID),
 				})
 			}
 

--- a/src/sgdisk/sgdisk.go
+++ b/src/sgdisk/sgdisk.go
@@ -31,10 +31,11 @@ type Operation struct {
 }
 
 type Partition struct {
-	Number int
-	Offset uint64 // 512-byte sectors
-	Length uint64 // 512-byte sectors
-	Label  string
+	Number   int
+	Offset   uint64 // 512-byte sectors
+	Length   uint64 // 512-byte sectors
+	Label    string
+	TypeGUID string
 }
 
 // Begin begins an sgdisk operation
@@ -67,6 +68,9 @@ func (op *Operation) Commit() error {
 		for _, p := range op.parts {
 			opts = append(opts, fmt.Sprintf("--new=%d:%d:+%d", p.Number, p.Offset, p.Length))
 			opts = append(opts, fmt.Sprintf("--change-name=%d:%s", p.Number, p.Label))
+			if p.TypeGUID != "" {
+				opts = append(opts, fmt.Sprintf("--partition-guid=%d:%s", p.Number, p.TypeGUID))
+			}
 		}
 		opts = append(opts, op.dev)
 		cmd := exec.Command(sgdiskPath, opts...)


### PR DESCRIPTION
JSON and YAML both now support "type-guid" in the partition specification.