### PR TITLE
providers: restore the file provider, add file oem

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/ignition/internal/providers/azure"
 	"github.com/coreos/ignition/internal/providers/cmdline"
 	"github.com/coreos/ignition/internal/providers/ec2"
+	"github.com/coreos/ignition/internal/providers/file"
 	"github.com/coreos/ignition/internal/providers/gce"
 	"github.com/coreos/ignition/internal/providers/noop"
 	"github.com/coreos/ignition/internal/providers/packet"
@@ -192,6 +193,10 @@ alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) >
 	configs.Register(Config{
 		name:  "qemu",
 		fetch: qemu.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "file",
+		fetch: file.FetchConfig,
 	})
 }
 

--- a/internal/providers/file/file.go
+++ b/internal/providers/file/file.go
@@ -1,0 +1,39 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"io/ioutil"
+
+	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/util"
+)
+
+const (
+	name     = "file"
+	fileName = "config.json"
+)
+
+func FetchConfig(logger *log.Logger, _ *util.HttpClient) (types.Config, report.Report, error) {
+	rawConfig, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		logger.Err("couldn't read config %q: %v", fileName, err)
+		return types.Config{}, report.Report{}, err
+	}
+	return config.Parse(rawConfig)
+}


### PR DESCRIPTION
Useful for ad-hoc tests using a local config.json.