### PR TITLE
RFC: rework filesystems and files

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -28,12 +28,14 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
     * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
     * **_spares_** (integer): the number of spares (if applicable) in the array.
-  * **_filesystems_** (list of objects): the list of filesystems to be configured. Typically, one filesystem is configured per partition.
-    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
-    * **format** (string): the filesystem format (ext4, btrfs, or xfs).
-    * **_create_** (object): contains the set of options to be used when creating the filesystem. A non-null entry indicates that the filesystem shall be created.
-      * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
-      * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured and/or used in the "files" section. Either "mount" or "path" needs to be specified.
+    * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.
+      * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+      * **format** (string): the filesystem format (ext4, btrfs, or xfs).
+      * **_create_** (object): contains the set of options to be used when creating the filesystem. A non-null entry indicates that the filesystem shall be created.
+        * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
+        * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_path_** (string): the mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for "/sysroot".
     * **_files_** (list of objects): the list of files, rooted in this particular filesystem, to be written.
       * **path** (string): the absolute path to the file.
       * **_contents_** (string): the contents of the file.

--- a/src/config/types/filesystem_test.go
+++ b/src/config/types/filesystem_test.go
@@ -202,12 +202,12 @@ func TestFilesystemUnmarshalJSON(t *testing.T) {
 		out out
 	}{
 		{
-			in:  in{data: `{"device": "/foo", "format": "ext4"}`},
-			out: out{filesystem: Filesystem{Device: "/foo", Format: "ext4"}},
+			in:  in{data: `{"mount": {"device": "/foo", "format": "ext4"}}`},
+			out: out{filesystem: Filesystem{Mount: &FilesystemMount{Device: "/foo", Format: "ext4"}}},
 		},
 		{
-			in:  in{data: `{"format": "ext4"}`},
-			out: out{filesystem: Filesystem{Format: "ext4"}, err: ErrPathRelative},
+			in:  in{data: `{"mount": {"format": "ext4"}}`},
+			out: out{err: ErrPathRelative},
 		},
 	}
 
@@ -237,12 +237,12 @@ func TestFilesystemUnmarshalYAML(t *testing.T) {
 		out out
 	}{
 		{
-			in:  in{data: "device: /foo\nformat: ext4"},
-			out: out{filesystem: Filesystem{Device: "/foo", Format: "ext4"}},
+			in:  in{data: "mount:\n  device: /foo\n  format: ext4"},
+			out: out{filesystem: Filesystem{Mount: &FilesystemMount{Device: "/foo", Format: "ext4"}}},
 		},
 		{
-			in:  in{data: "format: ext4"},
-			out: out{filesystem: Filesystem{Format: "ext4"}, err: ErrPathRelative},
+			in:  in{data: "mount:\n  format: ext4"},
+			out: out{err: ErrPathRelative},
 		},
 	}
 
@@ -271,20 +271,32 @@ func TestFilesystemAssertValid(t *testing.T) {
 		out out
 	}{
 		{
-			in:  in{filesystem: Filesystem{Device: "/foo", Format: "ext4"}},
+			in:  in{filesystem: Filesystem{Mount: &FilesystemMount{Device: "/foo", Format: "ext4"}}},
 			out: out{},
 		},
 		{
-			in:  in{filesystem: Filesystem{Device: "/foo"}},
+			in:  in{filesystem: Filesystem{Mount: &FilesystemMount{Device: "/foo"}}},
 			out: out{err: ErrFilesystemInvalidFormat},
 		},
 		{
-			in:  in{filesystem: Filesystem{Format: "ext4"}},
+			in:  in{filesystem: Filesystem{Mount: &FilesystemMount{Format: "ext4"}}},
 			out: out{err: ErrPathRelative},
 		},
 		{
-			in:  in{filesystem: Filesystem{}},
+			in:  in{filesystem: Filesystem{Path: Path("/mount")}},
+			out: out{},
+		},
+		{
+			in:  in{filesystem: Filesystem{Path: Path("mount")}},
 			out: out{err: ErrPathRelative},
+		},
+		{
+			in:  in{filesystem: Filesystem{Path: Path("/mount"), Mount: &FilesystemMount{Device: "/foo", Format: "ext4"}}},
+			out: out{err: ErrFilesystemMountAndPath},
+		},
+		{
+			in:  in{filesystem: Filesystem{}},
+			out: out{err: ErrFilesystemNoMountPath},
 		},
 	}
 

--- a/src/config/types/ignition.go
+++ b/src/config/types/ignition.go
@@ -53,6 +53,10 @@ func (v *IgnitionVersion) UnmarshalJSON(data []byte) error {
 	})
 }
 
+func (v IgnitionVersion) MarshalJSON() ([]byte, error) {
+	return semver.Version(v).MarshalJSON()
+}
+
 func (v *IgnitionVersion) unmarshal(unmarshal func(interface{}) error) error {
 	tv := semver.Version(*v)
 	if err := unmarshal(&tv); err != nil {

--- a/src/exec/stages/disks/disks.go
+++ b/src/exec/stages/disks/disks.go
@@ -20,10 +20,7 @@ package storage
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
-	"syscall"
 
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/src/exec/stages"
@@ -75,11 +72,6 @@ func (s stage) Run(config types.Config) bool {
 
 	if err := s.createFilesystems(config); err != nil {
 		s.Logger.Crit("failed to create filesystems: %v", err)
-		return false
-	}
-
-	if err := s.createFilesystemsFiles(config); err != nil {
-		s.Logger.Crit("failed to create files: %v", err)
 		return false
 	}
 
@@ -197,14 +189,21 @@ func (s stage) createRaids(config types.Config) error {
 
 // createFilesystems creates the filesystems described in config.Storage.Filesystems.
 func (s stage) createFilesystems(config types.Config) error {
-	if len(config.Storage.Filesystems) == 0 {
+	fss := make([]types.FilesystemMount, 0, len(config.Storage.Filesystems))
+	for _, fs := range config.Storage.Filesystems {
+		if len(fs.Path) == 0 {
+			fss = append(fss, *fs.Mount)
+		}
+	}
+
+	if len(fss) == 0 {
 		return nil
 	}
 	s.Logger.PushPrefix("createFilesystems")
 	defer s.Logger.PopPrefix()
 
 	devs := []string{}
-	for _, fs := range config.Storage.Filesystems {
+	for _, fs := range fss {
 		devs = append(devs, string(fs.Device))
 	}
 
@@ -212,7 +211,7 @@ func (s stage) createFilesystems(config types.Config) error {
 		return err
 	}
 
-	for _, fs := range config.Storage.Filesystems {
+	for _, fs := range fss {
 		if err := s.createFilesystem(fs); err != nil {
 			return err
 		}
@@ -221,7 +220,7 @@ func (s stage) createFilesystems(config types.Config) error {
 	return nil
 }
 
-func (s stage) createFilesystem(fs types.Filesystem) error {
+func (s stage) createFilesystem(fs types.FilesystemMount) error {
 	if fs.Create == nil {
 		return nil
 	}
@@ -255,67 +254,6 @@ func (s stage) createFilesystem(fs types.Filesystem) error {
 		fs.Format, string(fs.Device),
 	); err != nil {
 		return fmt.Errorf("failed to run %q: %v %v", mkfs, err, args)
-	}
-
-	return nil
-}
-
-// createFilesystemsFiles creates the files described in config.Storage.Filesystems.
-func (s stage) createFilesystemsFiles(config types.Config) error {
-	if len(config.Storage.Filesystems) == 0 {
-		return nil
-	}
-	s.Logger.PushPrefix("createFilesystemsFiles")
-	defer s.Logger.PopPrefix()
-
-	for _, fs := range config.Storage.Filesystems {
-		if err := s.createFiles(fs); err != nil {
-			return fmt.Errorf("failed to create files %q: %v", fs.Device, err)
-		}
-	}
-
-	return nil
-}
-
-// createFiles creates any files listed for the filesystem in fs.Files.
-func (s stage) createFiles(fs types.Filesystem) error {
-	if len(fs.Files) == 0 {
-		return nil
-	}
-	s.Logger.PushPrefix("createFiles")
-	defer s.Logger.PopPrefix()
-
-	mnt, err := ioutil.TempDir("", "ignition-files")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %v", err)
-	}
-	defer os.Remove(mnt)
-
-	dev := string(fs.Device)
-	format := string(fs.Format)
-
-	if err := s.Logger.LogOp(
-		func() error { return syscall.Mount(dev, mnt, format, 0, "") },
-		"mounting %q at %q", dev, mnt,
-	); err != nil {
-		return fmt.Errorf("failed to mount device %q at %q: %v", dev, mnt, err)
-	}
-	defer s.Logger.LogOp(
-		func() error { return syscall.Unmount(mnt, 0) },
-		"unmounting %q at %q", dev, mnt,
-	)
-
-	u := util.Util{
-		Logger:  s.Logger,
-		DestDir: mnt,
-	}
-	for _, f := range fs.Files {
-		if err := s.Logger.LogOp(
-			func() error { return u.WriteFile(&f) },
-			"writing file %q", string(f.Path),
-		); err != nil {
-			return fmt.Errorf("failed to create file %q: %v", f.Path, err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
This will end up looking like:

```json
{
        "ignition": { "version": "2.0.0-dev" },
        "storage": {
                "filesystems": [ {
                        "name": "root",
                        "mount": {
                                "device": "/dev/disk/by-label/ROOT",
                                "format": "btrfs",
                                "create": {
                                        "force": true,
                                        "allowExisting": true
                                }
                        }
                } ],
                "files": [ {
                        "filesystem": "root",
                        "path": "/file",
                        "contents": "This is a file!"
                } ]
        }
}
```

But it will also allow us to do neat things like:

The internal OEM config:
```json
{
        "ignition": { "version": "2.0.0-dev" },
        "storage": {
                "filesystems": [ {
                        "name": "root",
                        "path": "/sysroot"
                } ]
        }
}
```

...which is append by the user config:
```json
{
        "ignition": { "version": "2.0.0-dev" },
        "storage": {
                "files": [ {
                        "filesystem": "root",
                        "path": "/file",
                        "contents": "This works on disk and diskless installations. Neat!"
                } ]
        }
}
```