### PR TITLE
providers/ec2: strip support for SSH keys

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -58,6 +58,7 @@ type Engine struct {
 	Logger        *log.Logger
 	Root          string
 	Provider      providers.Provider
+	OemConfig     types.Config
 }
 
 // Run executes the stage of the given name. It returns true if the stage
@@ -68,7 +69,7 @@ func (e Engine) Run(stageName string) bool {
 	case nil:
 		e.Logger.PushPrefix(stageName)
 		defer e.Logger.PopPrefix()
-		return stages.Get(stageName).Create(e.Logger, e.Root).Run(config.Append(baseConfig, cfg))
+		return stages.Get(stageName).Create(e.Logger, e.Root).Run(config.Append(config.Append(baseConfig, e.OemConfig), cfg))
 	case config.ErrCloudConfig, config.ErrScript, config.ErrEmpty:
 		e.Logger.Info("%v: ignoring and exiting...", err)
 		return true

--- a/internal/main.go
+++ b/internal/main.go
@@ -82,12 +82,14 @@ func main() {
 		}
 	}
 
+	oemConfig := oem.MustGet(flags.oem.String())
 	engine := exec.Engine{
 		Root:          flags.root,
 		OnlineTimeout: flags.onlineTimeout,
 		Logger:        &logger,
 		ConfigCache:   flags.configCache,
-		Provider:      oem.MustGet(flags.oem.String()).Provider().Create(&logger),
+		Provider:      oemConfig.Provider().Create(&logger),
+		OemConfig:     oemConfig.Config(),
 	}
 
 	if !engine.Run(flags.stage.String()) {

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -85,6 +85,14 @@ func init() {
 		flags: map[string]string{
 			"online-timeout": "0",
 		},
+		config: types.Config{
+			Systemd: types.Systemd{
+				Units: []types.SystemdUnit{{
+					Name:   "coreos-metadata-sshkeys@.service",
+					Enable: true,
+				}},
+			},
+		},
 	})
 	configs.Register(Config{
 		name:     "exoscale",

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -17,6 +17,7 @@ package oem
 import (
 	"fmt"
 
+	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/azure"
 	"github.com/coreos/ignition/internal/providers/cmdline"
@@ -32,6 +33,7 @@ type Config struct {
 	name     string
 	flags    map[string]string
 	provider providers.ProviderCreator
+	config   types.Config
 }
 
 func (c Config) Name() string {
@@ -44,6 +46,10 @@ func (c Config) Flags() map[string]string {
 
 func (c Config) Provider() providers.ProviderCreator {
 	return c.provider
+}
+
+func (c Config) Config() types.Config {
+	return c.config
 }
 
 var configs = registry.Create("oem configs")

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -18,11 +18,7 @@
 package ec2
 
 import (
-	"bufio"
-	"bytes"
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/coreos/ignition/config"
@@ -36,9 +32,7 @@ import (
 const (
 	initialBackoff = 100 * time.Millisecond
 	maxBackoff     = 30 * time.Second
-	baseUrl        = "http://169.254.169.254/2009-04-04/"
-	userdataUrl    = baseUrl + "user-data"
-	metadataUrl    = baseUrl + "meta-data"
+	userdataUrl    = "http://169.254.169.254/2009-04-04/user-data"
 )
 
 type Creator struct{}
@@ -59,12 +53,7 @@ type provider struct {
 }
 
 func (p provider) FetchConfig() (types.Config, error) {
-	cfg, err := config.Parse(p.rawConfig)
-	if err == nil || err == config.ErrEmpty || err == config.ErrDeprecated {
-		err = p.fetchSSHKeys(&cfg)
-	}
-
-	return cfg, err
+	return config.Parse(p.rawConfig)
 }
 
 func (p *provider) IsOnline() bool {
@@ -78,79 +67,4 @@ func (p provider) ShouldRetry() bool {
 
 func (p *provider) BackoffDuration() time.Duration {
 	return putil.ExpBackoff(&p.backoff, maxBackoff)
-}
-
-// fetchSSHKeys fetches and appends ssh keys to the config.
-func (p *provider) fetchSSHKeys(cfg *types.Config) error {
-	keynames, err := p.getAttributes("/public-keys")
-	if err != nil {
-		return fmt.Errorf("error reading keys: %v", err)
-	}
-
-	keyIDs := make(map[string]string)
-	for _, keyname := range keynames {
-		tokens := strings.SplitN(keyname, "=", 2)
-		if len(tokens) != 2 {
-			return fmt.Errorf("malformed public key: %q", keyname)
-		}
-		keyIDs[tokens[1]] = tokens[0]
-	}
-
-	keys := []string{}
-	for _, id := range keyIDs {
-		sshkey, err := p.getAttribute("/public-keys/%s/openssh-key", id)
-		if err != nil {
-			return err
-		}
-		keys = append(keys, sshkey)
-		p.logger.Info("found SSH public key for %q", id)
-	}
-
-	for i, user := range cfg.Passwd.Users {
-		if user.Name == "core" {
-			cfg.Passwd.Users[i].SSHAuthorizedKeys =
-				append(cfg.Passwd.Users[i].SSHAuthorizedKeys,
-					keys...)
-			return nil
-		}
-	}
-
-	cfg.Passwd.Users = append(cfg.Passwd.Users, types.User{
-		Name:              "core",
-		SSHAuthorizedKeys: keys,
-	})
-
-	return nil
-}
-
-// getAttributes gets a list of metadata attributes from the format string.
-func (p *provider) getAttributes(format string, a ...interface{}) ([]string, error) {
-	path := fmt.Sprintf(format, a...)
-	data, status, err := p.client.Get(metadataUrl + path)
-	if err != nil {
-		return nil, err
-	}
-
-	switch status {
-	case http.StatusOK:
-		scanner := bufio.NewScanner(bytes.NewBuffer(data))
-		data := []string{}
-		for scanner.Scan() {
-			data = append(data, scanner.Text())
-		}
-		return data, scanner.Err()
-	case http.StatusNotFound:
-		return []string{}, nil
-	default:
-		return nil, fmt.Errorf("bad response: HTTP status code: %d", status)
-	}
-}
-
-// getAttribute gets a singleton metadata attribute from the format string.
-func (p *provider) getAttribute(format string, a ...interface{}) (string, error) {
-	if data, err := p.getAttributes(format, a...); err == nil && len(data) > 0 {
-		return data[0], nil
-	} else {
-		return "", err
-	}
 }


### PR DESCRIPTION
Key injection is going to be handled by a different utility. Keys added via the
Ignition config will still work.