### PR TITLE
exec/util: add missing import header

### DIFF
--- a/src/exec/util/user_lookup.c
+++ b/src/exec/util/user_lookup.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "user_lookup.h"


### PR DESCRIPTION
Silence implicit declaration warning for waitpid.