### PR TITLE
config: assert validity of filesystems

### DIFF
--- a/src/config/filesystem_test.go
+++ b/src/config/filesystem_test.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"reflect"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestDevicePathUnmarshalJSON(t *testing.T) {
 		},
 		{
 			in:  in{data: `"bad"`},
-			out: out{device: DevicePath("bad"), err: errors.New("device path not absolute")},
+			out: out{device: DevicePath("bad"), err: ErrFilesystemRelativePath},
 		},
 	}
 
@@ -77,7 +76,7 @@ func TestDevicePathUnmarshalYAML(t *testing.T) {
 		},
 		{
 			in:  in{data: `"bad"`},
-			out: out{device: DevicePath("bad"), err: errors.New("device path not absolute")},
+			out: out{device: DevicePath("bad"), err: ErrFilesystemRelativePath},
 		},
 	}
 
@@ -123,7 +122,7 @@ func TestDevicePathAssertValid(t *testing.T) {
 		},
 		{
 			in:  in{device: DevicePath("relative/path")},
-			out: out{err: errors.New("device path not absolute")},
+			out: out{err: ErrFilesystemRelativePath},
 		},
 	}
 
@@ -154,7 +153,7 @@ func TestFilesystemFormatUnmarshalJSON(t *testing.T) {
 		},
 		{
 			in:  in{data: `"bad"`},
-			out: out{format: FilesystemFormat("bad"), err: errors.New("invalid filesystem format")},
+			out: out{format: FilesystemFormat("bad"), err: ErrFilesystemInvalidFormat},
 		},
 	}
 
@@ -189,7 +188,7 @@ func TestFilesystemFormatUnmarshalYAML(t *testing.T) {
 		},
 		{
 			in:  in{data: `"bad"`},
-			out: out{format: FilesystemFormat("bad"), err: errors.New("invalid filesystem format")},
+			out: out{format: FilesystemFormat("bad"), err: ErrFilesystemInvalidFormat},
 		},
 	}
 
@@ -200,7 +199,7 @@ func TestFilesystemFormatUnmarshalYAML(t *testing.T) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
 		}
 		if !reflect.DeepEqual(test.out.format, format) {
-			t.Errorf("#%d: bad device: want %#v, got %#v", i, test.out.format, format)
+			t.Errorf("#%d: bad format: want %#v, got %#v", i, test.out.format, format)
 		}
 	}
 }
@@ -227,7 +226,7 @@ func TestFilesystemFormatAssertValid(t *testing.T) {
 		},
 		{
 			in:  in{format: FilesystemFormat("")},
-			out: out{err: errors.New("invalid filesystem format")},
+			out: out{err: ErrFilesystemInvalidFormat},
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/coreos/bugs/issues/1071

Given the following config:

```json
{
  "ignitionVersion": 1,
  "storage": {
    "filesystems": [
      {
        "device": "/dev/disk/by-label/ROOT",
        "files": [
          {
            "path": "/alex",
            "contents": "HELLO\n",
            "mode": 444
          }
        ]
      }
    ]
  }
}
```

Ignition now fails with:

```
Jan 11 19:12:16 localhost ignition[222]: Ignition v0.2.4-7-g6159283-dirty
Jan 11 19:12:16 localhost ignition[222]: parsed url from cmdline: "oem:///ignition.json"
Jan 11 19:12:16 localhost ignition[222]: oem config not found in "/usr/share/oem", trying "/mnt/oem"
Jan 11 19:12:17 localhost ignition[222]: op(1): [started]  mounting "/dev/disk/by-label/OEM" at "/mnt/oem"
Jan 11 19:12:17 localhost ignition[222]: op(1): [finished] mounting "/dev/disk/by-label/OEM" at "/mnt/oem"
Jan 11 19:12:17 localhost ignition[222]: op(2): [started]  unmounting "/mnt/oem"
Jan 11 19:12:17 localhost ignition[222]: op(2): [finished] unmounting "/mnt/oem"
Jan 11 19:12:17 localhost ignition[222]: failed to fetch config: missing filesystem format
Jan 11 19:12:17 localhost ignition[222]: failed to acquire config: missing filesystem format
```