### PR TITLE
docs: minor cleanups

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,107 +1,110 @@
 # Configuration Specification #
 
 The Ignition configuration is a JSON document conforming to the following
-specification:
+specification, with **_italicized_** entries being optional:
 
 - **ignitionVersion** (integer): the version number of the spec. Must be `1`.
-- **storage** (object): describes the desired state of the system's storage
+- **_storage_** (object): describes the desired state of the system's storage
                         devices.
-  - **disks** (list of objects): the list of disks to be configured and their
+  - **_disks_** (list of objects): the list of disks to be configured and their
                                  options.
     - **device** (string): the absolute path to the device. Devices are
                            typically referenced by the /dev/disk/by-* symlinks.
-    - **wipeTable** (boolean): whether or not the partition tables shall be
+    - **_wipeTable_** (boolean): whether or not the partition tables shall be
                                wiped. When true, the partition tables are
                                erased before any further manipulation.
                                Otherwise, the existing entries are left intact.
-    - **partitions** (list of objects): the list of partitions and their
+    - **_partitions_** (list of objects): the list of partitions and their
                                         configuration for this particular disk.
-      - **label** (string): the PARTLABEL for the partition.
-      - **number** (integer): the partition number, which dictates it's
+      - **_label_** (string): the PARTLABEL for the partition.
+      - **_number_** (integer): the partition number, which dictates it's
                               position in the partition table (one-indexed). If
                               zero, use the next available partition slot.
-      - **size** (integer): the size of the partition (in sectors). If zero,
+      - **_size_** (integer): the size of the partition (in sectors). If zero,
                             the partition will fill the remainder of the disk.
-      - **start** (integer): the start of the partition (in sectors). If zero,
+      - **_start_** (integer): the start of the partition (in sectors). If zero,
                              the partition will be positioned at the earliest
                              available part of the disk.
-      - **typeGuid** (string): the GPT [partition type GUID][part-types].
-  - **raid** (list of objects): the list of RAID arrays to be configured.
+      - **_typeGuid_** (string): the GPT [partition type GUID][part-types].  If
+                             omitted, the default will be
+                             0FC63DAF-8483-4772-8E79-3D69D8477DE4
+                             (Linux filesystem data).
+  - **_raid_** (list of objects): the list of RAID arrays to be configured.
     - **name** (string): the name to use for the resulting md device.
     - **level** (string): the redundancy level of the array (e.g. linear,
                           raid1, raid5, etc.).
     - **devices** (list of strings): the list of devices (referenced by their
                                      absolute path) in the array.
-    - **spares** (integer): the number of spares (if applicable) in the array.
-  - **filesystems** (list of objects): the list of filesystems to be
+    - **_spares_** (integer): the number of spares (if applicable) in the array.
+  - **_filesystems_** (list of objects): the list of filesystems to be
                                        configured. Typically, one filesystem
                                        is configured per partition.
     - **device** (string): the absolute path to the device. Devices are
                            typically referenced by the /dev/disk/by-* symlinks.
     - **format** (string): the filesystem format (e.g. ext4, btrfs, etc.).
-    - **create** (object): contains the set of options to be used when creating
+    - **_create_** (object): contains the set of options to be used when creating
                            the filesystem. A non-null entry indicates that the
                            filesystem shall be created.
-      - **force** (boolean): whether or not the create operation shall
+      - **_force_** (boolean): whether or not the create operation shall
                              overwrite an existing filesystem.
-      - **options** (list of strings): any additional options to be passed to
+      - **_options_** (list of strings): any additional options to be passed to
                                        the format-specific mkfs utility.
-    - **files** (list of objects): the list of files, rooted in this particular
+    - **_files_** (list of objects): the list of files, rooted in this particular
                                    filesystem, to be written.
       - **path** (string): the absolute path to the file.
-      - **contents** (string): the contents of the file.
-      - **mode** (integer): the file's permission mode. Note that the mode must
+      - **_contents_** (string): the contents of the file.
+      - **_mode_** (integer): the file's permission mode. Note that the mode must
                             be properly specified as a **decimal** value
                             (i.e. 0644 -> 420).
-      - **uid** (integer): the user ID of the owner.
-      - **gid** (integer): the group ID of the owner.
-- **systemd** (object): describes the desired state of the systemd units.
-  - **units** (list of objects): the list of systemd units.
+      - **_uid_** (integer): the user ID of the owner.
+      - **_gid_** (integer): the group ID of the owner.
+- **_systemd_** (object): describes the desired state of the systemd units.
+  - **_units_** (list of objects): the list of systemd units.
     - **name** (string): the name of the unit. This must be suffixed with a
                          valid unit type (e.g. "thing.service").
-    - **enable** (boolean): whether or not the service shall be enabled. When
+    - **_enable_** (boolean): whether or not the service shall be enabled. When
                             true, the service is enabled. In order for this to
                             have any effect, the unit must have an install
                             section.
-    - **mask** (boolean): whether or not the service shall be masked. When
+    - **_mask_** (boolean): whether or not the service shall be masked. When
                           true, the service is masked by symlinking it to
                           /dev/null.
-    - **contents** (string): the contents of the unit.
-    - **dropins** (list of objects): the list of drop-ins for the unit.
+    - **_contents_** (string): the contents of the unit.
+    - **_dropins_** (list of objects): the list of drop-ins for the unit.
       - **name** (string): the name of the drop-in. This must be suffixed with
                            ".conf".
-      - **contents** (string): the contents of the drop-in.
-- **networkd** (object): describes the desired state of the network units.
-  - **units** (list of objects): the list of networkd units.
-    - **name** (string): the name of the unit. This must be suffixed with a
+      - **_contents_** (string): the contents of the drop-in.
+- **_networkd_** (object): describes the desired state of the networkd files.
+  - **_units_** (list of objects): the list of networkd files.
+    - **name** (string): the name of the file. This must be suffixed with a
                          valid unit type (e.g. "00-eth0.network").
-    - **contents** (string): the contents of the unit.
-- **passwd** (object): describes the desired additions to the passwd database.
-  - **users** (list of objects): the list of accounts to be added.
+    - **_contents_** (string): the contents of the networkd file.
+- **_passwd_** (object): describes the desired additions to the passwd database.
+  - **_users_** (list of objects): the list of accounts to be added.
     - **name** (string): the username for the account.
-    - **passwordHash** (string): the encrypted password of the new account.
-    - **sshAuthorizedKeys** (list of strings): a list of SSH keys to be added
+    - **_passwordHash_** (string): the encrypted password for the account.
+    - **_sshAuthorizedKeys_** (list of strings): a list of SSH keys to be added
                                                to the user's authorized_keys.
-    - **create** (object): contains the set of options to be used when creating
+    - **_create_** (object): contains the set of options to be used when creating
                            the user. A non-null entry indicates that the user
                            account shall be created.
-      - **uid** (integer): the user ID of the new account.
-      - **gecos** (string): the GECOS field of the new account.
-      - **homeDir** (string): the home directory of the new account.
-      - **noCreateHome** (boolean): whether or not to create the user's home
+      - **_uid_** (integer): the user ID of the new account.
+      - **_gecos_** (string): the GECOS field of the new account.
+      - **_homeDir_** (string): the home directory of the new account.
+      - **_noCreateHome_** (boolean): whether or not to create the user's home
                                     directory.
-      - **primaryGroup** (string): the name or ID of the primary group of the
+      - **_primaryGroup_** (string): the name or ID of the primary group of the
                                    new account.
-      - **groups** (list of strings): the list of supplementary groups of the
+      - **_groups_** (list of strings): the list of supplementary groups of the
                                       new account.
-      - **noUserGroup** (boolean): whether or not to create a group with the
+      - **_noUserGroup_** (boolean): whether or not to create a group with the
                                    same name as the user.
-      - **noLogInit** (boolean): whether or not to add the user to the lastlog
+      - **_noLogInit_** (boolean): whether or not to add the user to the lastlog
                                  and faillog databases.
-      - **shell** (string): the login shell of the new account.
-  - **groups** (list of objects): the list of groups to be added.
+      - **_shell_** (string): the login shell of the new account.
+  - **_groups_** (list of objects): the list of groups to be added.
     - **name** (string): the name of the group.
-    - **gid** (integer): the group ID of the new group.
-    - **passwordHash** (string): the encrypted password of the new group.
+    - **_gid_** (integer): the group ID of the new group.
+    - **_passwordHash_** (string): the encrypted password of the new group.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -34,5 +34,5 @@ journalctl --identifier=ignition
 
 In the vast majority of cases, it will be immediately obvious why Ignition
 failed. If it's not, inspect the config that Ignition dumped into the log. This
-shows how Ignition interpretted the supplied configuration. The user-provided
+shows how Ignition interpreted the supplied configuration. The user-provided
 config may have a misspelled section or maybe an incorrect hierarchy.


### PR DESCRIPTION
Express optional fields in configuration.md using italics, other
small corrections.