### PR TITLE
Tables from the docs weren't rendering correctly

### DIFF
--- a/doc/ignition.md
+++ b/doc/ignition.md
@@ -24,10 +24,8 @@ The list of supported configuration providers are as follows:
 
   Provider Name  |                        Description
 -----------------|-------------------------------------------------------------
- cmdline         | Fetches the config from the URL provided via the
-                 : "coreos.config.url" kernel boot option.
- file            | Read the config from a file named "config.json" in the
-                 : current working directory.
+ cmdline         | Fetches the config from the URL provided via the `coreos.config.url` kernel boot option.
+ file            | Read the config from a file named `config.json` in the current working directory.
 
 ## Configuration ##
 


### PR DESCRIPTION
This breaks the 80 character column width in the markdown file, but the tables weren't rendering correctly on github's website. Not sure if there's a way to keep it to a max column width, but I think the html looking correct is more important than that.

Before:
![2015-07-31-154950_1920x1848_scrot](https://cloud.githubusercontent.com/assets/2439413/9019123/e45c627a-379b-11e5-9328-e2134d9b9ad2.png)
After:
![2015-07-31-155005_1920x1848_scrot](https://cloud.githubusercontent.com/assets/2439413/9019126/f3944712-379b-11e5-82a4-54ad34a4c363.png)
