### PR TITLE
*: move config type definitions into config/types

### DIFF
--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -17,6 +17,8 @@ package config
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/types"
 )
 
 func TestParse(t *testing.T) {
@@ -24,7 +26,7 @@ func TestParse(t *testing.T) {
 		config []byte
 	}
 	type out struct {
-		config Config
+		config types.Config
 		err    error
 	}
 
@@ -34,7 +36,7 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			in:  in{config: []byte(`{"ignitionVersion": 1}`)},
-			out: out{config: Config{Version: 1}},
+			out: out{config: types.Config{Version: 1}},
 		},
 		{
 			in:  in{config: []byte(`{}`)},

--- a/src/config/types/config.go
+++ b/src/config/types/config.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
-type Passwd struct {
-	Users  []User  `json:"users,omitempty"  yaml:"users"`
-	Groups []Group `json:"groups,omitempty" yaml:"groups"`
+const (
+	Version = 1
+)
+
+type Config struct {
+	Version  int      `json:"ignitionVersion"    yaml:"ignition_version"`
+	Storage  Storage  `json:"storage,omitempty"  yaml:"storage"`
+	Systemd  Systemd  `json:"systemd,omitempty"  yaml:"systemd"`
+	Networkd Networkd `json:"networkd,omitempty" yaml:"networkd"`
+	Passwd   Passwd   `json:"passwd,omitempty"   yaml:"passwd"`
 }

--- a/src/config/types/devicepath.go
+++ b/src/config/types/devicepath.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/disk.go
+++ b/src/config/types/disk.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/file.go
+++ b/src/config/types/file.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/file_test.go
+++ b/src/config/types/file_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/filesystem.go
+++ b/src/config/types/filesystem.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/filesystem_test.go
+++ b/src/config/types/filesystem_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/group.go
+++ b/src/config/types/group.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 type Group struct {
 	Name         string `json:"name,omitempty"          yaml:"name"`

--- a/src/config/types/networkd.go
+++ b/src/config/types/networkd.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
-type Storage struct {
-	Disks       []Disk       `json:"disks,omitempty"       yaml:"disks"`
-	Arrays      []Raid       `json:"raid,omitempty"        yaml:"raid"`
-	Filesystems []Filesystem `json:"filesystems,omitempty" yaml:"filesystems"`
+type Networkd struct {
+	Units []NetworkdUnit `json:"units,omitempty" yaml:"units"`
 }

--- a/src/config/types/partition.go
+++ b/src/config/types/partition.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/passwd.go
+++ b/src/config/types/passwd.go
@@ -1,0 +1,20 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type Passwd struct {
+	Users  []User  `json:"users,omitempty"  yaml:"users"`
+	Groups []Group `json:"groups,omitempty" yaml:"groups"`
+}

--- a/src/config/types/raid.go
+++ b/src/config/types/raid.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/storage.go
+++ b/src/config/types/storage.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
-type Networkd struct {
-	Units []NetworkdUnit `json:"units,omitempty" yaml:"units"`
+type Storage struct {
+	Disks       []Disk       `json:"disks,omitempty"       yaml:"disks"`
+	Arrays      []Raid       `json:"raid,omitempty"        yaml:"raid"`
+	Filesystems []Filesystem `json:"filesystems,omitempty" yaml:"filesystems"`
 }

--- a/src/config/types/systemd.go
+++ b/src/config/types/systemd.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 type Systemd struct {
 	Units []SystemdUnit `json:"units,omitempty" yaml:"units"`

--- a/src/config/types/unit.go
+++ b/src/config/types/unit.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/unit_test.go
+++ b/src/config/types/unit_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 import (
 	"encoding/json"

--- a/src/config/types/user.go
+++ b/src/config/types/user.go
@@ -1,4 +1,4 @@
-// Copyright 2015 CoreOS, Inc.
+// Copyright 2016 CoreOS, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package types
 
 type User struct {
 	Name              string      `json:"name,omitempty"              yaml:"name"`

--- a/src/exec/engine.go
+++ b/src/exec/engine.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/exec/stages"
 	"github.com/coreos/ignition/src/log"
 	"github.com/coreos/ignition/src/providers"
@@ -59,7 +60,7 @@ func (e Engine) Run(stageName string) bool {
 
 // acquireConfig returns the configuration, first checking a local cache
 // before attempting to fetch it from the provider.
-func (e Engine) acquireConfig() (cfg config.Config, err error) {
+func (e Engine) acquireConfig() (cfg types.Config, err error) {
 	// First try read the config @ e.ConfigCache.
 	b, err := ioutil.ReadFile(e.ConfigCache)
 	if err == nil {
@@ -93,9 +94,9 @@ func (e Engine) acquireConfig() (cfg config.Config, err error) {
 
 // fetchConfig returns the configuration from the provider or returns an error
 // if the provider is unavailable.
-func fetchConfig(provider providers.Provider, timeout time.Duration) (config.Config, error) {
+func fetchConfig(provider providers.Provider, timeout time.Duration) (types.Config, error) {
 	if err := util.WaitUntilOnline(provider, timeout); err != nil {
-		return config.Config{}, err
+		return types.Config{}, err
 	}
 
 	return provider.FetchConfig()

--- a/src/exec/engine_test.go
+++ b/src/exec/engine_test.go
@@ -20,22 +20,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/providers"
 )
 
 type mockProvider struct {
-	config  config.Config
+	config  types.Config
 	err     error
 	online  bool
 	retry   bool
 	backoff time.Duration
 }
 
-func (p mockProvider) FetchConfig() (config.Config, error) { return p.config, p.err }
-func (p mockProvider) IsOnline() bool                      { return p.online }
-func (p mockProvider) ShouldRetry() bool                   { return p.retry }
-func (p mockProvider) BackoffDuration() time.Duration      { return p.backoff }
+func (p mockProvider) FetchConfig() (types.Config, error) { return p.config, p.err }
+func (p mockProvider) IsOnline() bool                     { return p.online }
+func (p mockProvider) ShouldRetry() bool                  { return p.retry }
+func (p mockProvider) BackoffDuration() time.Duration     { return p.backoff }
 
 // TODO
 func TestRun(t *testing.T) {
@@ -47,16 +47,16 @@ func TestFetchConfigs(t *testing.T) {
 		timeout  time.Duration
 	}
 	type out struct {
-		config config.Config
+		config types.Config
 		err    error
 	}
 
 	online := mockProvider{
 		online: true,
 		err:    errors.New("test error"),
-		config: config.Config{
-			Systemd: config.Systemd{
-				Units: []config.SystemdUnit{},
+		config: types.Config{
+			Systemd: types.Systemd{
+				Units: []types.SystemdUnit{},
 			},
 		},
 	}
@@ -72,7 +72,7 @@ func TestFetchConfigs(t *testing.T) {
 		},
 		{
 			in:  in{provider: offline, timeout: time.Second},
-			out: out{config: config.Config{}, err: providers.ErrNoProvider},
+			out: out{config: types.Config{}, err: providers.ErrNoProvider},
 		},
 	}
 

--- a/src/exec/stages/disks/disks.go
+++ b/src/exec/stages/disks/disks.go
@@ -25,7 +25,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/exec/stages"
 	"github.com/coreos/ignition/src/exec/util"
 	"github.com/coreos/ignition/src/log"
@@ -62,7 +62,7 @@ func (stage) Name() string {
 	return name
 }
 
-func (s stage) Run(config config.Config) bool {
+func (s stage) Run(config types.Config) bool {
 	if err := s.createPartitions(config); err != nil {
 		s.Logger.Crit("create partitions failed: %v", err)
 		return false
@@ -99,7 +99,7 @@ func (s stage) waitOnDevices(devs []string, ctxt string) error {
 }
 
 // createPartitions creates the partitions described in config.Storage.Disks.
-func (s stage) createPartitions(config config.Config) error {
+func (s stage) createPartitions(config types.Config) error {
 	if len(config.Storage.Disks) == 0 {
 		return nil
 	}
@@ -147,7 +147,7 @@ func (s stage) createPartitions(config config.Config) error {
 }
 
 // createRaids creates the raid arrays described in config.Storage.Arrays.
-func (s stage) createRaids(config config.Config) error {
+func (s stage) createRaids(config types.Config) error {
 	if len(config.Storage.Arrays) == 0 {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (s stage) createRaids(config config.Config) error {
 }
 
 // createFilesystems creates the filesystems described in config.Storage.Filesystems.
-func (s stage) createFilesystems(config config.Config) error {
+func (s stage) createFilesystems(config types.Config) error {
 	if len(config.Storage.Filesystems) == 0 {
 		return nil
 	}
@@ -221,7 +221,7 @@ func (s stage) createFilesystems(config config.Config) error {
 	return nil
 }
 
-func (s stage) createFilesystem(fs config.Filesystem) error {
+func (s stage) createFilesystem(fs types.Filesystem) error {
 	if fs.Create == nil {
 		return nil
 	}
@@ -261,7 +261,7 @@ func (s stage) createFilesystem(fs config.Filesystem) error {
 }
 
 // createFilesystemsFiles creates the files described in config.Storage.Filesystems.
-func (s stage) createFilesystemsFiles(config config.Config) error {
+func (s stage) createFilesystemsFiles(config types.Config) error {
 	if len(config.Storage.Filesystems) == 0 {
 		return nil
 	}
@@ -278,7 +278,7 @@ func (s stage) createFilesystemsFiles(config config.Config) error {
 }
 
 // createFiles creates any files listed for the filesystem in fs.Files.
-func (s stage) createFiles(fs config.Filesystem) error {
+func (s stage) createFiles(fs types.Filesystem) error {
 	if len(fs.Files) == 0 {
 		return nil
 	}

--- a/src/exec/stages/files/files.go
+++ b/src/exec/stages/files/files.go
@@ -17,7 +17,7 @@ package prepivot
 import (
 	"fmt"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/exec/stages"
 	"github.com/coreos/ignition/src/exec/util"
 	"github.com/coreos/ignition/src/log"
@@ -52,7 +52,7 @@ func (stage) Name() string {
 	return name
 }
 
-func (s stage) Run(config config.Config) bool {
+func (s stage) Run(config types.Config) bool {
 	if err := s.createPasswd(config); err != nil {
 		s.Logger.Crit("failed to create users/groups: %v", err)
 		return false
@@ -66,7 +66,7 @@ func (s stage) Run(config config.Config) bool {
 }
 
 // createUnits creates the units listed under systemd.units and networkd.units.
-func (s stage) createUnits(config config.Config) error {
+func (s stage) createUnits(config types.Config) error {
 	for _, unit := range config.Systemd.Units {
 		if err := s.writeSystemdUnit(unit); err != nil {
 			return err
@@ -99,7 +99,7 @@ func (s stage) createUnits(config config.Config) error {
 // writeSystemdUnit creates the specified unit and any dropins for that unit.
 // If the contents of the unit or are empty, the unit is not created. The same
 // applies to the unit's dropins.
-func (s stage) writeSystemdUnit(unit config.SystemdUnit) error {
+func (s stage) writeSystemdUnit(unit types.SystemdUnit) error {
 	return s.Logger.LogOp(func() error {
 		for _, dropin := range unit.DropIns {
 			if dropin.Contents == "" {
@@ -133,7 +133,7 @@ func (s stage) writeSystemdUnit(unit config.SystemdUnit) error {
 
 // writeNetworkdUnit creates the specified unit. If the contents of the unit or
 // are empty, the unit is not created.
-func (s stage) writeNetworkdUnit(unit config.NetworkdUnit) error {
+func (s stage) writeNetworkdUnit(unit types.NetworkdUnit) error {
 	return s.Logger.LogOp(func() error {
 		if unit.Contents == "" {
 			return nil
@@ -152,7 +152,7 @@ func (s stage) writeNetworkdUnit(unit config.NetworkdUnit) error {
 }
 
 // createPasswd creates the users and groups as described in config.Passwd.
-func (s stage) createPasswd(config config.Config) error {
+func (s stage) createPasswd(config types.Config) error {
 	if err := s.createGroups(config); err != nil {
 		return fmt.Errorf("failed to create groups: %v", err)
 	}
@@ -165,7 +165,7 @@ func (s stage) createPasswd(config config.Config) error {
 }
 
 // createUsers creates the users as described in config.Passwd.Users.
-func (s stage) createUsers(config config.Config) error {
+func (s stage) createUsers(config types.Config) error {
 	if len(config.Passwd.Users) == 0 {
 		return nil
 	}
@@ -193,7 +193,7 @@ func (s stage) createUsers(config config.Config) error {
 }
 
 // createGroups creates the users as described in config.Passwd.Groups.
-func (s stage) createGroups(config config.Config) error {
+func (s stage) createGroups(config types.Config) error {
 	if len(config.Passwd.Groups) == 0 {
 		return nil
 	}

--- a/src/exec/stages/stages.go
+++ b/src/exec/stages/stages.go
@@ -15,14 +15,14 @@
 package stages
 
 import (
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/log"
 	"github.com/coreos/ignition/src/registry"
 )
 
 // Stage is responsible for actually executing a stage of the configuration.
 type Stage interface {
-	Run(config config.Config) bool
+	Run(config types.Config) bool
 	Name() string
 }
 

--- a/src/exec/util/file.go
+++ b/src/exec/util/file.go
@@ -19,16 +19,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 )
 
 const (
-	DefaultDirectoryPermissions config.FileMode = 0755
-	DefaultFilePermissions      config.FileMode = 0644
+	DefaultDirectoryPermissions types.FileMode = 0755
+	DefaultFilePermissions      types.FileMode = 0644
 )
 
 // WriteFile creates and writes the file described by f using the provided context
-func (u Util) WriteFile(f *config.File) error {
+func (u Util) WriteFile(f *types.File) error {
 	var err error
 
 	path := u.JoinPath(f.Path)

--- a/src/exec/util/passwd.go
+++ b/src/exec/util/passwd.go
@@ -20,13 +20,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 
 	keys "github.com/coreos/ignition/third_party/github.com/coreos/update-ssh-keys/authorized_keys_d"
 )
 
 // CreateUser creates the user as described.
-func (u Util) CreateUser(c config.User) error {
+func (u Util) CreateUser(c types.User) error {
 	if c.Create == nil {
 		return nil
 	}
@@ -90,7 +90,7 @@ func (u Util) CreateUser(c config.User) error {
 }
 
 // Add the provided SSH public keys to the user's authorized keys.
-func (u Util) AuthorizeSSHKeys(c config.User) error {
+func (u Util) AuthorizeSSHKeys(c types.User) error {
 	if len(c.SSHAuthorizedKeys) == 0 {
 		return nil
 	}
@@ -131,7 +131,7 @@ func (u Util) AuthorizeSSHKeys(c config.User) error {
 }
 
 // SetPasswordHash sets the password hash of the specified user.
-func (u Util) SetPasswordHash(c config.User) error {
+func (u Util) SetPasswordHash(c types.User) error {
 	if c.PasswordHash == "" {
 		return nil
 	}
@@ -148,7 +148,7 @@ func (u Util) SetPasswordHash(c config.User) error {
 }
 
 // CreateGroup creates the group as described.
-func (u Util) CreateGroup(g config.Group) error {
+func (u Util) CreateGroup(g types.Group) error {
 	args := []string{"--root", u.DestDir}
 
 	if g.Gid != nil {

--- a/src/exec/util/unit.go
+++ b/src/exec/util/unit.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 )
 
 const (
@@ -27,8 +27,8 @@ const (
 	DefaultPresetPermissions os.FileMode = 0644
 )
 
-func FileFromSystemdUnit(unit config.SystemdUnit) *config.File {
-	return &config.File{
+func FileFromSystemdUnit(unit types.SystemdUnit) *types.File {
+	return &types.File{
 		Path:     filepath.Join(SystemdUnitsPath(), string(unit.Name)),
 		Contents: unit.Contents,
 		Mode:     DefaultFilePermissions,
@@ -37,8 +37,8 @@ func FileFromSystemdUnit(unit config.SystemdUnit) *config.File {
 	}
 }
 
-func FileFromNetworkdUnit(unit config.NetworkdUnit) *config.File {
-	return &config.File{
+func FileFromNetworkdUnit(unit types.NetworkdUnit) *types.File {
+	return &types.File{
 		Path:     filepath.Join(NetworkdUnitsPath(), string(unit.Name)),
 		Contents: unit.Contents,
 		Mode:     DefaultFilePermissions,
@@ -47,8 +47,8 @@ func FileFromNetworkdUnit(unit config.NetworkdUnit) *config.File {
 	}
 }
 
-func FileFromUnitDropin(unit config.SystemdUnit, dropin config.SystemdUnitDropIn) *config.File {
-	return &config.File{
+func FileFromUnitDropin(unit types.SystemdUnit, dropin types.SystemdUnitDropIn) *types.File {
+	return &types.File{
 		Path:     filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
 		Contents: dropin.Contents,
 		Mode:     DefaultFilePermissions,
@@ -57,7 +57,7 @@ func FileFromUnitDropin(unit config.SystemdUnit, dropin config.SystemdUnitDropIn
 	}
 }
 
-func (u Util) MaskUnit(unit config.SystemdUnit) error {
+func (u Util) MaskUnit(unit types.SystemdUnit) error {
 	path := u.JoinPath(SystemdUnitsPath(), string(unit.Name))
 	if err := mkdirForFile(path); err != nil {
 		return err
@@ -65,7 +65,7 @@ func (u Util) MaskUnit(unit config.SystemdUnit) error {
 	return os.Symlink("/dev/null", path)
 }
 
-func (u Util) EnableUnit(unit config.SystemdUnit) error {
+func (u Util) EnableUnit(unit types.SystemdUnit) error {
 	path := u.JoinPath(presetPath)
 	if err := mkdirForFile(path); err != nil {
 		return err

--- a/src/providers/cmdline/cmdline.go
+++ b/src/providers/cmdline/cmdline.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/log"
 	"github.com/coreos/ignition/src/providers"
 	putil "github.com/coreos/ignition/src/providers/util"
@@ -66,9 +67,9 @@ type provider struct {
 	rawConfig []byte
 }
 
-func (p provider) FetchConfig() (config.Config, error) {
+func (p provider) FetchConfig() (types.Config, error) {
 	if p.rawConfig == nil {
-		return config.Config{}, nil
+		return types.Config{}, nil
 	} else {
 		return config.Parse(p.rawConfig)
 	}

--- a/src/providers/ec2/ec2.go
+++ b/src/providers/ec2/ec2.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/log"
 	"github.com/coreos/ignition/src/providers"
 	putil "github.com/coreos/ignition/src/providers/util"
@@ -57,7 +58,7 @@ type provider struct {
 	rawConfig []byte
 }
 
-func (p provider) FetchConfig() (config.Config, error) {
+func (p provider) FetchConfig() (types.Config, error) {
 	cfg, err := config.Parse(p.rawConfig)
 	if err == nil || err == config.ErrEmpty {
 		err = p.fetchSSHKeys(&cfg)
@@ -80,7 +81,7 @@ func (p *provider) BackoffDuration() time.Duration {
 }
 
 // fetchSSHKeys fetches and appends ssh keys to the config.
-func (p *provider) fetchSSHKeys(cfg *config.Config) error {
+func (p *provider) fetchSSHKeys(cfg *types.Config) error {
 	keynames, err := p.getAttributes("/public-keys")
 	if err != nil {
 		return fmt.Errorf("error reading keys: %v", err)
@@ -114,7 +115,7 @@ func (p *provider) fetchSSHKeys(cfg *config.Config) error {
 		}
 	}
 
-	cfg.Passwd.Users = append(cfg.Passwd.Users, config.User{
+	cfg.Passwd.Users = append(cfg.Passwd.Users, types.User{
 		Name:              "core",
 		SSHAuthorizedKeys: keys,
 	})

--- a/src/providers/noop/noop.go
+++ b/src/providers/noop/noop.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/log"
 	"github.com/coreos/ignition/src/providers"
 )
@@ -36,9 +37,9 @@ type provider struct {
 	logger *log.Logger
 }
 
-func (p provider) FetchConfig() (config.Config, error) {
+func (p provider) FetchConfig() (types.Config, error) {
 	p.logger.Debug("noop provider fetching empty config")
-	return config.Config{}, config.ErrEmpty
+	return types.Config{}, config.ErrEmpty
 }
 
 func (p *provider) IsOnline() bool {

--- a/src/providers/providers.go
+++ b/src/providers/providers.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/log"
 )
 
@@ -32,7 +32,7 @@ var (
 // or not the source is online, if the caller should try again when the source
 // is offline, and how long the caller should wait before retries.
 type Provider interface {
-	FetchConfig() (config.Config, error)
+	FetchConfig() (types.Config, error)
 	IsOnline() bool
 	ShouldRetry() bool
 	BackoffDuration() time.Duration

--- a/src/providers/util/wait_test.go
+++ b/src/providers/util/wait_test.go
@@ -18,22 +18,22 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/providers"
 )
 
 type mockProvider struct {
-	config  config.Config
+	config  types.Config
 	err     error
 	online  bool
 	retry   bool
 	backoff time.Duration
 }
 
-func (p mockProvider) FetchConfig() (config.Config, error) { return p.config, p.err }
-func (p mockProvider) IsOnline() bool                      { return p.online }
-func (p mockProvider) ShouldRetry() bool                   { return p.retry }
-func (p mockProvider) BackoffDuration() time.Duration      { return p.backoff }
+func (p mockProvider) FetchConfig() (types.Config, error) { return p.config, p.err }
+func (p mockProvider) IsOnline() bool                     { return p.online }
+func (p mockProvider) ShouldRetry() bool                  { return p.retry }
+func (p mockProvider) BackoffDuration() time.Duration     { return p.backoff }
 
 func TestWaitUntilOnline(t *testing.T) {
 	type in struct {

--- a/src/providers/vmware/vmware_amd64.go
+++ b/src/providers/vmware/vmware_amd64.go
@@ -19,16 +19,17 @@ package vmware
 
 import (
 	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
 
 	"github.com/coreos/ignition/third_party/github.com/sigma/vmw-guestinfo/rpcvmx"
 	"github.com/coreos/ignition/third_party/github.com/sigma/vmw-guestinfo/vmcheck"
 )
 
-func (p provider) FetchConfig() (config.Config, error) {
+func (p provider) FetchConfig() (types.Config, error) {
 	data, err := rpcvmx.NewConfig().String("coreos.config.data", "")
 	if err != nil {
 		p.logger.Debug("failed to fetch config: %v", err)
-		return config.Config{}, err
+		return types.Config{}, err
 	}
 
 	p.logger.Debug("config successfully fetched")


### PR DESCRIPTION
This splits up code and definitions nicely.