### PR TITLE
Add support writing large files/empty files

### DIFF
--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -193,15 +193,15 @@ func (u Util) WriteFile(f *File) error {
 	// by using syscall.Fchown() and syscall.Fchmod()
 
 	// Ensure the ownership and mode are as requested (since WriteFile can be affected by sticky bit)
-	if err := os.Chown(tmp.Name(), f.Uid, f.Gid); err != nil {
+	if err = os.Chown(tmp.Name(), f.Uid, f.Gid); err != nil {
 		return err
 	}
 
-	if err := os.Chmod(tmp.Name(), f.Mode); err != nil {
+	if err = os.Chmod(tmp.Name(), f.Mode); err != nil {
 		return err
 	}
 
-	if err := os.Rename(tmp.Name(), path); err != nil {
+	if err = os.Rename(tmp.Name(), path); err != nil {
 		return err
 	}
 

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -15,8 +15,11 @@
 package util
 
 import (
-	"bytes"
+	"bufio"
 	"compress/gzip"
+	"encoding/hex"
+	"hash"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -33,69 +36,127 @@ const (
 )
 
 type File struct {
-	Path     types.Path
-	Contents []byte
-	Mode     os.FileMode
-	Uid      int
-	Gid      int
+	io.ReadCloser
+	hash.Hash
+	Path        types.Path
+	Mode        os.FileMode
+	Uid         int
+	Gid         int
+	expectedSum string
 }
 
+func (f File) Verify() error {
+	if f.Hash == nil {
+		return nil
+	}
+	sum := f.Sum(nil)
+	encodedSum := make([]byte, hex.EncodedLen(len(sum)))
+	hex.Encode(encodedSum, sum)
+
+	if string(encodedSum) != f.expectedSum {
+		return util.ErrHashMismatch{
+			Calculated: string(encodedSum),
+			Expected:   f.expectedSum,
+		}
+	}
+	return nil
+}
+
+// newHashedReader returns a new ReadCloser that also writes to the provided hash.
+func newHashedReader(reader io.ReadCloser, hasher hash.Hash) io.ReadCloser {
+	return struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.TeeReader(reader, hasher),
+		Closer: reader,
+	}
+}
+
+// RenderFile returns a *File with a Reader that downloads, hashes, and decompresses the incoming data.
+// It returns nil if f had invalid options. Errors reading/verifying/decompressing the file will
+// present themselves when the Reader is actually read from.
 func RenderFile(l *log.Logger, f types.File) *File {
-	var contents []byte
+	var reader io.ReadCloser
 	var err error
+	var expectedSum string
 
-	fetch := func() error {
-		contents, err = util.FetchResource(l, url.URL(f.Contents.Source))
-		return err
-	}
-
-	validate := func() error {
-		return util.AssertValid(f.Contents.Verification, contents)
-	}
-
-	decompress := func() error {
-		contents, err = decompressFile(l, f, contents)
-		return err
-	}
-
-	if l.LogOp(fetch, "fetching file %q", f.Path) != nil {
+	reader, err = util.FetchResourceAsReader(l, url.URL(f.Contents.Source))
+	if err != nil {
+		l.Crit("Error fetching file %q: %v", f.Path, err)
 		return nil
 	}
-	if l.LogOp(validate, "validating file contents") != nil {
+
+	fileHash, err := util.GetHasher(f.Contents.Verification)
+	if err != nil {
+		l.Crit("Error verifying file %q: %v", f.Path, err)
 		return nil
 	}
-	if l.LogOp(decompress, "decompressing file contents") != nil {
+
+	if fileHash != nil {
+		reader = newHashedReader(reader, fileHash)
+		expectedSum = f.Contents.Verification.Hash.Sum
+	}
+
+	reader, err = decompressFileStream(l, f, reader)
+	if err != nil {
+		l.Crit("Error decompressing file %q: %v", f.Path, err)
 		return nil
 	}
 
 	return &File{
-		Path:     f.Path,
-		Contents: []byte(contents),
-		Mode:     os.FileMode(f.Mode),
-		Uid:      f.User.Id,
-		Gid:      f.Group.Id,
+		Path:        f.Path,
+		ReadCloser:  reader,
+		Hash:        fileHash,
+		Mode:        os.FileMode(f.Mode),
+		Uid:         f.User.Id,
+		Gid:         f.Group.Id,
+		expectedSum: expectedSum,
 	}
 }
 
-func decompressFile(l *log.Logger, f types.File, contents []byte) ([]byte, error) {
+// gzipReader is a wrapper for gzip's reader that closes the stream it wraps as well
+// as itself when Close() is called.
+type gzipReader struct {
+	*gzip.Reader //actually a ReadCloser
+	source       io.Closer
+}
+
+func newGzipReader(reader io.ReadCloser) (io.ReadCloser, error) {
+	gzReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return gzipReader{
+		Reader: gzReader,
+		source: reader,
+	}, nil
+}
+
+func (gz gzipReader) Close() error {
+	if err := gz.Reader.Close(); err != nil {
+		return err
+	}
+	if err := gz.source.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func decompressFileStream(l *log.Logger, f types.File, contents io.ReadCloser) (io.ReadCloser, error) {
 	switch f.Contents.Compression {
 	case "":
 		return contents, nil
 	case "gzip":
-		reader, err := gzip.NewReader(bytes.NewReader(contents))
-		if err != nil {
-			return nil, err
-		}
-		defer reader.Close()
-
-		return ioutil.ReadAll(reader)
+		return newGzipReader(contents)
 	default:
 		return nil, types.ErrCompressionInvalid
 	}
 }
 
-// WriteFile creates and writes the file described by f using the provided context
+// WriteFile creates and writes the file described by f using the provided context.
 func (u Util) WriteFile(f *File) error {
+	defer f.Close()
 	var err error
 
 	path := u.JoinPath(string(f.Path))
@@ -109,14 +170,22 @@ func (u Util) WriteFile(f *File) error {
 	if tmp, err = ioutil.TempFile(filepath.Dir(path), "tmp"); err != nil {
 		return err
 	}
-	tmp.Close()
+
 	defer func() {
+		tmp.Close()
 		if err != nil {
 			os.Remove(tmp.Name())
 		}
 	}()
 
-	if err := ioutil.WriteFile(tmp.Name(), f.Contents, f.Mode); err != nil {
+	fileWriter := bufio.NewWriter(tmp)
+
+	if _, err = io.Copy(fileWriter, f); err != nil {
+		return err
+	}
+	fileWriter.Flush()
+
+	if err = f.Verify(); err != nil {
 		return err
 	}
 
@@ -139,7 +208,7 @@ func (u Util) WriteFile(f *File) error {
 	return nil
 }
 
-// mkdirForFile helper creates the directory components of path
+// mkdirForFile helper creates the directory components of path.
 func mkdirForFile(path string) error {
 	return os.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions)
 }

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -15,7 +15,9 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,25 +31,25 @@ const (
 
 func FileFromSystemdUnit(unit types.SystemdUnit) *File {
 	return &File{
-		Path:     types.Path(filepath.Join(SystemdUnitsPath(), string(unit.Name))),
-		Contents: []byte(unit.Contents),
-		Mode:     DefaultFilePermissions,
+		Path:       types.Path(filepath.Join(SystemdUnitsPath(), string(unit.Name))),
+		ReadCloser: ioutil.NopCloser(bytes.NewReader([]byte(unit.Contents))),
+		Mode:       DefaultFilePermissions,
 	}
 }
 
 func FileFromNetworkdUnit(unit types.NetworkdUnit) *File {
 	return &File{
-		Path:     types.Path(filepath.Join(NetworkdUnitsPath(), string(unit.Name))),
-		Contents: []byte(unit.Contents),
-		Mode:     DefaultFilePermissions,
+		Path:       types.Path(filepath.Join(NetworkdUnitsPath(), string(unit.Name))),
+		ReadCloser: ioutil.NopCloser(bytes.NewReader([]byte(unit.Contents))),
+		Mode:       DefaultFilePermissions,
 	}
 }
 
 func FileFromUnitDropin(unit types.SystemdUnit, dropin types.SystemdUnitDropIn) *File {
 	return &File{
-		Path:     types.Path(filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name))),
-		Contents: []byte(dropin.Contents),
-		Mode:     DefaultFilePermissions,
+		Path:       types.Path(filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name))),
+		ReadCloser: ioutil.NopCloser(bytes.NewReader([]byte(dropin.Contents))),
+		Mode:       DefaultFilePermissions,
 	}
 }
 

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -47,7 +48,7 @@ func (c HttpClient) Get(url string) ([]byte, int, error) {
 	return c.GetWithHeader(url, http.Header{})
 }
 
-// Get performs an HTTP GET on the provided URL with the provided request header
+// GetWithHeader performs an HTTP GET on the provided URL with the provided request header
 // and returns the response body, HTTP status code, and error (if any). By
 // default, User-Agent and Accept are added to the header but these can be
 // overridden.
@@ -56,27 +57,55 @@ func (c HttpClient) GetWithHeader(url string, header http.Header) ([]byte, int, 
 	var status int
 
 	err := c.logger.LogOp(func() error {
-		req, err := http.NewRequest("GET", url, nil)
-		req.Header.Set("User-Agent", "Ignition/"+version.Raw)
-		req.Header.Set("Accept", "*")
-		for key, values := range header {
-			req.Header.Del(key)
-			for _, value := range values {
-				req.Header.Add(key, value)
-			}
-		}
-		resp, err := c.client.Do(req)
+		var bodyReader io.ReadCloser
+		var err error
+
+		bodyReader, status, err = c.GetReaderWithHeader(url, header)
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer bodyReader.Close()
 
-		status = resp.StatusCode
-		c.logger.Debug("GET result: %s", http.StatusText(status))
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = ioutil.ReadAll(bodyReader)
 
 		return err
 	}, "GET %q", url)
+
+	return body, status, err
+}
+
+// GetReader performs an HTTP GET on the provided URL and returns the response body Reader,
+// HTTP status code, and error (if any).
+func (c HttpClient) GetReader(url string) (io.ReadCloser, int, error) {
+	return c.GetReaderWithHeader(url, http.Header{})
+}
+
+// GetReaderWithHeader performs an HTTP GET on the provided URL with the provided request header
+// and returns the response body Reader, HTTP status code, and error (if any). By
+// default, User-Agent and Accept are added to the header but these can be
+// overridden.
+func (c HttpClient) GetReaderWithHeader(url string, header http.Header) (io.ReadCloser, int, error) {
+	var body io.ReadCloser
+	var status int
+
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Set("User-Agent", "Ignition/"+version.Raw)
+	req.Header.Set("Accept", "*")
+	for key, values := range header {
+		req.Header.Del(key)
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return body, status, err
+	}
+
+	status = resp.StatusCode
+	c.logger.Debug("GET result: %s", http.StatusText(status))
+	body = resp.Body
 
 	return body, status, err
 }

--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"time"
 
@@ -36,7 +37,14 @@ type HttpClient struct {
 func NewHttpClient(logger *log.Logger) HttpClient {
 	return HttpClient{
 		client: &http.Client{
-			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: 10 * time.Second,
+				Dial: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout: 10 * time.Second,
+			},
 		},
 		logger: logger,
 	}

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -141,6 +141,14 @@ func FetchResourceAsReader(l *log.Logger, u url.URL) (io.ReadCloser, error) {
 			ReadCloser: f,
 		}, nil
 
+	case "":
+		f, err := os.Open(os.DevNull)
+		if err != nil {
+			l.Err("Failed to open /dev/null for writing empty files")
+			return nil, ErrFailed
+		}
+		return f, nil
+
 	default:
 		return nil, ErrSchemeUnsupported
 	}

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -15,8 +15,10 @@
 package util
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -45,10 +47,40 @@ const (
 
 // FetchResource fetches a resource given a URL. The supported schemes are http, data, and oem.
 func FetchResource(l *log.Logger, u url.URL) ([]byte, error) {
+	var data []byte
+
+	dataReader, err := FetchResourceAsReader(l, u)
+	if err != nil {
+		return nil, err
+	}
+	defer dataReader.Close()
+
+	data, err = ioutil.ReadAll(dataReader)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// ReadUnmounter calls umountOEM() when closed, in addition to closing the ReadCloser it wraps.
+type ReadUnmounter struct {
+	io.ReadCloser
+	logger *log.Logger
+}
+
+func (f ReadUnmounter) Close() error {
+	defer umountOEM(f.logger)
+	return f.ReadCloser.Close()
+}
+
+// FetchResourceAsReader returns a ReadCloser to the data at the url specified. The caller is responsible for
+// closing the reader.
+func FetchResourceAsReader(l *log.Logger, u url.URL) (io.ReadCloser, error) {
 	switch u.Scheme {
 	case "http", "https":
 		client := NewHttpClient(l)
-		data, status, err := client.Get(u.String())
+		dataReader, status, err := client.GetReader(u.String())
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +88,7 @@ func FetchResource(l *log.Logger, u url.URL) ([]byte, error) {
 		l.Debug("GET result: %s", http.StatusText(status))
 		switch status {
 		case http.StatusOK, http.StatusNoContent:
-			return data, nil
+			return dataReader, nil
 		case http.StatusNotFound:
 			return nil, ErrNotFound
 		default:
@@ -68,8 +100,7 @@ func FetchResource(l *log.Logger, u url.URL) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		return url.Data, nil
+		return ioutil.NopCloser(bytes.NewReader(url.Data)), nil
 
 	case "oem":
 		path := filepath.Clean(u.Path)
@@ -80,27 +111,35 @@ func FetchResource(l *log.Logger, u url.URL) ([]byte, error) {
 
 		// check if present under oemDirPath, if so use it.
 		absPath := filepath.Join(oemDirPath, path)
-		data, err := ioutil.ReadFile(absPath)
-		if os.IsNotExist(err) {
-			l.Info("oem config not found in %q, trying %q",
-				oemDirPath, oemMountPath)
 
-			// try oemMountPath, requires mounting it.
-			err := mountOEM(l)
-			if err != nil {
-				l.Err("failed to mount oem partition: %v", err)
-				return nil, ErrFailed
-			}
-
-			absPath := filepath.Join(oemMountPath, path)
-			data, err = ioutil.ReadFile(absPath)
-			umountOEM(l)
-		} else if err != nil {
+		if f, err := os.Open(absPath); err == nil {
+			return f, nil
+		} else if !os.IsNotExist(err) {
 			l.Err("failed to read oem config: %v", err)
 			return nil, ErrFailed
 		}
 
-		return data, nil
+		l.Info("oem config not found in %q, trying %q",
+			oemDirPath, oemMountPath)
+
+		// try oemMountPath, requires mounting it.
+		if err := mountOEM(l); err != nil {
+			l.Err("failed to mount oem partition: %v", err)
+			return nil, ErrFailed
+		}
+
+		absPath = filepath.Join(oemMountPath, path)
+		f, err := os.Open(absPath)
+		if err != nil {
+			l.Err("failed to read oem config: %v", err)
+			umountOEM(l)
+			return nil, ErrFailed
+		}
+
+		return ReadUnmounter{
+			logger:     l,
+			ReadCloser: f,
+		}, nil
 
 	default:
 		return nil, ErrSchemeUnsupported

--- a/internal/util/verification_test.go
+++ b/internal/util/verification_test.go
@@ -69,8 +69,8 @@ func TestAssertValid(t *testing.T) {
 				data: []byte("hello"),
 			},
 			out: out{err: ErrHashMismatch{
-				calculated: "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
-				expected:   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				Calculated: "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+				Expected:   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			}},
 		},
 	}


### PR DESCRIPTION
Use io.Reader instead of reading whole files into memory. Prevent
ignition from using large amounts of memory when writing large files.

Also make default http timeout for connection, not the entire transfer