### PR TITLE
exec: execute empty user configs

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -66,11 +66,11 @@ type Engine struct {
 func (e Engine) Run(stageName string) bool {
 	cfg, err := e.acquireConfig()
 	switch err {
-	case nil:
+	case config.ErrEmpty, nil:
 		e.Logger.PushPrefix(stageName)
 		defer e.Logger.PopPrefix()
 		return stages.Get(stageName).Create(e.Logger, e.Root).Run(config.Append(config.Append(baseConfig, e.OemConfig), cfg))
-	case config.ErrCloudConfig, config.ErrScript, config.ErrEmpty:
+	case config.ErrCloudConfig, config.ErrScript:
 		e.Logger.Info("%v: ignoring and exiting...", err)
 		return true
 	default:

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -191,7 +191,7 @@ func (s stage) createRaids(config types.Config) error {
 func (s stage) createFilesystems(config types.Config) error {
 	fss := make([]types.FilesystemMount, 0, len(config.Storage.Filesystems))
 	for _, fs := range config.Storage.Filesystems {
-		if len(fs.Path) == 0 {
+		if fs.Mount != nil {
 			fss = append(fss, *fs.Mount)
 		}
 	}


### PR DESCRIPTION
Executing even if the user config is empty allows us to always execute
the OEM config. If both the user config and the OEM config are empty,
this is a no-op.