### PR TITLE
docs: use semantic versioning for the spec

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2,7 +2,8 @@
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
-* **ignitionVersion** (integer): the version number of the spec. Must be `1`.
+* **ignition** (object): metadata about the configuration itself.
+  * **version** (string): the semantic version number of the spec. Must be at least `2.0.0`.
 * **_storage_** (object): describes the desired state of the system's storage devices.
   * **_disks_** (list of objects): the list of disks to be configured and their options.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.


### PR DESCRIPTION
This also moves the version number from:

```json
  "ignitionVersion":
```

to

```json
  "ignition": {
    "version":
  }
```