### PR TITLE
config/types: fix url parsing

### DIFF
--- a/config/types/url.go
+++ b/config/types/url.go
@@ -28,8 +28,12 @@ func (u *Url) UnmarshalJSON(data []byte) error {
 	}
 
 	pu, err := url.Parse(tu)
+	if err != nil {
+		return err
+	}
+
 	*u = Url(*pu)
-	return err
+	return nil
 }
 
 func (u Url) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
If the URL fails to parse, we shouldn't try to dereference a nil.