### PR TITLE
providers/cmdline: fix OEM root path for PXE image

### DIFF
--- a/src/providers/cmdline/cmdline.go
+++ b/src/providers/cmdline/cmdline.go
@@ -42,7 +42,7 @@ const (
 	cmdlinePath    = "/proc/cmdline"
 	cmdlineUrlFlag = "coreos.config.url"
 	oemDevicePath  = "/dev/disk/by-label/OEM" // Device link where oem partition is found.
-	oemDirPath     = "/sysroot/usr/share/oem" // OEM dir within root fs to consider for pxe scenarios.
+	oemDirPath     = "/usr/share/oem"         // OEM dir within root fs to consider for pxe scenarios.
 	oemMountPath   = "/mnt/oem"               // Mountpoint where oem partition is mounted when present.
 )
 


### PR DESCRIPTION
When Ignition is run with oem:// and the config is contained in the
CPIO, the path is not prefixed by sysroot/. On CoreOS, usr.squashfs is
mounted to /sysroot/usr and the CPIO is mounted to /.