### PR TITLE
providers/ec2: fix handling of configs to always fetch ssh keys.

### DIFF
--- a/src/providers/ec2/ec2.go
+++ b/src/providers/ec2/ec2.go
@@ -72,13 +72,9 @@ func (provider) Name() string {
 
 func (p provider) FetchConfig() (config.Config, error) {
 	cfg, err := config.Parse(p.rawConfig)
-	switch err {
-	case config.ErrCloudConfig, config.ErrScript, config.ErrEmpty:
-	default:
-		return cfg, err
+	if err == nil || err == config.ErrEmpty {
+		err = p.fetchSSHKeys(&cfg)
 	}
-
-	err = p.fetchSSHKeys(&cfg)
 
 	return cfg, err
 }


### PR DESCRIPTION
Was short-circuiting the fetching of ssh keys when the config parsed
successfully.

Now ssh keys will be fetched if the config is empty or valid, but not
when the config is a cloud-config, script, or other error.