### PR TITLE
main: use /run/ignition.json instead of /tmp

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -52,7 +52,7 @@ func main() {
 	}{}
 
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
-	flag.StringVar(&flags.configCache, "config-cache", "/tmp/ignition.json", "where to cache the config")
+	flag.StringVar(&flags.configCache, "config-cache", "/run/ignition.json", "where to cache the config")
 	flag.DurationVar(&flags.onlineTimeout, "online-timeout", exec.DefaultOnlineTimeout, "how long to wait for a provider to come online")
 	flag.Var(&flags.oem, "oem", fmt.Sprintf("current oem. %v", oem.Names()))
 	flag.Var(&flags.providers, "provider", fmt.Sprintf("provider of config. can be specified multiple times. %v", providers.Names()))


### PR DESCRIPTION
Early enough in the boot process /tmp isn't a tmpfs, it's prudent to
use /run instead.