### PR TITLE
stages/disks: adds -p flag to mkfs.ext4

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -235,6 +235,7 @@ func (s stage) createFilesystem(fs types.FilesystemMount) error {
 		}
 	case "ext4":
 		mkfs = "/sbin/mkfs.ext4"
+		args = append(args, "-p")
 		if fs.Create.Force {
 			args = append(args, "-F")
 		}


### PR DESCRIPTION
Fixes problem where ignition overwrites other partitions reguardless of what
filesystems.mount.create.force is set to