### PR TITLE
config: be more specific on JSON unmarshal failure

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -15,8 +15,12 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+
+	"github.com/coreos/ignition/third_party/github.com/camlistore/camlistore/pkg/errorutil"
 )
 
 type Config struct {
@@ -50,6 +54,11 @@ func Parse(config []byte) (cfg Config, err error) {
 	} else if isEmpty(config) {
 		err = ErrEmpty
 	}
+	if serr, ok := err.(*json.SyntaxError); ok {
+		line, col, highlight := errorutil.HighlightBytePosition(bytes.NewReader(config), serr.Offset)
+		err = fmt.Errorf("error at line %d, column %d\n%s%v", line, col, highlight, err)
+	}
+
 	return
 }
 

--- a/third_party.manifest
+++ b/third_party.manifest
@@ -1,6 +1,7 @@
 # If you manipulate the contents of third_party/, amend this accordingly.
 # pkg							version
 github.com/alecthomas/units				6b4e7dc5e3143b85ea77909c72caf89416fc2915
+github.com/camlistore/camlistore/pkg/errorutil		9106ce829629773474c689b34aacd7d3aaa99426
 github.com/coreos/go-systemd/dbus			9b2f329b69ae0292a30f426867494f38af617a42
 github.com/coreos/go-systemd/unit			9b2f329b69ae0292a30f426867494f38af617a42
 github.com/coreos/update-ssh-keys/authorized_keys_d	539317dc5100bc599dab125b1e644a2b017b2b35

--- a/third_party/github.com/camlistore/camlistore/pkg/errorutil/highlight.go
+++ b/third_party/github.com/camlistore/camlistore/pkg/errorutil/highlight.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errorutil helps make better error messages.
+package errorutil
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// HighlightBytePosition takes a reader and the location in bytes of a parse
+// error (for instance, from json.SyntaxError.Offset) and returns the line, column,
+// and pretty-printed context around the error with an arrow indicating the exact
+// position of the syntax error.
+func HighlightBytePosition(f io.Reader, pos int64) (line, col int, highlight string) {
+	line = 1
+	br := bufio.NewReader(f)
+	lastLine := ""
+	thisLine := new(bytes.Buffer)
+	for n := int64(0); n < pos; n++ {
+		b, err := br.ReadByte()
+		if err != nil {
+			break
+		}
+		if b == '\n' {
+			lastLine = thisLine.String()
+			thisLine.Reset()
+			line++
+			col = 1
+		} else {
+			col++
+			thisLine.WriteByte(b)
+		}
+	}
+	if line > 1 {
+		highlight += fmt.Sprintf("%5d: %s\n", line-1, lastLine)
+	}
+	highlight += fmt.Sprintf("%5d: %s\n", line, thisLine.String())
+	highlight += fmt.Sprintf("%s^\n", strings.Repeat(" ", col+5))
+	return
+}


### PR DESCRIPTION
Use a library from camlistore to help pinpoint exactly where the problem
is if invalid JSON is supplied to Ignition.