### PR TITLE
system: properly escape device paths

### DIFF
--- a/src/systemd/systemd.go
+++ b/src/systemd/systemd.go
@@ -30,7 +30,7 @@ func WaitOnDevices(devs []string, stage string) error {
 
 	results := map[string]chan string{}
 	for _, dev := range devs {
-		unitName := unit.UnitNameEscape(dev + ".device")
+		unitName := unit.UnitNamePathEscape(dev + ".device")
 		results[unitName] = make(chan string)
 
 		if _, err = conn.StartUnit(unitName, "replace", results[unitName]); err != nil {


### PR DESCRIPTION
The absolute paths were prefixed with a leading '-', which is incorrect.
Using UnitNamePathEscape() correctly escapes these absolute paths.