### PR TITLE
sgdisk: retry zap-all operation on failure

### DIFF
--- a/src/sgdisk/sgdisk.go
+++ b/src/sgdisk/sgdisk.go
@@ -59,7 +59,11 @@ func (op *Operation) Commit() error {
 	if op.wipe {
 		cmd := exec.Command(sgdiskPath, "--zap-all", op.dev)
 		if err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
-			return fmt.Errorf("wipe failed: %v")
+			op.logger.Info("potential error encountered while wiping table... retrying")
+			cmd = exec.Command(sgdiskPath, "--zap-all", op.dev)
+			if err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
+				return fmt.Errorf("wipe failed: %v")
+			}
 		}
 	}
 


### PR DESCRIPTION
sgdisk is a bit weird and will exit with code 2 if there is trouble with the GPT
headers, even it successfully zaps them. Retrying the zap operation will allow
us to be sure that the operation completed successfully.