### PR TITLE
providers/cmdline: add missing return in http failed fetch path

### DIFF
--- a/src/providers/cmdline/cmdline.go
+++ b/src/providers/cmdline/cmdline.go
@@ -160,6 +160,7 @@ func (p *provider) getRawConfig() bool {
 			}
 		} else {
 			p.logger.Warning("failed fetching: %v", err)
+			return false
 		}
 	case "oem":
 		path := filepath.Clean(url.Path)


### PR DESCRIPTION
Fix bug introduced when inverting the fall-through return path in
oem:// addition.