### PR TITLE
[WIP] Add initial support for the openstack OEM

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -8,6 +8,7 @@ Ignition is currently only supported for the following platforms:
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
 * [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64".
 * [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
+* [OpenStack] - Ignition will read its configuration from the EC2-compatible configdrive. SSH keys are handled by coreos-metadata.
 
 Ignition is under active development so expect this list to expand in the coming months.
 
@@ -17,3 +18,4 @@ Ignition is under active development so expect this list to expand in the coming
 [Microsoft Azure]: https://github.com/coreos/docs/blob/master/os/booting-on-azure.md
 [VMware]: https://github.com/coreos/docs/blob/master/os/booting-on-vmware.md
 [Google Compute Engine]: https://github.com/coreos/docs/blob/master/os/booting-on-google-compute-engine.md
+[OpenStack]: https://github.com/coreos/docs/blob/master/os/booting-on-openstack.md

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/azure"
 	"github.com/coreos/ignition/internal/providers/cmdline"
+	"github.com/coreos/ignition/internal/providers/configdrive"
 	"github.com/coreos/ignition/internal/providers/ec2"
 	"github.com/coreos/ignition/internal/providers/gce"
 	"github.com/coreos/ignition/internal/providers/noop"
@@ -84,7 +85,15 @@ func init() {
 	})
 	configs.Register(Config{
 		name:     "openstack",
-		provider: noop.Creator{},
+		provider: configdrive.Creator{},
+		baseConfig: types.Config{
+			Systemd: types.Systemd{
+				Units: []types.SystemdUnit{{
+					Name:   "coreos-metadata-sshkeys@.service",
+					Enable: true,
+				}},
+			},
+		},
 	})
 	configs.Register(Config{
 		name:     "ec2",

--- a/internal/providers/configdrive/configdrive.go
+++ b/internal/providers/configdrive/configdrive.go
@@ -1,0 +1,102 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The configdrive provider fetches a user_data from a config-2 file system.
+
+package configdrive
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/providers"
+	"github.com/coreos/ignition/internal/providers/util"
+)
+
+const (
+	initialBackoff = 100 * time.Millisecond
+	maxBackoff     = 30 * time.Second
+	configDevice   = "/dev/disk/by-label/config-2"
+	configPath     = "/openstack/latest/user_data:/ec2/latest/user-data"
+)
+
+type Creator struct{}
+
+func (Creator) Create(logger *log.Logger) providers.Provider {
+	return &provider{
+		logger:  logger,
+		backoff: initialBackoff,
+	}
+}
+
+type provider struct {
+	logger  *log.Logger
+	backoff time.Duration
+}
+
+func (p provider) FetchConfig() (types.Config, error) {
+	p.logger.Debug("creating temporary mount point")
+	mnt, err := ioutil.TempDir("", "ignition-configdrive")
+	if err != nil {
+		return types.Config{}, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.Remove(mnt)
+
+	p.logger.Debug("mounting config drive")
+	if cmd := exec.Command("/usr/bin/mount", "-o", "ro", "-t", "auto", configDevice, mnt); cmd.Run() != nil {
+		return types.Config{}, fmt.Errorf("failed to mount device %q at %q: %v", configDevice, mnt, err)
+	}
+	defer p.logger.LogOp(
+		func() error { return syscall.Unmount(mnt, 0) },
+		"unmounting %q at %q", configDevice, mnt,
+	)
+
+	p.logger.Debug("reading config")
+	for _, path := range strings.Split(configPath, ":") {
+		rawConfig, err := ioutil.ReadFile(filepath.Join(mnt, path))
+		if err == nil {
+			return config.Parse(rawConfig)
+		}
+	}
+
+	return types.Config{}, fmt.Errorf("failed to find config in %s", configPath)
+}
+
+func (p provider) IsOnline() bool {
+	p.logger.Debug("opening config drive: %s", configDevice)
+	err := util.AssertCdromOnline(configDevice)
+	if err == nil || err == util.ErrNotACdrom {
+		return true
+	} else {
+		p.logger.Info("Drive is not online: %s", err)
+		return false
+	}
+}
+
+func (p provider) ShouldRetry() bool {
+	return true
+}
+
+func (p *provider) BackoffDuration() time.Duration {
+	return util.ExpBackoff(&p.backoff, maxBackoff)
+}

--- a/internal/providers/util/cdrom.go
+++ b/internal/providers/util/cdrom.go
@@ -1,0 +1,65 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// These constants come from <cdrom.h>.
+const (
+	CDROM_DRIVE_STATUS = 0x5326
+)
+
+// These constants come from <cdrom.h>.
+const (
+	CDS_NO_INFO = iota
+	CDS_NO_DISC
+	CDS_TRAY_OPEN
+	CDS_DRIVE_NOT_READY
+	CDS_DISC_OK
+)
+
+func AssertCdromOnline(devicePath string) error {
+	device, err := os.Open(devicePath)
+	if err != nil {
+		return fmt.Errorf("failed to open CD-ROM device %s: %v", devicePath, err)
+	}
+	defer device.Close()
+
+	status, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(device.Fd()),
+		uintptr(CDROM_DRIVE_STATUS),
+		uintptr(0),
+	)
+
+	switch status {
+	case CDS_NO_INFO:
+		return fmt.Errorf("%s drive status: no info", devicePath)
+	case CDS_NO_DISC:
+		return fmt.Errorf("%s drive status: no disc", devicePath)
+	case CDS_TRAY_OPEN:
+		return fmt.Errorf("%s drive status: open", devicePath)
+	case CDS_DRIVE_NOT_READY:
+		return fmt.Errorf("%s drive status: not ready", devicePath)
+	case CDS_DISC_OK:
+		return nil
+	default:
+		return fmt.Errorf("%s failed to get drive status: %s", devicePath, errno.Error())
+	}
+}

--- a/internal/providers/util/cdrom.go
+++ b/internal/providers/util/cdrom.go
@@ -34,6 +34,12 @@ const (
 	CDS_DISC_OK
 )
 
+type constantError string
+func (e constantError) Error() string { return string(e) }
+const (
+	ErrNotACdrom = constantError("Not a CD-ROM drive")
+)
+
 func AssertCdromOnline(devicePath string) error {
 	device, err := os.Open(devicePath)
 	if err != nil {
@@ -60,6 +66,9 @@ func AssertCdromOnline(devicePath string) error {
 	case CDS_DISC_OK:
 		return nil
 	default:
+		if errno == syscall.ENOTTY {
+			return ErrNotACdrom
+		}
 		return fmt.Errorf("%s failed to get drive status: %s", devicePath, errno.Error())
 	}
 }


### PR DESCRIPTION
This is a first-pass at supporting OpenStack via the EC2-compatible configdrive CD.  The network metadata service will be added eventually.