### PR TITLE
providers/vmware: allow building on non-amd64

### DIFF
--- a/src/providers/vmware/vmware.go
+++ b/src/providers/vmware/vmware.go
@@ -28,15 +28,7 @@ import (
 	"github.com/coreos/ignition/third_party/github.com/sigma/vmw-guestinfo/vmcheck"
 )
 
-const (
-	name = "vmware"
-)
-
 type Creator struct{}
-
-func (Creator) Name() string {
-	return name
-}
 
 func (Creator) Create(logger log.Logger) providers.Provider {
 	return &provider{
@@ -46,10 +38,6 @@ func (Creator) Create(logger log.Logger) providers.Provider {
 
 type provider struct {
 	logger log.Logger
-}
-
-func (provider) Name() string {
-	return name
 }
 
 func (p provider) FetchConfig() (config.Config, error) {

--- a/src/providers/vmware/vmware_amd64.go
+++ b/src/providers/vmware/vmware_amd64.go
@@ -18,28 +18,23 @@
 package vmware
 
 import (
-	"time"
+	"github.com/coreos/ignition/config"
 
-	"github.com/coreos/ignition/src/log"
-	"github.com/coreos/ignition/src/providers"
+	"github.com/coreos/ignition/third_party/github.com/sigma/vmw-guestinfo/rpcvmx"
+	"github.com/coreos/ignition/third_party/github.com/sigma/vmw-guestinfo/vmcheck"
 )
 
-type Creator struct{}
-
-func (Creator) Create(logger log.Logger) providers.Provider {
-	return &provider{
-		logger: logger,
+func (p provider) FetchConfig() (config.Config, error) {
+	data, err := rpcvmx.NewConfig().String("coreos.config.data", "")
+	if err != nil {
+		p.logger.Debug("failed to fetch config: %v", err)
+		return config.Config{}, err
 	}
+
+	p.logger.Debug("config successfully fetched")
+	return config.Parse([]byte(data))
 }
 
-type provider struct {
-	logger log.Logger
-}
-
-func (p provider) ShouldRetry() bool {
-	return false
-}
-
-func (p *provider) BackoffDuration() time.Duration {
-	return 0
+func (p *provider) IsOnline() bool {
+	return vmcheck.IsVirtualWorld()
 }

--- a/src/providers/vmware/vmware_unsupported.go
+++ b/src/providers/vmware/vmware_unsupported.go
@@ -15,31 +15,20 @@
 // The vmware provider fetches a configuration from the VMware Guest Info
 // interface.
 
+// +build !amd64
+
 package vmware
 
 import (
-	"time"
+	"errors"
 
-	"github.com/coreos/ignition/src/log"
-	"github.com/coreos/ignition/src/providers"
+	"github.com/coreos/ignition/config"
 )
 
-type Creator struct{}
-
-func (Creator) Create(logger log.Logger) providers.Provider {
-	return &provider{
-		logger: logger,
-	}
+func (p provider) FetchConfig() (config.Config, error) {
+	return config.Config{}, errors.New("vmware provider is not supported on this architecture")
 }
 
-type provider struct {
-	logger log.Logger
-}
-
-func (p provider) ShouldRetry() bool {
+func (p *provider) IsOnline() bool {
 	return false
-}
-
-func (p *provider) BackoffDuration() time.Duration {
-	return 0
 }


### PR DESCRIPTION
When built on unsupported architectures, the datasource will permanently report that it is offline.