### PR TITLE
third_party: fix header alignment of version in manifest

### DIFF
--- a/third_party.manifest
+++ b/third_party.manifest
@@ -1,5 +1,5 @@
 # If you manipulate the contents of third_party/, amend this accordingly.
-# pkg					version
+# pkg							version
 github.com/alecthomas/units				6b4e7dc5e3143b85ea77909c72caf89416fc2915
 github.com/coreos/go-semver/semver			568e959cd89871e61434c1143528d9162da89ef2
 github.com/coreos/go-systemd/dbus			2688e91251d9d8e404e86dd8f096e23b2f086958


### PR DESCRIPTION
The version column was shifted with the addition of update-ssh-keys, but the
header wasn't updated accordingly.