### PR TITLE
providers/azure: handle missing userdata correctly

### DIFF
--- a/src/providers/azure/azure.go
+++ b/src/providers/azure/azure.go
@@ -100,7 +100,7 @@ func (p provider) FetchConfig() (config.Config, error) {
 
 	p.logger.Debug("reading config")
 	rawConfig, err := ioutil.ReadFile(filepath.Join(mnt, configPath))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return config.Config{}, fmt.Errorf("failed to read config: %v", err)
 	}
 


### PR DESCRIPTION
If no userdata is provided, CustomData.bin does not exist on the OVF
DVD. This would result in the following error:

 failed to fetch config: failed to read config: open
 /tmp/ignition-azure525503356/CustomData.bin: no such file or directory