### PR TITLE
config: rearrange config.Filesystem for optional forcing

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -28,7 +28,7 @@ storage:
 
   raid:
     - name: "md0"
-      level: stripe
+      level: raid1
       devices:
         - "/dev/disk/by-partlabel/raid.1.1"
         - "/dev/disk/by-partlabel/raid.1.2"
@@ -38,10 +38,10 @@ storage:
   filesystems:
     - device: "/dev/disk/by-partlabel/ROOT" # switch coreos' ext4 root to btrfs
       format: btrfs
-      initialize: true
-      options:
-        - "--force"
-        - "--label=ROOT"
+      create:
+        force: true
+        options:
+          - "--label=ROOT"
       files:
         - path: "/home/core/bin/find-ip4.sh"
           permissions: 0755
@@ -63,10 +63,11 @@ storage:
 
             sed -i -e "/^${VARIABLE}=/d" "${FILE}"
             echo "${VARIABLE}=${ip}" >> "${FILE}"
-         - path: "/home/foouser/stuff"
-           permissions: 0600
-           uid: 4242
-           gid: 4242
+
+        - path: "/home/foouser/stuff"
+          permissions: 0600
+          uid: 4242
+          gid: 4242
 
 systemd:
   units:
@@ -112,25 +113,25 @@ networkd:
         DNS=4.4.4.4
 
 passwd:
- users:
-  - name: foouser
-    ssh_authorized_keys:
-     - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEtomdD5MpmzEvLILIyn6l/TTrVOc2iRkeEgBjNEEFujkCOVMQrP7TFln+E2Ve0m5ngP+sImhYItpMpHOwRlBjUhFCzTZF8QJwUKyg2A59TV2uFEetosms7z4aW8lgQgm4m1ovi3G2R6BG3h01ogm3PC5YaAAkEbr0V0BxVN0rsTrq/dRNs2drLNw4giqJ5mBwzqXmepp7orJifyiKBueDQYsO367V7v9H797p3WmnFlg+T3LYiYfUQCkpxj/X+NYGbQBqsk5EXqAt/mi056HWu4esVJNwcIeiTdAWJ8/naKMAeEYoc8fJzbQ4rzIawRdAUk/QjxhVBbC4BxpGbsxr foouser@host"
-    password_hash: "$6$L5wKa16S$6qwF3RtAmPTlsDu/mVq53zzgL4htS0cw6GhFEDC9V6v6W7ydzxYN.dmJwlwBhMsi6vaNgkGvCRNwYhuFinA2w0"
-    create:
-     uid: 4242
-     primary_group: foouser
-     groups: foogroup
-     gecos: "Foo Bar"
-     homedir: "/home/abc"
-     shell: "/bin/zsh"
-     no_create_home: false
-     no_user_group: false
-     system: false
-     no_log_init: false
+  users:
+    - name: foouser
+      ssh_authorized_keys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEtomdD5MpmzEvLILIyn6l/TTrVOc2iRkeEgBjNEEFujkCOVMQrP7TFln+E2Ve0m5ngP+sImhYItpMpHOwRlBjUhFCzTZF8QJwUKyg2A59TV2uFEetosms7z4aW8lgQgm4m1ovi3G2R6BG3h01ogm3PC5YaAAkEbr0V0BxVN0rsTrq/dRNs2drLNw4giqJ5mBwzqXmepp7orJifyiKBueDQYsO367V7v9H797p3WmnFlg+T3LYiYfUQCkpxj/X+NYGbQBqsk5EXqAt/mi056HWu4esVJNwcIeiTdAWJ8/naKMAeEYoc8fJzbQ4rzIawRdAUk/QjxhVBbC4BxpGbsxr foouser@host"
+      password_hash: "$6$L5wKa16S$6qwF3RtAmPTlsDu/mVq53zzgL4htS0cw6GhFEDC9V6v6W7ydzxYN.dmJwlwBhMsi6vaNgkGvCRNwYhuFinA2w0"
+      create:
+        uid: 4242
+        primary_group: foouser
+        groups: foogroup
+        gecos: "Foo Bar"
+        homedir: "/home/abc"
+        shell: "/bin/zsh"
+        no_create_home: false
+        no_user_group: false
+        system: false
+        no_log_init: false
 
- groups:
-  - name: foogroup
-    gid: 4242
-    password_hash: "$6$L5wKa16S$6qwF3RtAmPTlsDu/mVq53zzgL4htS0cw6GhFEDC9V6v6W7ydzxYN.dmJwlwBhMsi6vaNgkGvCRNwYhuFinA2w0"
+  groups:
+    - name: foogroup
+      gid: 4242
+      password_hash: "$6$L5wKa16S$6qwF3RtAmPTlsDu/mVq53zzgL4htS0cw6GhFEDC9V6v6W7ydzxYN.dmJwlwBhMsi6vaNgkGvCRNwYhuFinA2w0"
 ```

--- a/src/config/filesystem.go
+++ b/src/config/filesystem.go
@@ -25,11 +25,15 @@ var (
 )
 
 type Filesystem struct {
-	Device     DevicePath       `json:"device,omitempty"     yaml:"device"`
-	Initialize bool             `json:"initialize,omitempty" yaml:"initialize"`
-	Format     FilesystemFormat `json:"format,omitempty"     yaml:"format"`
-	Options    MkfsOptions      `json:"options,omitempty"    yaml:"options"`
-	Files      []File           `json:"files,omitempty"      yaml:"files"`
+	Device DevicePath        `json:"device,omitempty" yaml:"device"`
+	Format FilesystemFormat  `json:"format,omitempty" yaml:"format"`
+	Create *FilesystemCreate `json:"create,omitempty" yaml:"create"`
+	Files  []File            `json:"files,omitempty"  yaml:"files"`
+}
+
+type FilesystemCreate struct {
+	Force   bool        `json:"force,omitempty"   yaml:"force"`
+	Options MkfsOptions `json:"options,omitempty" yaml:"options"`
 }
 
 type FilesystemFormat string


### PR DESCRIPTION
changes from:

  filesystems:
    - device: "/dev/disk/by-partlabel/ROOT"
      format: btrfs
      initialize: true
      options:
        - "--label=ROOT"

to:

  filesystems:
    - device: "/dev/disk/by-partlabel/ROOT"
      format: btrfs
      create:
       force: true
       options:
         - "--label=ROOT"

Previously the force flag was always added to the mkfs options, now
it's only added when `force: true`.

The mkfs.$format is only performed if a `create` section is present,
instead of using the `initialize` boolean.

Also some minor cleanups to the config.md example/doc.