### PR TITLE
oem: remove timeout for EC2

### DIFF
--- a/src/oem/oem.go
+++ b/src/oem/oem.go
@@ -74,7 +74,8 @@ func init() {
 	configs.Register(Config{
 		name: "ec2",
 		flags: map[string]string{
-			"provider": "ec2",
+			"provider":       "ec2",
+			"online-timeout": "0",
 		},
 	})
 	configs.Register(Config{


### PR DESCRIPTION
We've seen cases if AWS taking 66 seconds to offer a DHCP lease. Rather
than playing cat and mouse with them, just remove the timeout
altogether. The emergency shell doesn't buy us anything anyway, given
that the console is not interactive.