### PR TITLE
Makefile: add ec2 and files providers to PACKAGES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ PACKAGES = \
     src/exec/util \
     src/providers \
     src/providers/cmdline \
+    src/providers/ec2 \
+    src/providers/file \
     src/providers/util \
     src/registry \
 


### PR DESCRIPTION
So they're included in vet/fmt/fix/test.