### PR TITLE
{docs,exec}: add a base configuration

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -8,7 +8,18 @@ Ignition uses a JSON configuration file to represent the set of changes to be ma
 
 Ignition will choose where to look for configuration based on the underlying platform. A list of [supported platforms][platforms] and metadata sources is provided for reference.
 
-The configuration must be passed to Ignition through the designated data source. Please refer to Ignition [config examples][examples] to learn about writing config files.
+The configuration must be passed to Ignition through the designated data source. Please refer to Ignition [config examples][examples] to learn about writing config files. The provided configuration will be appended to the universal base configuration:
+
+```json
+{
+  "storage": {
+    "filesystems": [{
+      "name": "root",
+      "path": "/sysroot"
+    }]
+  }
+}
+```
 
 ## Troubleshooting
 

--- a/src/exec/engine.go
+++ b/src/exec/engine.go
@@ -39,6 +39,18 @@ var (
 	ErrNetworkFailure    = errors.New("network failure")
 )
 
+var (
+	baseConfig = types.Config{
+		Ignition: types.Ignition{Version: types.IgnitionVersion(types.MaxVersion)},
+		Storage: types.Storage{
+			Filesystems: []types.Filesystem{{
+				Name: "root",
+				Path: "/sysroot",
+			}},
+		},
+	}
+)
+
 // Engine represents the entity that fetches and executes a configuration.
 type Engine struct {
 	ConfigCache   string
@@ -56,7 +68,7 @@ func (e Engine) Run(stageName string) bool {
 	case nil:
 		e.Logger.PushPrefix(stageName)
 		defer e.Logger.PopPrefix()
-		return stages.Get(stageName).Create(e.Logger, e.Root).Run(cfg)
+		return stages.Get(stageName).Create(e.Logger, e.Root).Run(config.Append(baseConfig, cfg))
 	case config.ErrCloudConfig, config.ErrScript, config.ErrEmpty:
 		e.Logger.Info("%v: ignoring and exiting...", err)
 		return true


### PR DESCRIPTION
This will be appended by all configs and provides a definition for the "root"
filesystem mounted at "/sysroot". This way, users don't need to worry about the
implementation details of the initramfs and Ignition.