### PR TITLE
providers/ec2: properly handle a lack of userdata

### DIFF
--- a/src/providers/ec2/ec2.go
+++ b/src/providers/ec2/ec2.go
@@ -74,16 +74,18 @@ func (p *provider) IsOnline() bool {
 
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusNoContent:
+			p.logger.Debug("successfully fetched")
+			if p.rawConfig, err = ioutil.ReadAll(resp.Body); err != nil {
+				p.logger.Err("failed to read body: %v", err)
+				return false
+			}
+		case http.StatusNotFound:
+			p.logger.Debug("no config to fetch")
 		default:
 			p.logger.Debug("failed fetching: HTTP status: %s", resp.Status)
 			return false
 		}
 
-		p.logger.Debug("successfully fetched")
-		if p.rawConfig, err = ioutil.ReadAll(resp.Body); err != nil {
-			p.logger.Err("failed to read body: %v", err)
-			return false
-		}
 		return true
 	} else {
 		p.logger.Warning("failed fetching: %v", err)


### PR DESCRIPTION
On EC2, the metadata service returns a 404 when there is no userdata.
Treat this as a successful fetch.