### PR TITLE
util/http: unconditionally return HTTP result

### DIFF
--- a/internal/util/http.go
+++ b/internal/util/http.go
@@ -125,8 +125,7 @@ func (c HttpClient) GetReaderWithHeader(url string, header http.Header) (io.Read
 
 		if err == nil {
 			c.logger.Debug("GET result: %s", http.StatusText(resp.StatusCode))
-			switch resp.StatusCode {
-			case http.StatusOK, http.StatusNonAuthoritativeInfo, http.StatusNoContent:
+			if resp.StatusCode < 500 {
 				return resp.Body, resp.StatusCode, nil
 			}
 			resp.Body.Close()


### PR DESCRIPTION
The original intention of this code was to retry requests if the remote
server didn't return content. This caused issues for the HTTP-based
providers because they will return a 404 when there is no userdata.
Since the underlying purpose of this retry is to handle transient
errors, it makes sense to only retry if there is a network error or if
the remote system returned a 5xx error.