### PR TITLE
config: properly handle non-ignition configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,15 +74,14 @@ func ParseFromV1(rawConfig []byte) (types.Config, error) {
 	return TranslateFromV1(config)
 }
 
-type config struct {
-	Version  *int `json:"ignitionVersion" yaml:"ignition_version"`
-	Ignition struct {
-		Version *types.IgnitionVersion `json:"version,omitempty" yaml:"version" merge:"old"`
-	} `json:"ignition" yaml:"ignition"`
-}
-
 func majorVersion(rawConfig []byte) int64 {
-	var composite config
+	var composite struct {
+		Version  *int `json:"ignitionVersion"`
+		Ignition struct {
+			Version *types.IgnitionVersion `json:"version"`
+		} `json:"ignition"`
+	}
+
 	if json.Unmarshal(rawConfig, &composite) != nil {
 		return 0
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -34,12 +34,7 @@ var (
 )
 
 func Parse(rawConfig []byte) (types.Config, error) {
-	major, err := majorVersion(rawConfig)
-	if err != nil {
-		return types.Config{}, err
-	}
-
-	switch major {
+	switch majorVersion(rawConfig) {
 	case 1:
 		config, err := ParseFromV1(rawConfig)
 		if err != nil {
@@ -86,14 +81,10 @@ type config struct {
 	} `json:"ignition" yaml:"ignition"`
 }
 
-func majorVersion(rawConfig []byte) (int64, error) {
+func majorVersion(rawConfig []byte) int64 {
 	var composite config
-	if err := json.Unmarshal(rawConfig, &composite); err != nil {
-		if serr, ok := err.(*json.SyntaxError); ok {
-			line, col, highlight := errorutil.HighlightBytePosition(bytes.NewReader(rawConfig), serr.Offset)
-			err = fmt.Errorf("error at line %d, column %d\n%s%v", line, col, highlight, err)
-		}
-		return 0, err
+	if json.Unmarshal(rawConfig, &composite) != nil {
+		return 0
 	}
 
 	var major int64
@@ -103,7 +94,7 @@ func majorVersion(rawConfig []byte) (int64, error) {
 		major = int64(*composite.Version)
 	}
 
-	return major, nil
+	return major
 }
 
 func isEmpty(userdata []byte) bool {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 
 	"github.com/coreos/ignition/config/types"
+	v1 "github.com/coreos/ignition/config/v1"
 )
 
-func TestParseFromLatest(t *testing.T) {
+func TestParse(t *testing.T) {
 	type in struct {
 		config []byte
 	}
@@ -36,11 +37,11 @@ func TestParseFromLatest(t *testing.T) {
 	}{
 		{
 			in:  in{config: []byte(`{"ignitionVersion": 1}`)},
-			out: out{err: types.ErrOldVersion},
+			out: out{err: ErrDeprecated},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "1.0.0"}}`)},
-			out: out{err: types.ErrOldVersion},
+			out: out{err: v1.ErrVersion},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.0.0"}}`)},
@@ -90,7 +91,7 @@ func TestParseFromLatest(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		config, err := ParseFromLatest(test.in.config)
+		config, err := Parse(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
 		}


### PR DESCRIPTION
The check for major version was causing Parse() to bail too early. The test was
also mistakenly updated to only test ParseFromLatest() instead of Parse(), so it
didn't pick up on this regression.