### PR TITLE
exec/stages: write files after users are created

### DIFF
--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -61,11 +61,6 @@ func (stage) Name() string {
 }
 
 func (s stage) Run(config types.Config) bool {
-	if err := s.createFilesystemsFiles(config); err != nil {
-		s.Logger.Crit("failed to create files: %v", err)
-		return false
-	}
-
 	if err := s.createPasswd(config); err != nil {
 		s.Logger.Crit("failed to create users/groups: %v", err)
 		return false
@@ -75,6 +70,12 @@ func (s stage) Run(config types.Config) bool {
 		s.Logger.Crit("failed to create units: %v", err)
 		return false
 	}
+
+	if err := s.createFilesystemsFiles(config); err != nil {
+		s.Logger.Crit("failed to create files: %v", err)
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
If the files are created before the user, the home directory might not
have the correct permissions. When we try to add SSH keys, it fails due
to insufficient permissions.

Fixes https://github.com/coreos/bugs/issues/1241.