### PR TITLE
Add dirs

### DIFF
--- a/config/translate.go
+++ b/config/translate.go
@@ -83,17 +83,19 @@ func TranslateFromV1(old v1.Config) (types.Config, error) {
 
 		for _, oldFile := range oldFilesystem.Files {
 			file := types.File{
-				Filesystem: filesystem.Name,
-				Path:       types.Path(oldFile.Path),
+				Node: types.Node{
+					Filesystem: filesystem.Name,
+					Path:       types.Path(oldFile.Path),
+					Mode:       types.NodeMode(oldFile.Mode),
+					User:       types.NodeUser{Id: oldFile.Uid},
+					Group:      types.NodeGroup{Id: oldFile.Gid},
+				},
 				Contents: types.FileContents{
 					Source: types.Url{
 						Scheme: "data",
 						Opaque: "," + dataurl.EscapeString(oldFile.Contents),
 					},
 				},
-				Mode:  types.FileMode(oldFile.Mode),
-				User:  types.FileUser{Id: oldFile.Uid},
-				Group: types.FileGroup{Id: oldFile.Gid},
 			}
 
 			config.Storage.Files = append(config.Storage.Files, file)

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -188,43 +188,49 @@ func TestTranslateFromV1(t *testing.T) {
 					},
 					Files: []types.File{
 						{
-							Filesystem: "_translate-filesystem-0",
-							Path:       types.Path("/opt/file1"),
+							Node: types.Node{
+								Filesystem: "_translate-filesystem-0",
+								Path:       types.Path("/opt/file1"),
+								Mode:       types.NodeMode(0664),
+								User:       types.NodeUser{Id: 500},
+								Group:      types.NodeGroup{Id: 501},
+							},
 							Contents: types.FileContents{
 								Source: types.Url{
 									Scheme: "data",
 									Opaque: ",file1",
 								},
 							},
-							Mode:  types.FileMode(0664),
-							User:  types.FileUser{Id: 500},
-							Group: types.FileGroup{Id: 501},
 						},
 						{
-							Filesystem: "_translate-filesystem-0",
-							Path:       types.Path("/opt/file2"),
+							Node: types.Node{
+								Filesystem: "_translate-filesystem-0",
+								Path:       types.Path("/opt/file2"),
+								Mode:       types.NodeMode(0644),
+								User:       types.NodeUser{Id: 502},
+								Group:      types.NodeGroup{Id: 503},
+							},
 							Contents: types.FileContents{
 								Source: types.Url{
 									Scheme: "data",
 									Opaque: ",file2",
 								},
 							},
-							Mode:  types.FileMode(0644),
-							User:  types.FileUser{Id: 502},
-							Group: types.FileGroup{Id: 503},
 						},
 						{
-							Filesystem: "_translate-filesystem-1",
-							Path:       types.Path("/opt/file3"),
+							Node: types.Node{
+								Filesystem: "_translate-filesystem-1",
+								Path:       types.Path("/opt/file3"),
+								Mode:       types.NodeMode(0400),
+								User:       types.NodeUser{Id: 1000},
+								Group:      types.NodeGroup{Id: 1001},
+							},
 							Contents: types.FileContents{
 								Source: types.Url{
 									Scheme: "data",
 									Opaque: ",file3",
 								},
 							},
-							Mode:  types.FileMode(0400),
-							User:  types.FileUser{Id: 1000},
-							Group: types.FileGroup{Id: 1001},
 						},
 					},
 				},

--- a/config/types/directory.go
+++ b/config/types/directory.go
@@ -14,10 +14,16 @@
 
 package types
 
-type Storage struct {
-	Disks       []Disk       `json:"disks,omitempty"`
-	Arrays      []Raid       `json:"raid,omitempty"`
-	Filesystems []Filesystem `json:"filesystems,omitempty"`
-	Files       []File       `json:"files,omitempty"`
-	Directories []Directory  `json:"directories,omitempty"`
+import (
+	"path/filepath"
+)
+
+type Directory Node
+
+func (d *Directory) Depth() int {
+	count := 0
+	for p := filepath.Clean(string(d.Path)); p != "/"; count++ {
+		p = filepath.Dir(p)
+	}
+	return count
 }

--- a/config/types/file.go
+++ b/config/types/file.go
@@ -14,54 +14,14 @@
 
 package types
 
-import (
-	"encoding/json"
-	"errors"
-	"os"
-)
-
-var (
-	ErrFileIllegalMode = errors.New("illegal file mode")
-)
-
+// File represents regular files
 type File struct {
-	Filesystem string       `json:"filesystem,omitempty"`
-	Path       Path         `json:"path,omitempty"`
-	Contents   FileContents `json:"contents,omitempty"`
-	Mode       FileMode     `json:"mode,omitempty"`
-	User       FileUser     `json:"user,omitempty"`
-	Group      FileGroup    `json:"group,omitempty"`
-}
-
-type FileUser struct {
-	Id int `json:"id,omitempty"`
-}
-
-type FileGroup struct {
-	Id int `json:"id,omitempty"`
+	Node
+	Contents FileContents `json:"contents,omitempty"`
 }
 
 type FileContents struct {
 	Compression  Compression  `json:"compression,omitempty"`
 	Source       Url          `json:"source,omitempty"`
 	Verification Verification `json:"verification,omitempty"`
-}
-
-type FileMode os.FileMode
-type fileMode FileMode
-
-func (m *FileMode) UnmarshalJSON(data []byte) error {
-	tm := fileMode(*m)
-	if err := json.Unmarshal(data, &tm); err != nil {
-		return err
-	}
-	*m = FileMode(tm)
-	return m.AssertValid()
-}
-
-func (m FileMode) AssertValid() error {
-	if (m &^ 07777) != 0 {
-		return ErrFileIllegalMode
-	}
-	return nil
 }

--- a/config/types/file_test.go
+++ b/config/types/file_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 )
 
-func TestFileModeUnmarshalJSON(t *testing.T) {
+func TestNodeModeUnmarshalJSON(t *testing.T) {
 	type in struct {
 		data string
 	}
 	type out struct {
-		mode FileMode
+		mode NodeMode
 		err  error
 	}
 
@@ -35,16 +35,16 @@ func TestFileModeUnmarshalJSON(t *testing.T) {
 	}{
 		{
 			in:  in{data: `420`},
-			out: out{mode: FileMode(420)},
+			out: out{mode: NodeMode(420)},
 		},
 		{
 			in:  in{data: `9999`},
-			out: out{mode: FileMode(9999), err: ErrFileIllegalMode},
+			out: out{mode: NodeMode(9999), err: ErrFileIllegalMode},
 		},
 	}
 
 	for i, test := range tests {
-		var mode FileMode
+		var mode NodeMode
 		err := json.Unmarshal([]byte(test.in.data), &mode)
 		if !reflect.DeepEqual(test.out.err, err) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
@@ -57,7 +57,7 @@ func TestFileModeUnmarshalJSON(t *testing.T) {
 
 func TestFileAssertValid(t *testing.T) {
 	type in struct {
-		mode FileMode
+		mode NodeMode
 	}
 	type out struct {
 		err error
@@ -68,23 +68,23 @@ func TestFileAssertValid(t *testing.T) {
 		out out
 	}{
 		{
-			in:  in{mode: FileMode(0)},
+			in:  in{mode: NodeMode(0)},
 			out: out{},
 		},
 		{
-			in:  in{mode: FileMode(0644)},
+			in:  in{mode: NodeMode(0644)},
 			out: out{},
 		},
 		{
-			in:  in{mode: FileMode(01755)},
+			in:  in{mode: NodeMode(01755)},
 			out: out{},
 		},
 		{
-			in:  in{mode: FileMode(07777)},
+			in:  in{mode: NodeMode(07777)},
 			out: out{},
 		},
 		{
-			in:  in{mode: FileMode(010000)},
+			in:  in{mode: NodeMode(010000)},
 			out: out{err: ErrFileIllegalMode},
 		},
 	}

--- a/config/types/node.go
+++ b/config/types/node.go
@@ -1,0 +1,61 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+var (
+	ErrFileIllegalMode = errors.New("illegal file mode")
+)
+
+// Node represents all common info for files (special types, e.g. directories, included).
+type Node struct {
+	Filesystem string    `json:"filesystem,omitempty"`
+	Path       Path      `json:"path,omitempty"`
+	Mode       NodeMode  `json:"mode,omitempty"`
+	User       NodeUser  `json:"user,omitempty"`
+	Group      NodeGroup `json:"group,omitempty"`
+}
+
+type NodeUser struct {
+	Id int `json:"id,omitempty"`
+}
+
+type NodeGroup struct {
+	Id int `json:"id,omitempty"`
+}
+
+type NodeMode os.FileMode
+type nodeMode NodeMode
+
+func (m *NodeMode) UnmarshalJSON(data []byte) error {
+	tm := nodeMode(*m)
+	if err := json.Unmarshal(data, &tm); err != nil {
+		return err
+	}
+	*m = NodeMode(tm)
+	return m.AssertValid()
+}
+
+func (m NodeMode) AssertValid() error {
+	if (m &^ 07777) != 0 {
+		return ErrFileIllegalMode
+	}
+	return nil
+}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -37,8 +37,8 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
         * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
     * **_path_** (string): the mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for "/sysroot".
-  * **_files_** (list of objects): the list of files, rooted in this particular filesystem, to be written.
-    * **filesystem** (string): the internal identifier of the filesystem. This matches the last filesystem with the given identifier.
+  * **_files_** (list of objects): the list of files to be written.
+    * **filesystem** (string): the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the file.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -50,6 +50,14 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_id_** (integer): the user ID of the owner.
     * **_group_** (object): specifies the group of the owner.
       * **_id_** (integer): the group ID of the owner.
+  * **_directories_** (list of objects): the list of directories to be created.
+    * **filesystem** (string): the internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.
+    * **path** (string): the absolute path to the directory.
+    * **_mode_** (integer): the directory's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0755 -> 493).
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
 * **_systemd_** (object): describes the desired state of the systemd units.
   * **_units_** (list of objects): the list of systemd units.
     * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service").

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"sort"
 	"syscall"
 
 	"github.com/coreos/ignition/config/types"
@@ -72,7 +74,7 @@ func (s stage) Run(config types.Config) bool {
 		return false
 	}
 
-	if err := s.createFilesystemsFiles(config); err != nil {
+	if err := s.createFilesystemsEntries(config); err != nil {
 		s.Logger.Crit("failed to create files: %v", err)
 		return false
 	}
@@ -85,21 +87,21 @@ func (s stage) Run(config types.Config) bool {
 	return true
 }
 
-// createFilesystemsFiles creates the files described in config.Storage.Filesystems.
-func (s stage) createFilesystemsFiles(config types.Config) error {
+// createFilesystemsEntries creates the files described in config.Storage.{Files,Directories}.
+func (s stage) createFilesystemsEntries(config types.Config) error {
 	if len(config.Storage.Filesystems) == 0 {
 		return nil
 	}
 	s.Logger.PushPrefix("createFilesystemsFiles")
 	defer s.Logger.PopPrefix()
 
-	fileMap, err := s.mapFilesToFilesystems(config)
+	entryMap, err := s.mapEntriesToFilesystems(config)
 	if err != nil {
 		return err
 	}
 
-	for fs, f := range fileMap {
-		if err := s.createFiles(fs, f); err != nil {
+	for fs, f := range entryMap {
+		if err := s.createEntries(fs, f); err != nil {
 			return fmt.Errorf("failed to create files: %v", err)
 		}
 	}
@@ -107,35 +109,125 @@ func (s stage) createFilesystemsFiles(config types.Config) error {
 	return nil
 }
 
-// mapFilesToFilesystems builds a map of filesystems to files. If multiple
-// definitions of the same filesystem are present, only the final definition is
-// used.
-func (s stage) mapFilesToFilesystems(config types.Config) (map[types.Filesystem][]types.File, error) {
-	files := map[string][]types.File{}
-	for _, f := range config.Storage.Files {
-		files[f.Filesystem] = append(files[f.Filesystem], f)
+// filesystemEntry represent a thing that knows how to create itself.
+type filesystemEntry interface {
+	create(l *log.Logger, c *util.HttpClient, u eutil.Util) error
+}
+
+type fileEntry types.File
+
+func (tmp fileEntry) create(l *log.Logger, c *util.HttpClient, u eutil.Util) error {
+	f := types.File(tmp)
+	file := eutil.RenderFile(l, c, f)
+	if file == nil {
+		return fmt.Errorf("failed to resolve file %q", f.Path)
 	}
 
+	if err := l.LogOp(
+		func() error { return u.WriteFile(file) },
+		"writing file %q", string(f.Path),
+	); err != nil {
+		return fmt.Errorf("failed to create file %q: %v", file.Path, err)
+	}
+
+	return nil
+}
+
+type dirEntry types.Directory
+
+func (tmp dirEntry) create(l *log.Logger, _ *util.HttpClient, u eutil.Util) error {
+	d := types.Directory(tmp)
+	err := l.LogOp(func() error {
+		path := filepath.Clean(u.JoinPath(string(d.Path)))
+
+		// Build a list of paths to create. Since os.MkdirAll only sets the mode for new directories and not the
+		// ownership, we need to determine which directories will be created so we don't chown something that already
+		// exists.
+		newPaths := []string{}
+		for p := path; p != "/"; p = filepath.Dir(p) {
+			_, err := os.Stat(p)
+			if err == nil {
+				break
+			}
+			if !os.IsNotExist(err) {
+				return err
+			}
+			newPaths = append(newPaths, p)
+		}
+
+		if err := os.MkdirAll(path, os.FileMode(d.Mode)); err != nil {
+			return err
+		}
+
+		for _, newPath := range newPaths {
+			if err := os.Chmod(newPath, os.FileMode(d.Mode)); err != nil {
+				return err
+			}
+			if err := os.Chown(newPath, d.User.Id, d.Group.Id); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, "creating directory %q", string(d.Path))
+	if err != nil {
+		return fmt.Errorf("failed to create directory %q: %v", d.Path, err)
+	}
+
+	return nil
+}
+
+// ByDirectorySegments is used to sort directories so /foo gets created before /foo/bar if they are both specified.
+type ByDirectorySegments []types.Directory
+
+func (lst ByDirectorySegments) Len() int { return len(lst) }
+
+func (lst ByDirectorySegments) Swap(i, j int) {
+	lst[i], lst[j] = lst[j], lst[i]
+}
+
+func (lst ByDirectorySegments) Less(i, j int) bool {
+	return lst[i].Depth() < lst[j].Depth()
+}
+
+// mapEntriesToFilesystems builds a map of filesystems to files. If multiple
+// definitions of the same filesystem are present, only the final definition is
+// used. The directories are sorted to ensure /foo gets created before /foo/bar.
+func (s stage) mapEntriesToFilesystems(config types.Config) (map[types.Filesystem][]filesystemEntry, error) {
 	filesystems := map[string]types.Filesystem{}
 	for _, fs := range config.Storage.Filesystems {
 		filesystems[fs.Name] = fs
 	}
 
-	fileMap := map[types.Filesystem][]types.File{}
-	for fsn, f := range files {
-		if fs, ok := filesystems[fsn]; ok {
-			fileMap[fs] = append(fileMap[fs], f...)
+	entryMap := map[types.Filesystem][]filesystemEntry{}
+
+	// Sort directories to ensure /a gets created before /a/b.
+	sortedDirs := config.Storage.Directories
+	sort.Sort(ByDirectorySegments(sortedDirs))
+
+	// Add directories first to ensure they are created before files.
+	for _, d := range sortedDirs {
+		if fs, ok := filesystems[d.Filesystem]; ok {
+			entryMap[fs] = append(entryMap[fs], dirEntry(d))
 		} else {
-			s.Logger.Crit("the filesystem (%q), was not defined", fsn)
+			s.Logger.Crit("the filesystem (%q), was not defined", d.Filesystem)
 			return nil, ErrFilesystemUndefined
 		}
 	}
 
-	return fileMap, nil
+	for _, f := range config.Storage.Files {
+		if fs, ok := filesystems[f.Filesystem]; ok {
+			entryMap[fs] = append(entryMap[fs], fileEntry(f))
+		} else {
+			s.Logger.Crit("the filesystem (%q), was not defined", f.Filesystem)
+			return nil, ErrFilesystemUndefined
+		}
+	}
+
+	return entryMap, nil
 }
 
-// createFiles creates any files listed for the filesystem in storage.Files.
-func (s stage) createFiles(fs types.Filesystem, files []types.File) error {
+// createEntries creates any files or directories listed for the filesystem in Storage.{Files,Directories}.
+func (s stage) createEntries(fs types.Filesystem, files []filesystemEntry) error {
 	s.Logger.PushPrefix("createFiles")
 	defer s.Logger.PopPrefix()
 
@@ -169,18 +261,9 @@ func (s stage) createFiles(fs types.Filesystem, files []types.File) error {
 		Logger:  s.Logger,
 		DestDir: mnt,
 	}
-	for _, f := range files {
-		file := eutil.RenderFile(s.Logger, s.client, f)
-		if file == nil {
-			return fmt.Errorf("failed to resolve file %q", f.Path)
-		}
 
-		if err := s.Logger.LogOp(
-			func() error { return u.WriteFile(file) },
-			"writing file %q", string(f.Path),
-		); err != nil {
-			return fmt.Errorf("failed to create file %q: %v", file.Path, err)
-		}
+	for _, e := range files {
+		e.create(s.Logger, s.client, u)
 	}
 
 	return nil

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -134,7 +134,7 @@ func (s stage) mapFilesToFilesystems(config types.Config) (map[types.Filesystem]
 	return fileMap, nil
 }
 
-// createFiles creates any files listed for the filesystem in fs.Files.
+// createFiles creates any files listed for the filesystem in storage.Files.
 func (s stage) createFiles(fs types.Filesystem, files []types.File) error {
 	s.Logger.PushPrefix("createFiles")
 	defer s.Logger.PopPrefix()

--- a/internal/exec/stages/files/files_test.go
+++ b/internal/exec/stages/files/files_test.go
@@ -16,6 +16,7 @@ package files
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/coreos/ignition/config/types"
@@ -23,12 +24,12 @@ import (
 	"github.com/coreos/ignition/internal/log"
 )
 
-func TestMapFilesToFilesystems(t *testing.T) {
+func TestMapEntriesToFilesystems(t *testing.T) {
 	type in struct {
 		config types.Config
 	}
 	type out struct {
-		files map[types.Filesystem][]types.File
+		files map[types.Filesystem][]filesystemEntry
 		err   error
 	}
 
@@ -41,7 +42,7 @@ func TestMapFilesToFilesystems(t *testing.T) {
 	}{
 		{
 			in:  in{config: types.Config{}},
-			out: out{files: map[types.Filesystem][]types.File{}},
+			out: out{files: map[types.Filesystem][]filesystemEntry{}},
 		},
 		{
 			in:  in{config: types.Config{Storage: types.Storage{Files: []types.File{{Node: types.Node{Filesystem: "foo"}}}}}},
@@ -55,9 +56,9 @@ func TestMapFilesToFilesystems(t *testing.T) {
 					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
 				},
 			}}},
-			out: out{files: map[types.Filesystem][]types.File{types.Filesystem{Name: "fs1"}: {
-				{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
-				{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
+			out: out{files: map[types.Filesystem][]filesystemEntry{types.Filesystem{Name: "fs1"}: {
+				fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}}),
+				fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/bar"}}),
 			}}},
 		},
 		{
@@ -68,9 +69,9 @@ func TestMapFilesToFilesystems(t *testing.T) {
 					{Node: types.Node{Filesystem: "fs2", Path: "/bar"}},
 				},
 			}}},
-			out: out{files: map[types.Filesystem][]types.File{
-				types.Filesystem{Name: "fs1", Path: &fs1}: {{Node: types.Node{Filesystem: "fs1", Path: "/foo"}}},
-				types.Filesystem{Name: "fs2", Path: &fs2}: {{Node: types.Node{Filesystem: "fs2", Path: "/bar"}}},
+			out: out{files: map[types.Filesystem][]filesystemEntry{
+				types.Filesystem{Name: "fs1", Path: &fs1}: {fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}})},
+				types.Filesystem{Name: "fs2", Path: &fs2}: {fileEntry(types.File{Node: types.Node{Filesystem: "fs2", Path: "/bar"}})},
 			}},
 		},
 		{
@@ -81,10 +82,10 @@ func TestMapFilesToFilesystems(t *testing.T) {
 					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
 				},
 			}}},
-			out: out{files: map[types.Filesystem][]types.File{
+			out: out{files: map[types.Filesystem][]filesystemEntry{
 				types.Filesystem{Name: "fs1", Path: &fs1}: {
-					{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
-					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
+					fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}}),
+					fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/bar"}}),
 				},
 			}},
 		},
@@ -92,12 +93,55 @@ func TestMapFilesToFilesystems(t *testing.T) {
 
 	for i, test := range tests {
 		logger := log.New()
-		files, err := stage{Util: util.Util{Logger: &logger}}.mapFilesToFilesystems(test.in.config)
+		files, err := stage{Util: util.Util{Logger: &logger}}.mapEntriesToFilesystems(test.in.config)
 		if !reflect.DeepEqual(test.out.err, err) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
 		}
 		if !reflect.DeepEqual(test.out.files, files) {
 			t.Errorf("#%d: bad map: want %#v, got %#v", i, test.out.files, files)
+		}
+	}
+}
+
+func TestDirectorySort(t *testing.T) {
+	type in struct {
+		data []string
+	}
+
+	type out struct {
+		data []string
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{data: []string{"/a/b/c/d/e/", "/a/b/c/d/", "/a/b/c/", "/a/b/", "/a/"}},
+			out: out{data: []string{"/a/", "/a/b/", "/a/b/c/", "/a/b/c/d/", "/a/b/c/d/e/"}},
+		},
+		{
+			in:  in{data: []string{"/a////b/c/d/e/", "/", "/a/b/c//d/", "/a/b/c/", "/a/b/", "/a/"}},
+			out: out{data: []string{"/", "/a/", "/a/b/", "/a/b/c/", "/a/b/c//d/", "/a////b/c/d/e/"}},
+		},
+		{
+			in:  in{data: []string{"/a/", "/a/../a/b", "/"}},
+			out: out{data: []string{"/", "/a/", "/a/../a/b"}},
+		},
+	}
+
+	for i, test := range tests {
+		dirs := make([]types.Directory, len(test.in.data))
+		for j := range dirs {
+			dirs[j].Path = types.Path(test.in.data[j])
+		}
+		sort.Sort(ByDirectorySegments(dirs))
+		outpaths := make([]string, len(test.in.data))
+		for j, dir := range dirs {
+			outpaths[j] = string(dir.Path)
+		}
+		if !reflect.DeepEqual(test.out.data, outpaths) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.data, outpaths)
 		}
 	}
 }

--- a/internal/exec/stages/files/files_test.go
+++ b/internal/exec/stages/files/files_test.go
@@ -44,33 +44,48 @@ func TestMapFilesToFilesystems(t *testing.T) {
 			out: out{files: map[types.Filesystem][]types.File{}},
 		},
 		{
-			in:  in{config: types.Config{Storage: types.Storage{Files: []types.File{{Filesystem: "foo"}}}}},
+			in:  in{config: types.Config{Storage: types.Storage{Files: []types.File{{Node: types.Node{Filesystem: "foo"}}}}}},
 			out: out{err: ErrFilesystemUndefined},
 		},
 		{
 			in: in{config: types.Config{Storage: types.Storage{
 				Filesystems: []types.Filesystem{{Name: "fs1"}},
-				Files:       []types.File{{Filesystem: "fs1", Path: "/foo"}, {Filesystem: "fs1", Path: "/bar"}},
+				Files: []types.File{
+					{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
+					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
+				},
 			}}},
-			out: out{files: map[types.Filesystem][]types.File{types.Filesystem{Name: "fs1"}: {{Filesystem: "fs1", Path: "/foo"}, {Filesystem: "fs1", Path: "/bar"}}}},
+			out: out{files: map[types.Filesystem][]types.File{types.Filesystem{Name: "fs1"}: {
+				{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
+				{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
+			}}},
 		},
 		{
 			in: in{config: types.Config{Storage: types.Storage{
 				Filesystems: []types.Filesystem{{Name: "fs1", Path: &fs1}, {Name: "fs2", Path: &fs2}},
-				Files:       []types.File{{Filesystem: "fs1", Path: "/foo"}, {Filesystem: "fs2", Path: "/bar"}},
+				Files: []types.File{
+					{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
+					{Node: types.Node{Filesystem: "fs2", Path: "/bar"}},
+				},
 			}}},
 			out: out{files: map[types.Filesystem][]types.File{
-				types.Filesystem{Name: "fs1", Path: &fs1}: {{Filesystem: "fs1", Path: "/foo"}},
-				types.Filesystem{Name: "fs2", Path: &fs2}: {{Filesystem: "fs2", Path: "/bar"}},
+				types.Filesystem{Name: "fs1", Path: &fs1}: {{Node: types.Node{Filesystem: "fs1", Path: "/foo"}}},
+				types.Filesystem{Name: "fs2", Path: &fs2}: {{Node: types.Node{Filesystem: "fs2", Path: "/bar"}}},
 			}},
 		},
 		{
 			in: in{config: types.Config{Storage: types.Storage{
 				Filesystems: []types.Filesystem{{Name: "fs1"}, {Name: "fs1", Path: &fs1}},
-				Files:       []types.File{{Filesystem: "fs1", Path: "/foo"}, {Filesystem: "fs1", Path: "/bar"}},
+				Files: []types.File{
+					{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
+					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
+				},
 			}}},
 			out: out{files: map[types.Filesystem][]types.File{
-				types.Filesystem{Name: "fs1", Path: &fs1}: {{Filesystem: "fs1", Path: "/foo"}, {Filesystem: "fs1", Path: "/bar"}},
+				types.Filesystem{Name: "fs1", Path: &fs1}: {
+					{Node: types.Node{Filesystem: "fs1", Path: "/foo"}},
+					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
+				},
 			}},
 		},
 	}

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -161,7 +161,7 @@ func (u Util) WriteFile(f *File) error {
 
 	path := u.JoinPath(string(f.Path))
 
-	if err := mkdirForFile(path); err != nil {
+	if err := MkdirForFile(path); err != nil {
 		return err
 	}
 
@@ -208,7 +208,7 @@ func (u Util) WriteFile(f *File) error {
 	return nil
 }
 
-// mkdirForFile helper creates the directory components of path.
-func mkdirForFile(path string) error {
+// MkdirForFile helper creates the directory components of path.
+func MkdirForFile(path string) error {
 	return os.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions)
 }

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -55,7 +55,7 @@ func FileFromUnitDropin(unit types.SystemdUnit, dropin types.SystemdUnitDropIn) 
 
 func (u Util) MaskUnit(unit types.SystemdUnit) error {
 	path := u.JoinPath(SystemdUnitsPath(), string(unit.Name))
-	if err := mkdirForFile(path); err != nil {
+	if err := MkdirForFile(path); err != nil {
 		return err
 	}
 	if err := os.RemoveAll(path); err != nil {
@@ -66,7 +66,7 @@ func (u Util) MaskUnit(unit types.SystemdUnit) error {
 
 func (u Util) EnableUnit(unit types.SystemdUnit) error {
 	path := u.JoinPath(presetPath)
-	if err := mkdirForFile(path); err != nil {
+	if err := MkdirForFile(path); err != nil {
 		return err
 	}
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND|os.O_CREATE, DefaultPresetPermissions)

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -128,15 +128,19 @@ func init() {
 					serviceFromOem("google-startup-scripts-onboot.service"),
 					serviceFromOem("google-startup-scripts.service"),
 					{
-						Filesystem: "root",
-						Path:       "/etc/hosts",
-						Mode:       0444,
-						Contents:   contentsFromString("169.254.169.254 metadata\n127.0.0.1 localhost\n"),
+						Node: types.Node{
+							Filesystem: "root",
+							Path:       "/etc/hosts",
+							Mode:       0444,
+						},
+						Contents: contentsFromString("169.254.169.254 metadata\n127.0.0.1 localhost\n"),
 					},
 					{
-						Filesystem: "root",
-						Path:       "/etc/profile.d/google-cloud-sdk.sh",
-						Mode:       0444,
+						Node: types.Node{
+							Filesystem: "root",
+							Path:       "/etc/profile.d/google-cloud-sdk.sh",
+							Mode:       0444,
+						},
 						Contents: contentsFromString(`#!/bin/sh
 alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/doker.sock google/cloud-sdk gcloud"
 alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gcutil"
@@ -246,9 +250,11 @@ WantedBy=multi-user.target
 
 func serviceFromOem(unit string) types.File {
 	return types.File{
-		Filesystem: "root",
-		Path:       types.Path("/etc/systemd/system/" + unit),
-		Mode:       0444,
-		Contents:   contentsFromOem("/units/" + unit),
+		Node: types.Node{
+			Filesystem: "root",
+			Path:       types.Path("/etc/systemd/system/" + unit),
+			Mode:       0444,
+		},
+		Contents: contentsFromOem("/units/" + unit),
 	}
 }


### PR DESCRIPTION
WIP. The filesystemEntries in internal/exec/stages/files/files.go seems gross, but go's lack of generics makes it hard to find a better solution without duplicating a ton of code.