### PR TITLE
config: handle empty config

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -35,6 +35,7 @@ var (
 	ErrVersion     = errors.New("incorrect config version")
 	ErrCloudConfig = errors.New("not a config (found coreos-cloudconfig)")
 	ErrScript      = errors.New("not a config (found coreos-cloudinit script)")
+	ErrEmpty       = errors.New("not a config (empty)")
 )
 
 func Parse(config []byte) (cfg Config, err error) {
@@ -46,6 +47,12 @@ func Parse(config []byte) (cfg Config, err error) {
 		err = ErrCloudConfig
 	} else if isScript(config) {
 		err = ErrScript
+	} else if isEmpty(config) {
+		err = ErrEmpty
 	}
 	return
+}
+
+func isEmpty(userdata []byte) bool {
+	return len(userdata) == 0
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -41,6 +41,10 @@ func TestParse(t *testing.T) {
 			out: out{err: ErrVersion},
 		},
 		{
+			in:  in{config: []byte{}},
+			out: out{err: ErrEmpty},
+		},
+		{
 			in:  in{config: []byte(`#cloud-config`)},
 			out: out{err: ErrCloudConfig},
 		},

--- a/src/exec/engine.go
+++ b/src/exec/engine.go
@@ -80,7 +80,7 @@ func (e Engine) Run(stageName string) bool {
 		e.Logger.PushPrefix(stageName)
 		defer e.Logger.PopPrefix()
 		return stages.Get(stageName).Create(&e.Logger, e.Root).Run(cfg)
-	case config.ErrCloudConfig, config.ErrScript:
+	case config.ErrCloudConfig, config.ErrScript, config.ErrEmpty:
 		e.Logger.Info("%v: ignoring and exiting...", err)
 		return true
 	default:


### PR DESCRIPTION
When an empty config is encountered, Ignition needs to recognize it and
ignore it. Otherwise, cloud environments with an empty userdata, will
trigger an Ignition failure.