### PR TITLE
providers/vmware: add support for config encoding

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -6,7 +6,7 @@ Ignition is currently only supported for the following platforms:
 * [PXE] - Use the `coreos.config.url` and `coreos.first_boot=1` (**in case of the very first PXE boot only**) kernel parameters to provide a URL to the configuration. The URL can use the `http://` scheme to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
 * [Amazon EC2] - Ignition will read its configuration from the userdata and append the SSH keys listed in the instance metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
-* [VMware] - Use the VMware Guestinfo Variable `coreos.config.data` to provide the config to the virtual machine.
+* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64".
 
 Ignition is under active development so expect this list to expand in the coming months.
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -16,11 +16,9 @@ package config
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/coreos/ignition/config/types"
 
@@ -41,9 +39,9 @@ func Parse(rawConfig []byte) (config types.Config, err error) {
 		}
 	} else if isEmpty(rawConfig) {
 		err = ErrEmpty
-	} else if isCloudConfig(decompressIfGzipped(rawConfig)) {
+	} else if isCloudConfig(rawConfig) {
 		err = ErrCloudConfig
-	} else if isScript(decompressIfGzipped(rawConfig)) {
+	} else if isScript(rawConfig) {
 		err = ErrScript
 	}
 	if serr, ok := err.(*json.SyntaxError); ok {
@@ -56,18 +54,4 @@ func Parse(rawConfig []byte) (config types.Config, err error) {
 
 func isEmpty(userdata []byte) bool {
 	return len(userdata) == 0
-}
-
-func decompressIfGzipped(data []byte) []byte {
-	if reader, err := gzip.NewReader(bytes.NewReader(data)); err == nil {
-		uncompressedData, err := ioutil.ReadAll(reader)
-		reader.Close()
-		if err == nil {
-			return uncompressedData
-		} else {
-			return data
-		}
-	} else {
-		return data
-	}
 }

--- a/src/providers/vmware/vmware.go
+++ b/src/providers/vmware/vmware.go
@@ -18,6 +18,11 @@
 package vmware
 
 import (
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"strings"
 	"time"
 
 	"github.com/coreos/ignition/src/log"
@@ -42,4 +47,47 @@ func (p provider) ShouldRetry() bool {
 
 func (p *provider) BackoffDuration() time.Duration {
 	return 0
+}
+
+func decodeData(data string, encoding string) ([]byte, error) {
+	switch encoding {
+	case "":
+		return []byte(data), nil
+
+	case "b64", "base64":
+		return decodeBase64Data(data)
+
+	case "gz", "gzip":
+		return decodeGzipData(data)
+
+	case "gz+base64", "gzip+base64", "gz+b64", "gzip+b64":
+		gz, err := decodeBase64Data(data)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return decodeGzipData(string(gz))
+	}
+
+	return nil, fmt.Errorf("Unsupported encoding %q", encoding)
+}
+
+func decodeBase64Data(data string) ([]byte, error) {
+	decodedData, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to decode base64: %q", err)
+	}
+
+	return decodedData, nil
+}
+
+func decodeGzipData(data string) ([]byte, error) {
+	reader, err := gzip.NewReader(strings.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	return ioutil.ReadAll(reader)
 }

--- a/src/providers/vmware/vmware_amd64.go
+++ b/src/providers/vmware/vmware_amd64.go
@@ -26,14 +26,27 @@ import (
 )
 
 func (p provider) FetchConfig() (types.Config, error) {
-	data, err := rpcvmx.NewConfig().String("coreos.config.data", "")
+	info := rpcvmx.NewConfig()
+	data, err := info.String("coreos.config.data", "")
 	if err != nil {
 		p.logger.Debug("failed to fetch config: %v", err)
 		return types.Config{}, err
 	}
 
+	encoding, err := info.String("coreos.config.data.encoding", "")
+	if err != nil {
+		p.logger.Debug("failed to fetch config encoding: %v", err)
+		return types.Config{}, err
+	}
+
+	decodedData, err := decodeData(data, encoding)
+	if err != nil {
+		p.logger.Debug("failed to decode config: %v", err)
+		return types.Config{}, err
+	}
+
 	p.logger.Debug("config successfully fetched")
-	return config.Parse([]byte(data))
+	return config.Parse(decodedData)
 }
 
 func (p *provider) IsOnline() bool {


### PR DESCRIPTION
This is needed to properly decode cloud-configs, which this needs to recognize
and ignore. While we are at it, we might as well add encoding support for
Ignition configs as well.

Fixes https://github.com/coreos/bugs/issues/1170