### PR TITLE
providers: add support for qemu firmware config

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/ignition/internal/providers/gce"
 	"github.com/coreos/ignition/internal/providers/noop"
 	"github.com/coreos/ignition/internal/providers/packet"
+	"github.com/coreos/ignition/internal/providers/qemu"
 	"github.com/coreos/ignition/internal/providers/vmware"
 	"github.com/coreos/ignition/internal/registry"
 
@@ -187,6 +188,10 @@ alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) >
 	configs.Register(Config{
 		name:  "interoute",
 		fetch: noop.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "qemu",
+		fetch: qemu.FetchConfig,
 	})
 }
 

--- a/internal/providers/qemu/qemu.go
+++ b/internal/providers/qemu/qemu.go
@@ -1,0 +1,51 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The QEMU provider fetches a local configuration from the firmware config
+// interface (opt/com.coreos/config).
+
+package qemu
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/util"
+)
+
+const (
+	firmwareConfigPath = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
+)
+
+func FetchConfig(logger *log.Logger, client *util.HttpClient) (types.Config, report.Report, error) {
+	err := logger.LogCmd(exec.Command("modprobe", "qemu_fw_cfg"), "loading QEMU firmware config module")
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+
+	data, err := ioutil.ReadFile(firmwareConfigPath)
+	if os.IsNotExist(err) {
+		logger.Info("QEMU firmware config was not found. Ignoring...")
+	} else if err != nil {
+		logger.Err("couldn't read QEMU firmware config: %v", err)
+		return types.Config{}, report.Report{}, err
+	}
+
+	return config.Parse(data)
+}


### PR DESCRIPTION
The config can be passed to QEMU by using the following:

    -fw_cfg name=opt/com.coreos/config,file=config.ignition