### PR TITLE
oem: disable ec2

### DIFF
--- a/src/oem/oem.go
+++ b/src/oem/oem.go
@@ -74,7 +74,7 @@ func init() {
 	configs.Register(Config{
 		name: "ec2",
 		flags: map[string]string{
-			"provider": "ec2",
+			"provider": "noop",
 		},
 	})
 	configs.Register(Config{


### PR DESCRIPTION
There are still some unresolved issues around networking. Disable ec2
for now.