### PR TITLE
config: seperate systemd and network units

### DIFF
--- a/src/config/networkd.go
+++ b/src/config/networkd.go
@@ -15,5 +15,5 @@
 package config
 
 type Networkd struct {
-	Units []Unit `json:"units,omitempty" yaml:"units"`
+	Units []NetworkdUnit `json:"units,omitempty" yaml:"units"`
 }

--- a/src/config/systemd.go
+++ b/src/config/systemd.go
@@ -15,5 +15,5 @@
 package config
 
 type Systemd struct {
-	Units []Unit `json:"units,omitempty" yaml:"units"`
+	Units []SystemdUnit `json:"units,omitempty" yaml:"units"`
 }

--- a/src/config/unit.go
+++ b/src/config/unit.go
@@ -16,44 +16,120 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"path/filepath"
 )
 
-type Unit struct {
-	Name     UnitName     `json:"name,omitempty"     yaml:"name"`
-	Enable   bool         `json:"enable,omitempty"   yaml:"enable"`
-	Mask     bool         `json:"mask,omitempty"     yaml:"mask"`
-	Contents string       `json:"contents,omitempty" yaml:"contents"`
-	DropIns  []UnitDropIn `json:"dropins,omitempty"  yaml:"dropins"`
+type SystemdUnit struct {
+	Name     SystemdUnitName     `json:"name,omitempty"     yaml:"name"`
+	Enable   bool                `json:"enable,omitempty"   yaml:"enable"`
+	Mask     bool                `json:"mask,omitempty"     yaml:"mask"`
+	Contents string              `json:"contents,omitempty" yaml:"contents"`
+	DropIns  []SystemdUnitDropIn `json:"dropins,omitempty"  yaml:"dropins"`
 }
 
-type UnitDropIn struct {
-	Name     UnitName `json:"name,omitempty"     yaml:"name"`
-	Contents string   `json:"contents,omitempty" yaml:"contents"`
+type SystemdUnitDropIn struct {
+	Name     SystemdUnitDropInName `json:"name,omitempty"     yaml:"name"`
+	Contents string                `json:"contents,omitempty" yaml:"contents"`
 }
 
-type UnitName string
+type SystemdUnitName string
 
-func (n *UnitName) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (n *SystemdUnitName) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return n.unmarshal(unmarshal)
 }
 
-func (n *UnitName) UnmarshalJSON(data []byte) error {
+func (n *SystemdUnitName) UnmarshalJSON(data []byte) error {
 	return n.unmarshal(func(tn interface{}) error {
 		return json.Unmarshal(data, tn)
 	})
 }
 
-type unitName UnitName
+type systemdUnitName SystemdUnitName
 
-func (n *UnitName) unmarshal(unmarshal func(interface{}) error) error {
-	tn := unitName(*n)
+func (n *SystemdUnitName) unmarshal(unmarshal func(interface{}) error) error {
+	tn := systemdUnitName(*n)
 	if err := unmarshal(&tn); err != nil {
 		return err
 	}
-	*n = UnitName(tn)
+	*n = SystemdUnitName(tn)
 	return n.assertValid()
 }
 
-func (n UnitName) assertValid() error {
-	return nil
+func (n SystemdUnitName) assertValid() error {
+	switch filepath.Ext(string(n)) {
+	case ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice", ".scope":
+		return nil
+	default:
+		return errors.New("invalid systemd unit extension")
+	}
+}
+
+type SystemdUnitDropInName string
+
+func (n *SystemdUnitDropInName) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return n.unmarshal(unmarshal)
+}
+
+func (n *SystemdUnitDropInName) UnmarshalJSON(data []byte) error {
+	return n.unmarshal(func(tn interface{}) error {
+		return json.Unmarshal(data, tn)
+	})
+}
+
+type systemdUnitDropInName SystemdUnitDropInName
+
+func (n *SystemdUnitDropInName) unmarshal(unmarshal func(interface{}) error) error {
+	tn := systemdUnitDropInName(*n)
+	if err := unmarshal(&tn); err != nil {
+		return err
+	}
+	*n = SystemdUnitDropInName(tn)
+	return n.assertValid()
+}
+
+func (n SystemdUnitDropInName) assertValid() error {
+	switch filepath.Ext(string(n)) {
+	case "conf":
+		return nil
+	default:
+		return errors.New("invalid systemd unit drop-in extension")
+	}
+}
+
+type NetworkdUnit struct {
+	Name     NetworkdUnitName `json:"name,omitempty"     yaml:"name"`
+	Contents string           `json:"contents,omitempty" yaml:"contents"`
+}
+
+type NetworkdUnitName string
+
+func (n *NetworkdUnitName) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return n.unmarshal(unmarshal)
+}
+
+func (n *NetworkdUnitName) UnmarshalJSON(data []byte) error {
+	return n.unmarshal(func(tn interface{}) error {
+		return json.Unmarshal(data, tn)
+	})
+}
+
+type networkdUnitName NetworkdUnitName
+
+func (n *NetworkdUnitName) unmarshal(unmarshal func(interface{}) error) error {
+	tn := networkdUnitName(*n)
+	if err := unmarshal(&tn); err != nil {
+		return err
+	}
+	*n = NetworkdUnitName(tn)
+	return n.assertValid()
+}
+
+func (n NetworkdUnitName) assertValid() error {
+	switch filepath.Ext(string(n)) {
+	case ".link", ".netdev", ".network":
+		return nil
+	default:
+		return errors.New("invalid networkd unit extension")
+	}
 }

--- a/src/config/unit_test.go
+++ b/src/config/unit_test.go
@@ -16,18 +16,19 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/coreos/ignition/Godeps/_workspace/src/github.com/go-yaml/yaml"
 )
 
-func TestUnitNameUnmarshalJSON(t *testing.T) {
+func TestSystemdUnitNameUnmarshalJSON(t *testing.T) {
 	type in struct {
 		data string
 	}
 	type out struct {
-		unit UnitName
+		unit SystemdUnitName
 		err  error
 	}
 
@@ -37,32 +38,40 @@ func TestUnitNameUnmarshalJSON(t *testing.T) {
 	}{
 		{
 			in:  in{data: `"test.service"`},
-			out: out{unit: UnitName("test.service")},
+			out: out{unit: SystemdUnitName("test.service")},
 		},
 		{
 			in:  in{data: `"test.socket"`},
-			out: out{unit: UnitName("test.socket")},
+			out: out{unit: SystemdUnitName("test.socket")},
+		},
+		{
+			in:  in{data: `"test.blah"`},
+			out: out{err: errors.New("invalid systemd unit extension")},
 		},
 	}
 
 	for i, test := range tests {
-		var unit UnitName
+		var unit SystemdUnitName
 		err := json.Unmarshal([]byte(test.in.data), &unit)
 		if !reflect.DeepEqual(test.out.err, err) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
 		}
+		if err != nil {
+			continue
+		}
+
 		if !reflect.DeepEqual(test.out.unit, unit) {
 			t.Errorf("#%d: bad unit: want %#v, got %#v", i, test.out.unit, unit)
 		}
 	}
 }
 
-func TestUnitNameUnmarshalYAML(t *testing.T) {
+func TestSystemdUnitNameUnmarshalYAML(t *testing.T) {
 	type in struct {
 		data string
 	}
 	type out struct {
-		unit UnitName
+		unit SystemdUnitName
 		err  error
 	}
 
@@ -72,20 +81,122 @@ func TestUnitNameUnmarshalYAML(t *testing.T) {
 	}{
 		{
 			in:  in{data: `"test.service"`},
-			out: out{unit: UnitName("test.service")},
+			out: out{unit: SystemdUnitName("test.service")},
 		},
 		{
 			in:  in{data: `"test.socket"`},
-			out: out{unit: UnitName("test.socket")},
+			out: out{unit: SystemdUnitName("test.socket")},
+		},
+		{
+			in:  in{data: `"test.blah"`},
+			out: out{err: errors.New("invalid systemd unit extension")},
 		},
 	}
 
 	for i, test := range tests {
-		var unit UnitName
+		var unit SystemdUnitName
 		err := yaml.Unmarshal([]byte(test.in.data), &unit)
 		if !reflect.DeepEqual(test.out.err, err) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
 		}
+		if err != nil {
+			continue
+		}
+
+		if !reflect.DeepEqual(test.out.unit, unit) {
+			t.Errorf("#%d: bad unit: want %#v, got %#v", i, test.out.unit, unit)
+		}
+	}
+}
+
+func TestNetworkdUnitNameUnmarshalJSON(t *testing.T) {
+	type in struct {
+		data string
+	}
+	type out struct {
+		unit NetworkdUnitName
+		err  error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{data: `"test.network"`},
+			out: out{unit: NetworkdUnitName("test.network")},
+		},
+		{
+			in:  in{data: `"test.link"`},
+			out: out{unit: NetworkdUnitName("test.link")},
+		},
+		{
+			in:  in{data: `"test.netdev"`},
+			out: out{unit: NetworkdUnitName("test.netdev")},
+		},
+		{
+			in:  in{data: `"test.blah"`},
+			out: out{err: errors.New("invalid networkd unit extension")},
+		},
+	}
+
+	for i, test := range tests {
+		var unit NetworkdUnitName
+		err := json.Unmarshal([]byte(test.in.data), &unit)
+		if !reflect.DeepEqual(test.out.err, err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+		if err != nil {
+			continue
+		}
+
+		if !reflect.DeepEqual(test.out.unit, unit) {
+			t.Errorf("#%d: bad unit: want %#v, got %#v", i, test.out.unit, unit)
+		}
+	}
+}
+
+func TestNetworkdUnitNameUnmarshalYAML(t *testing.T) {
+	type in struct {
+		data string
+	}
+	type out struct {
+		unit NetworkdUnitName
+		err  error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{data: `"test.network"`},
+			out: out{unit: NetworkdUnitName("test.network")},
+		},
+		{
+			in:  in{data: `"test.link"`},
+			out: out{unit: NetworkdUnitName("test.link")},
+		},
+		{
+			in:  in{data: `"test.netdev"`},
+			out: out{unit: NetworkdUnitName("test.netdev")},
+		},
+		{
+			in:  in{data: `"test.blah"`},
+			out: out{err: errors.New("invalid networkd unit extension")},
+		},
+	}
+
+	for i, test := range tests {
+		var unit NetworkdUnitName
+		err := yaml.Unmarshal([]byte(test.in.data), &unit)
+		if !reflect.DeepEqual(test.out.err, err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+		if err != nil {
+			continue
+		}
+
 		if !reflect.DeepEqual(test.out.unit, unit) {
 			t.Errorf("#%d: bad unit: want %#v, got %#v", i, test.out.unit, unit)
 		}

--- a/src/exec/engine_test.go
+++ b/src/exec/engine_test.go
@@ -143,7 +143,7 @@ func TestFetchConfigs(t *testing.T) {
 		err:    errors.New("test error"),
 		config: config.Config{
 			Systemd: config.Systemd{
-				Units: []config.Unit{},
+				Units: []config.SystemdUnit{},
 			},
 		},
 	}

--- a/src/exec/util/unit.go
+++ b/src/exec/util/unit.go
@@ -27,7 +27,7 @@ const (
 	DefaultPresetPermissions os.FileMode = 0644
 )
 
-func FileFromSystemdUnit(unit config.Unit) *config.File {
+func FileFromSystemdUnit(unit config.SystemdUnit) *config.File {
 	return &config.File{
 		Path:     filepath.Join(SystemdUnitsPath(), string(unit.Name)),
 		Contents: unit.Contents,
@@ -37,7 +37,7 @@ func FileFromSystemdUnit(unit config.Unit) *config.File {
 	}
 }
 
-func FileFromNetworkdUnit(unit config.Unit) *config.File {
+func FileFromNetworkdUnit(unit config.NetworkdUnit) *config.File {
 	return &config.File{
 		Path:     filepath.Join(NetworkdUnitsPath(), string(unit.Name)),
 		Contents: unit.Contents,
@@ -47,7 +47,7 @@ func FileFromNetworkdUnit(unit config.Unit) *config.File {
 	}
 }
 
-func FileFromUnitDropin(unit config.Unit, dropin config.UnitDropIn) *config.File {
+func FileFromUnitDropin(unit config.SystemdUnit, dropin config.SystemdUnitDropIn) *config.File {
 	return &config.File{
 		Path:     filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
 		Contents: dropin.Contents,
@@ -57,7 +57,7 @@ func FileFromUnitDropin(unit config.Unit, dropin config.UnitDropIn) *config.File
 	}
 }
 
-func (d *DestDir) MaskUnit(unit config.Unit) error {
+func (d *DestDir) MaskUnit(unit config.SystemdUnit) error {
 	path := d.JoinPath(SystemdUnitsPath(), string(unit.Name))
 	if err := mkdirForFile(path); err != nil {
 		return err
@@ -65,7 +65,7 @@ func (d *DestDir) MaskUnit(unit config.Unit) error {
 	return os.Symlink("/dev/null", path)
 }
 
-func (d *DestDir) EnableUnit(unit config.Unit) error {
+func (d *DestDir) EnableUnit(unit config.SystemdUnit) error {
 	path := d.JoinPath(presetPath)
 	if err := mkdirForFile(path); err != nil {
 		return err


### PR DESCRIPTION
systemd and networkd units are fundamentally different structures. It
doesn't make much sense for them to share the same representation during
parsing.