### PR TITLE
config/types: add validity assertion for node

### DIFF
--- a/config/types/node.go
+++ b/config/types/node.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	ErrNoFilesystem    = errors.New("no filesystem specified")
 	ErrFileIllegalMode = errors.New("illegal file mode")
 )
 
@@ -39,6 +40,13 @@ type NodeUser struct {
 
 type NodeGroup struct {
 	Id int `json:"id,omitempty"`
+}
+
+func (n Node) AssertValid() error {
+	if n.Filesystem == "" {
+		return ErrNoFilesystem
+	}
+	return nil
 }
 
 type NodeMode os.FileMode

--- a/config/types/node_test.go
+++ b/config/types/node_test.go
@@ -55,7 +55,37 @@ func TestNodeModeUnmarshalJSON(t *testing.T) {
 	}
 }
 
-func TestFileAssertValid(t *testing.T) {
+func TestNodeAssertValid(t *testing.T) {
+	type in struct {
+		node Node
+	}
+	type out struct {
+		err error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{node: Node{}},
+			out: out{err: ErrNoFilesystem},
+		},
+		{
+			in:  in{node: Node{Filesystem: "foo"}},
+			out: out{},
+		},
+	}
+
+	for i, test := range tests {
+		err := test.in.node.AssertValid()
+		if !reflect.DeepEqual(test.out.err, err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+	}
+}
+
+func TestNodeModeAssertValid(t *testing.T) {
 	type in struct {
 		mode NodeMode
 	}


### PR DESCRIPTION
This was lost in 14ae594fa6e31b67a6756cfd57296f5687b76f96.