### PR TITLE
docs: remove line-wrapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,10 @@
 # How to Contribute
 
-CoreOS projects are [Apache 2.0 licensed](LICENSE) and accept contributions via
-GitHub pull requests.  This document outlines some of the conventions on
-development workflow, commit message formatting, contact points and other
-resources to make it easier to get your contribution accepted.
+CoreOS projects are [Apache 2.0 licensed](LICENSE) and accept contributions via GitHub pull requests.  This document outlines some of the conventions on development workflow, commit message formatting, contact points and other resources to make it easier to get your contribution accepted.
 
 # Certificate of Origin
 
-By contributing to this project you agree to the Developer Certificate of
-Origin (DCO). This document was created by the Linux Kernel community and is a
-simple statement that you, as a contributor, have the legal right to make the
-contribution. See the [DCO](DCO) file for details.
+By contributing to this project you agree to the Developer Certificate of Origin (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the [DCO](DCO) file for details.
 
 # Email and Chat
 
@@ -18,8 +12,7 @@ The project currently uses the general CoreOS email list and IRC channel:
 - Email: [coreos-dev](https://groups.google.com/forum/#!forum/coreos-dev)
 - IRC: #[coreos-dev](irc://irc.freenode.org:6667/#coreos-dev) IRC channel on freenode.org
 
-Please avoid emailing maintainers found in the MAINTAINERS file directly. They
-are very busy and read the mailing lists.
+Please avoid emailing maintainers found in the MAINTAINERS file directly. They are very busy and read the mailing lists.
 
 ## Getting Started
 
@@ -42,9 +35,7 @@ Thanks for your contributions!
 
 ### Format of the Commit Message
 
-We follow a rough convention for commit messages that is designed to answer two
-questions: what changed and why. The subject line should feature the what and
-the body of the commit should describe the why.
+We follow a rough convention for commit messages that is designed to answer two questions: what changed and why. The subject line should feature the what and the body of the commit should describe the why.
 
 ```
 scripts: add the test-cluster command
@@ -65,7 +56,4 @@ The format can be described more formally as follows:
 <footer>
 ```
 
-The first line is the subject and should be no longer than 70 characters, the
-second line is always blank, and other lines should be wrapped at 80 characters.
-This allows the message to be easier to read on GitHub as well as in various
-git tools.
+The first line is the subject and should be no longer than 70 characters, the second line is always blank, and other lines should be wrapped at 80 characters. This allows the message to be easier to read on GitHub as well as in various git tools.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,15 @@
 # Ignition #
 
-Ignition is the utility used by CoreOS Linux to manipulate disks during the
-initramfs. This includes partitioning disks, formatting partitions, writing
-files (regular files, systemd units, networkd units, etc.), and configuring
-users. On first boot, Ignition reads its configuration from a source of truth
-(remote URL, network metadata service, hypervisor bridge, etc.) and applies the
-configuration.
+Ignition is the utility used by CoreOS Linux to manipulate disks during the initramfs. This includes partitioning disks, formatting partitions, writing files (regular files, systemd units, networkd units, etc.), and configuring users. On first boot, Ignition reads its configuration from a source of truth (remote URL, network metadata service, hypervisor bridge, etc.) and applies the configuration.
 
 ## Usage ##
 
-Odds are good that you don't want to invoke Ignition directly. In fact, it
-isn't even present in the CoreOS Linux root filesystem. Take a look at the
-[Getting Started Guide][getting started] for details on providing Ignition
-with a runtime configuration.
+Odds are good that you don't want to invoke Ignition directly. In fact, it isn't even present in the CoreOS Linux root filesystem. Take a look at the [Getting Started Guide][getting started] for details on providing Ignition with a runtime configuration.
 
 [getting started]: doc/getting-started.md
 
 **Ignition is under very active development!**
 
-Please check out the [roadmap](ROADMAP.md) for information about the timeline.
-Use the [bug tracker][issues] to report bugs, but please avoid the urge to
-report lack of features for now.
+Please check out the [roadmap](ROADMAP.md) for information about the timeline. Use the [bug tracker][issues] to report bugs, but please avoid the urge to report lack of features for now.
 
 [issues]: https://github.com/coreos/bugs/issues/new?labels=component/ignition

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,7 @@
 
 **work in progress**
 
-This document defines a high level roadmap for Ignition development. The dates
-below should not be considered authoritative, but rather indicative of the
-projected timeline of the project.
+This document defines a high level roadmap for Ignition development. The dates below should not be considered authoritative, but rather indicative of the projected timeline of the project.
 
 ## Ignition 0.1 (Jul) ##
 - support basic disk manipulation

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,112 +1,66 @@
 # Configuration Specification #
 
-The Ignition configuration is a JSON document conforming to the following
-specification, with **_italicized_** entries being optional:
+The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
-- **ignitionVersion** (integer): the version number of the spec. Must be `1`.
-- **_storage_** (object): describes the desired state of the system's storage
-                          devices.
-  - **_disks_** (list of objects): the list of disks to be configured and their
-                                   options.
-    - **device** (string): the absolute path to the device. Devices are
-                           typically referenced by the /dev/disk/by-* symlinks.
-    - **_wipeTable_** (boolean): whether or not the partition tables shall be
-                                 wiped. When true, the partition tables are
-                                 erased before any further manipulation.
-                                 Otherwise, the existing entries are left
-                                 intact.
-    - **_partitions_** (list of objects): the list of partitions and their
-                                          configuration for this particular
-                                          disk.
-      - **_label_** (string): the PARTLABEL for the partition.
-      - **_number_** (integer): the partition number, which dictates it's
-                                position in the partition table (one-indexed).
-                                If zero, use the next available partition slot.
-      - **_size_** (integer): the size of the partition (in sectors). If zero,
-                            the partition will fill the remainder of the disk.
-      - **_start_** (integer): the start of the partition (in sectors). If
-                               zero, the partition will be positioned at the
-                               earliest available part of the disk.
-      - **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If
-                                 omitted, the default will be
-                                 0FC63DAF-8483-4772-8E79-3D69D8477DE4
-                                 (Linux filesystem data).
-  - **_raid_** (list of objects): the list of RAID arrays to be configured.
-    - **name** (string): the name to use for the resulting md device.
-    - **level** (string): the redundancy level of the array (e.g. linear,
-                          raid1, raid5, etc.).
-    - **devices** (list of strings): the list of devices (referenced by their
-                                     absolute path) in the array.
-    - **_spares_** (integer): the number of spares (if applicable) in the array.
-  - **_filesystems_** (list of objects): the list of filesystems to be
-                                         configured. Typically, one filesystem
-                                         is configured per partition.
-    - **device** (string): the absolute path to the device. Devices are
-                           typically referenced by the /dev/disk/by-* symlinks.
-    - **format** (string): the filesystem format (ext4, btrfs, or xfs).
-    - **_create_** (object): contains the set of options to be used when
-                             creating the filesystem. A non-null entry
-                             indicates that the filesystem shall be created.
-      - **_force_** (boolean): whether or not the create operation shall
-                               overwrite an existing filesystem.
-      - **_options_** (list of strings): any additional options to be passed to
-                                         the format-specific mkfs utility.
-    - **_files_** (list of objects): the list of files, rooted in this
-                                     particular filesystem, to be written.
-      - **path** (string): the absolute path to the file.
-      - **_contents_** (string): the contents of the file.
-      - **_mode_** (integer): the file's permission mode. Note that the mode
-                              must be properly specified as a **decimal** value
-                              (i.e. 0644 -> 420).
-      - **_uid_** (integer): the user ID of the owner.
-      - **_gid_** (integer): the group ID of the owner.
-- **_systemd_** (object): describes the desired state of the systemd units.
-  - **_units_** (list of objects): the list of systemd units.
-    - **name** (string): the name of the unit. This must be suffixed with a
-                         valid unit type (e.g. "thing.service").
-    - **_enable_** (boolean): whether or not the service shall be enabled. When
-                              true, the service is enabled. In order for this
-                              to have any effect, the unit must have an install
-                              section.
-    - **_mask_** (boolean): whether or not the service shall be masked. When
-                            true, the service is masked by symlinking it to
-                            /dev/null.
-    - **_contents_** (string): the contents of the unit.
-    - **_dropins_** (list of objects): the list of drop-ins for the unit.
-      - **name** (string): the name of the drop-in. This must be suffixed with
-                           ".conf".
-      - **_contents_** (string): the contents of the drop-in.
-- **_networkd_** (object): describes the desired state of the networkd files.
-  - **_units_** (list of objects): the list of networkd files.
-    - **name** (string): the name of the file. This must be suffixed with a
-                         valid unit type (e.g. "00-eth0.network").
-    - **_contents_** (string): the contents of the networkd file.
-- **_passwd_** (object): describes the desired additions to the passwd database.
-  - **_users_** (list of objects): the list of accounts to be added.
-    - **name** (string): the username for the account.
-    - **_passwordHash_** (string): the encrypted password for the account.
-    - **_sshAuthorizedKeys_** (list of strings): a list of SSH keys to be added
-                                                 to the user's authorized_keys.
-    - **_create_** (object): contains the set of options to be used when
-                             creating the user. A non-null entry indicates that
-                             the user account shall be created.
-      - **_uid_** (integer): the user ID of the new account.
-      - **_gecos_** (string): the GECOS field of the new account.
-      - **_homeDir_** (string): the home directory of the new account.
-      - **_noCreateHome_** (boolean): whether or not to create the user's home
-                                      directory.
-      - **_primaryGroup_** (string): the name or ID of the primary group of the
-                                     new account.
-      - **_groups_** (list of strings): the list of supplementary groups of the
-                                        new account.
-      - **_noUserGroup_** (boolean): whether or not to create a group with the
-                                     same name as the user.
-      - **_noLogInit_** (boolean): whether or not to add the user to the lastlog
-                                   and faillog databases.
-      - **_shell_** (string): the login shell of the new account.
-  - **_groups_** (list of objects): the list of groups to be added.
-    - **name** (string): the name of the group.
-    - **_gid_** (integer): the group ID of the new group.
-    - **_passwordHash_** (string): the encrypted password of the new group.
+* **ignitionVersion** (integer): the version number of the spec. Must be `1`.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_disks_** (list of objects): the list of disks to be configured and their options.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_wipeTable_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
+    * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
+      * **_label_** (string): the PARTLABEL for the partition.
+      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_size_** (integer): the size of the partition (in sectors). If zero, the partition will fill the remainder of the disk.
+      * **_start_** (integer): the start of the partition (in sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+  * **_raid_** (list of objects): the list of RAID arrays to be configured.
+    * **name** (string): the name to use for the resulting md device.
+    * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
+    * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
+    * **_spares_** (integer): the number of spares (if applicable) in the array.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured. Typically, one filesystem is configured per partition.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **format** (string): the filesystem format (ext4, btrfs, or xfs).
+    * **_create_** (object): contains the set of options to be used when creating the filesystem. A non-null entry indicates that the filesystem shall be created.
+      * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
+      * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_files_** (list of objects): the list of files, rooted in this particular filesystem, to be written.
+      * **path** (string): the absolute path to the file.
+      * **_contents_** (string): the contents of the file.
+      * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
+      * **_uid_** (integer): the user ID of the owner.
+      * **_gid_** (integer): the group ID of the owner.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").
+    * **_enable_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_networkd_** (object): describes the desired state of the networkd files.
+  * **_units_** (list of objects): the list of networkd files.
+    * **name** (string): the name of the file. This must be suffixed with a valid unit type (e.g. "00-eth0.network").
+    * **_contents_** (string): the contents of the networkd file.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts to be added.
+    * **name** (string): the username for the account.
+    * **_passwordHash_** (string): the encrypted password for the account.
+    * **_sshAuthorizedKeys_** (list of strings): a list of SSH keys to be added to the user's authorized_keys.
+    * **_create_** (object): contains the set of options to be used when creating the user. A non-null entry indicates that the user account shall be created.
+      * **_uid_** (integer): the user ID of the new account.
+      * **_gecos_** (string): the GECOS field of the new account.
+      * **_homeDir_** (string): the home directory of the new account.
+      * **_noCreateHome_** (boolean): whether or not to create the user's home directory.
+      * **_primaryGroup_** (string): the name or ID of the primary group of the new account.
+      * **_groups_** (list of strings): the list of supplementary groups of the new account.
+      * **_noUserGroup_** (boolean): whether or not to create a group with the same name as the user.
+      * **_noLogInit_** (boolean): whether or not to add the user to the lastlog and faillog databases.
+      * **_shell_** (string): the login shell of the new account.
+  * **_groups_** (list of objects): the list of groups to be added.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_passwordHash_** (string): the encrypted password of the new group.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,14 +1,14 @@
 # Getting Started with Ignition #
 
-Ignition uses a JSON config to represent the set of changes to be made. The format of this config is detailed [in the spec][config spec]. One of the most important parts of this config is the version number. This **must** match the version number accepted by Ignition. If the config version isn't accepted by Ignition, Ignition will fail to run and prevent the machine from booting. This can be seen by inspecting the console output of the failed instance. For more information, check out the [troubleshooting section](#troubleshooting).
+Ignition uses a JSON configuration file to represent the set of changes to be made. The format of this config is detailed [in the spec][config spec]. One of the most important parts of this config is the version number. This **must** match the version number accepted by Ignition. If the config version isn't accepted by Ignition, Ignition will fail to run and prevent the machine from booting. This can be seen by inspecting the console output of the failed instance. For more information, check out the [troubleshooting section](#troubleshooting).
 
 [config spec]: configuration.md
 
 ## Providing a Config ##
 
-Ignition will look in different places for its configuration and metadata, depending on the platform on which it is running. A full list of the [supported platforms] and their data sources is provided for reference.
+Ignition will choose where to look for configuration based on the underlying platform. A list of [supported platforms] and metadata sources is provided for reference.
 
-The configuration will need to be passed to Ignition via the designated data source.
+The configuration must be passed to Ignition through the designated data source.
 
 [supported platforms]: supported-platforms.md
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,38 +1,23 @@
 # Getting Started with Ignition #
 
-Ignition uses a JSON config to represent the set of changes to be made. The
-format of this config is detailed [in the spec][config spec]. One of the most
-important parts of this config is the version number. This **must** match the
-version number accepted by Ignition. If the config version isn't accepted by
-Ignition, Ignition will fail to run and prevent the machine from booting. This
-can be seen by inspecting the console output of the failed instance. For more
-information, check out the [troubleshooting section](#troubleshooting).
+Ignition uses a JSON config to represent the set of changes to be made. The format of this config is detailed [in the spec][config spec]. One of the most important parts of this config is the version number. This **must** match the version number accepted by Ignition. If the config version isn't accepted by Ignition, Ignition will fail to run and prevent the machine from booting. This can be seen by inspecting the console output of the failed instance. For more information, check out the [troubleshooting section](#troubleshooting).
 
 [config spec]: configuration.md
 
 ## Providing a Config ##
 
-Ignition will look in different places for its configuration and metadata,
-depending on the platform on which it is running. A full list of the
-[supported platforms] and their data sources is provided for reference.
+Ignition will look in different places for its configuration and metadata, depending on the platform on which it is running. A full list of the [supported platforms] and their data sources is provided for reference.
 
-The configuration will need to be passed to Ignition via the designated data
-source.
+The configuration will need to be passed to Ignition via the designated data source.
 
 [supported platforms]: supported-platforms.md
 
 ## Troubleshooting ##
 
-The single most useful piece of information needed when troubleshooting is the
-log from Ignition. Ignition runs in multiple stages so it's easiest to filter
-by the syslog identifier: `ignition`. When using systemd, this can be
-accomplished with the following command:
+The single most useful piece of information needed when troubleshooting is the log from Ignition. Ignition runs in multiple stages so it's easiest to filter by the syslog identifier: `ignition`. When using systemd, this can be accomplished with the following command:
 
 ```
 journalctl --identifier=ignition
 ```
 
-In the vast majority of cases, it will be immediately obvious why Ignition
-failed. If it's not, inspect the config that Ignition dumped into the log. This
-shows how Ignition interpreted the supplied configuration. The user-provided
-config may have a misspelled section or maybe an incorrect hierarchy.
+In the vast majority of cases, it will be immediately obvious why Ignition failed. If it's not, inspect the config that Ignition dumped into the log. This shows how Ignition interpreted the supplied configuration. The user-provided config may have a misspelled section or maybe an incorrect hierarchy.

--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -2,21 +2,9 @@
 
 Ignition is currently only supported for the following platforms:
 
-- [Bare Metal](https://coreos.com/os/docs/latest/installing-to-disk.html) - Use
-  the `coreos.config.url` kernel parameter to provide a URL to the
-  configuration. The URL can use the `http://` scheme to specify a remote
-  config or the `oem://` scheme to specify a local config, rooted in
-  `/usr/share/oem`.
-- [PXE](https://coreos.com/os/docs/latest/booting-with-pxe.html) - Use the
-  `coreos.config.url` kernel parameter to provide a URL to the configuration.
-  The URL can use the `http://` scheme to specify a remote config or the
-  `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
-- [Amazon EC2](https://coreos.com/os/docs/latest/booting-on-ec2.html) -
-  Ignition will read its configuration from the userdata and append the SSH
-  keys listed in the instance metadata.
-- [Microsoft Azure](https://coreos.com/os/docs/latest/booting-on-azure.html) -
-  Ignition will read its configuration from the custom data provided to the
-  instance. SSH keys are handled by the Azure Linux Agent.
+* [Bare Metal](https://coreos.com/os/docs/latest/installing-to-disk.html) - Use the `coreos.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://` scheme to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
+* [PXE](https://coreos.com/os/docs/latest/booting-with-pxe.html) - Use the `coreos.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://` scheme to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
+* [Amazon EC2](https://coreos.com/os/docs/latest/booting-on-ec2.html) - Ignition will read its configuration from the userdata and append the SSH keys listed in the instance metadata.
+* [Microsoft Azure](https://coreos.com/os/docs/latest/booting-on-azure.html) - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
 
-Ignition is under active development so expect this list to expand in the
-coming months.
+Ignition is under active development so expect this list to expand in the coming months.


### PR DESCRIPTION
Per CoreOS documentation standards, use one line per block of text rather than
wrapping at 80 columns.

/cc @joshix 