### PR TITLE
*: add support for allowing existing filesystems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     # install cross compilers for cgo support.
     - gcc-aarch64-linux-gnu
     - libc6-dev-arm64-cross
+    - libblkid-dev
 
 install:
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,22 @@ addons:
     - libblkid-dev
 
 install:
-  -
+  # since libblkid-dev:arm64 cannot be installed, spoof it
+  -     if [ "${TARGET}" == "arm64" ]; then
+                echo "void blkid_new_probe_from_filename(void) {}" >> stub.c;
+                echo "void blkid_do_probe(void) {}"                >> stub.c;
+                echo "void blkid_probe_has_value(void) {}"         >> stub.c;
+                echo "void blkid_probe_lookup_value(void) {}"      >> stub.c;
+                echo "void blkid_free_probe(void) {}"              >> stub.c;
+                aarch64-linux-gnu-gcc-4.8 -c -o stub.o stub.c;
+                aarch64-linux-gnu-gcc-ar-4.8 cq libblkid.a stub.o;
+        fi
 
 script:
   -     if [ "${TARGET}" == "amd64" ]; then
                 GOARCH="${TARGET}" ./test;
         elif [ "${TARGET}" == "arm64" ]; then
+                export CGO_LDFLAGS="-L ${PWD}";
                 GOARCH="${TARGET}" ./build;
                 file "bin/${TARGET}/ignition" | egrep 'aarch64';
         fi

--- a/config/types/filesystem.go
+++ b/config/types/filesystem.go
@@ -33,9 +33,10 @@ type Filesystem struct {
 }
 
 type FilesystemMount struct {
-	Device Path              `json:"device,omitempty"`
-	Format FilesystemFormat  `json:"format,omitempty"`
-	Create *FilesystemCreate `json:"create,omitempty"`
+	Device      Path              `json:"device,omitempty"`
+	Format      FilesystemFormat  `json:"format,omitempty"`
+	UseIfExists bool              `json:"useIfExists,omitempty"`
+	Create      *FilesystemCreate `json:"create,omitempty"`
 }
 
 type FilesystemCreate struct {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -36,6 +36,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.
       * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
       * **format** (string): the filesystem format (ext4, btrfs, or xfs).
+      * **_useIfExists_** (boolean): whether or not the create operation shall be skipped if the target filesystem is already formatted with the desired filesystem type.
       * **_create_** (object): contains the set of options to be used when creating the filesystem. A non-null entry indicates that the filesystem shall be created.
         * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
         * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.

--- a/internal/exec/util/blkid.c
+++ b/internal/exec/util/blkid.c
@@ -1,0 +1,39 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <blkid/blkid.h>
+#include "blkid.h"
+
+result_t filesystem_type(const char *device, char type[], size_t type_len)
+{
+	const char *type_name = "\0";
+
+	blkid_probe pr = blkid_new_probe_from_filename(device);
+	if (!pr)
+		return RESULT_OPEN_FAILED;
+
+	if (blkid_do_probe(pr) != 0)
+		return RESULT_PROBE_FAILED;
+
+	if (blkid_probe_has_value(pr, "TYPE"))
+		if (blkid_probe_lookup_value(pr, "TYPE", &type_name, NULL))
+			return RESULT_LOOKUP_FAILED;
+
+	strncpy(type, type_name, type_len);
+
+	blkid_free_probe(pr);
+
+	return RESULT_OK;
+}
+

--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -1,0 +1,49 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package util
+
+// #cgo LDFLAGS: -lblkid
+// #include <stdlib.h>
+// #include "blkid.h"
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/coreos/ignition/config/types"
+)
+
+func FilesystemType(device types.Path) (string, error) {
+	var fsType [16]byte
+
+	cDevice := C.CString(string(device))
+	defer C.free(unsafe.Pointer(cDevice))
+
+	switch C.filesystem_type(cDevice, (*C.char)(unsafe.Pointer(&fsType[0])), C.size_t(len(fsType))) {
+	case C.RESULT_OK:
+		return string(fsType[:]), nil
+	case C.RESULT_OPEN_FAILED:
+		return "", fmt.Errorf("failed to open %q", device)
+	case C.RESULT_PROBE_FAILED:
+		return "", fmt.Errorf("failed to perform probe on %q", device)
+	case C.RESULT_LOOKUP_FAILED:
+		return "", fmt.Errorf("failed to lookup filesystem type of %q", device)
+	default:
+		return "", fmt.Errorf("unknown error")
+	}
+}

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -1,0 +1,30 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _BLKID_H_
+#define _BLKID_H_
+
+#include <string.h>
+
+typedef enum {
+	RESULT_OK,
+	RESULT_OPEN_FAILED,
+	RESULT_PROBE_FAILED,
+	RESULT_LOOKUP_FAILED,
+} result_t;
+
+result_t filesystem_type(const char *device, char type[], size_t type_len);
+
+#endif // _BLKID_H_
+


### PR DESCRIPTION
This adds the 'allowExisting' flag to filesystem's 'create' object. When
this flag is set, Ignition will not format the filesystem if it is
already of the correct type. This is useful if the user wants to persist
data across multiple runs of Ignition.

This new flag can be safely used in conjunction with the 'force' flag.
When both are set, the target filesystem is first checked to see if it's
the correct type. If so, the format operation is skipped. If not, the
'force' flag determines if the existing filesystem (if any) will be
overwritten.

Fixes https://github.com/coreos/bugs/issues/1070.
