### PR TITLE
exec/util: create and use stable device path aliases

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -93,6 +93,33 @@ func (s stage) waitOnDevices(devs []string, ctxt string) error {
 	); err != nil {
 		return fmt.Errorf("failed to wait on %s devs: %v", ctxt, err)
 	}
+
+	return nil
+}
+
+// createDeviceAliases creates device aliases for every device in devs.
+func (s stage) createDeviceAliases(devs []string) error {
+	for _, dev := range devs {
+		target, err := util.CreateDeviceAlias(dev)
+		if err != nil {
+			return fmt.Errorf("failed to create device alias for %q: %v", dev, err)
+		}
+		s.Logger.Info("created device alias for %q: %q -> %q", dev, util.DeviceAlias(dev), target)
+	}
+
+	return nil
+}
+
+// waitOnDevicesAndCreateAliases simply wraps waitOnDevices and createDeviceAliases.
+func (s stage) waitOnDevicesAndCreateAliases(devs []string, ctxt string) error {
+	if err := s.waitOnDevices(devs, ctxt); err != nil {
+		return err
+	}
+
+	if err := s.createDeviceAliases(devs); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -109,15 +136,17 @@ func (s stage) createPartitions(config types.Config) error {
 		devs = append(devs, string(disk.Device))
 	}
 
-	if err := s.waitOnDevices(devs, "disks"); err != nil {
+	if err := s.waitOnDevicesAndCreateAliases(devs, "disks"); err != nil {
 		return err
 	}
 
 	for _, dev := range config.Storage.Disks {
+		devAlias := util.DeviceAlias(string(dev.Device))
+
 		err := s.Logger.LogOp(func() error {
-			op := sgdisk.Begin(s.Logger, string(dev.Device))
+			op := sgdisk.Begin(s.Logger, devAlias)
 			if dev.WipeTable {
-				s.Logger.Info("wiping partition table requested on %q", dev.Device)
+				s.Logger.Info("wiping partition table requested on %q", devAlias)
 				op.WipeTable(true)
 			}
 
@@ -135,7 +164,7 @@ func (s stage) createPartitions(config types.Config) error {
 				return fmt.Errorf("commit failure: %v", err)
 			}
 			return nil
-		}, "partitioning %q", dev.Device)
+		}, "partitioning %q", devAlias)
 		if err != nil {
 			return err
 		}
@@ -159,7 +188,7 @@ func (s stage) createRaids(config types.Config) error {
 		}
 	}
 
-	if err := s.waitOnDevices(devs, "raids"); err != nil {
+	if err := s.waitOnDevicesAndCreateAliases(devs, "raids"); err != nil {
 		return err
 	}
 
@@ -179,7 +208,7 @@ func (s stage) createRaids(config types.Config) error {
 		}
 
 		for _, dev := range md.Devices {
-			args = append(args, string(dev))
+			args = append(args, util.DeviceAlias(string(dev)))
 		}
 
 		if err := s.Logger.LogCmd(
@@ -213,7 +242,7 @@ func (s stage) createFilesystems(config types.Config) error {
 		devs = append(devs, string(fs.Device))
 	}
 
-	if err := s.waitOnDevices(devs, "filesystems"); err != nil {
+	if err := s.waitOnDevicesAndCreateAliases(devs, "filesystems"); err != nil {
 		return err
 	}
 
@@ -254,11 +283,12 @@ func (s stage) createFilesystem(fs types.FilesystemMount) error {
 		return fmt.Errorf("unsupported filesystem format: %q", fs.Format)
 	}
 
-	args = append(args, string(fs.Device))
+	devAlias := util.DeviceAlias(string(fs.Device))
+	args = append(args, devAlias)
 	if err := s.Logger.LogCmd(
 		exec.Command(mkfs, args...),
 		"creating %q filesystem on %q",
-		fs.Format, string(fs.Device),
+		fs.Format, devAlias,
 	); err != nil {
 		return fmt.Errorf("mkfs failed: %v", err)
 	}

--- a/internal/exec/util/device_alias.go
+++ b/internal/exec/util/device_alias.go
@@ -1,0 +1,55 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const deviceAliasDir = "/dev_aliases"
+
+// DeviceAlias returns the aliased form of the supplied path.
+// Note device paths in ignition are always absolute.
+func DeviceAlias(path string) string {
+	return filepath.Join(deviceAliasDir, filepath.Clean(path))
+}
+
+// CreateDeviceAlias creates a device alias for the supplied path.
+// On success the canonicalized path used as the alias target is returned.
+func CreateDeviceAlias(path string) (string, error) {
+	target, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+
+	alias := DeviceAlias(path)
+
+	if err := os.Remove(alias); err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		if err = os.MkdirAll(filepath.Dir(alias), 0750); err != nil {
+			return "", err
+		}
+	}
+
+	if err = os.Symlink(target, alias); err != nil {
+		return "", err
+	}
+
+	return target, nil
+}


### PR DESCRIPTION
Because ignition and the utilities it invokes may race with udev
manipulating symlinks in response to actions performed on the devices,
create stable aliases for the user-provided device paths which are
derived from the supplied paths for convenient correlation within the
logs.

We could simply resolve the symlinks to the bare device paths and use
those, but we execute external utilities against the devices and it's
preferable to have the potential errors printed by those utilities
include device paths resembling what the user provided.

The aliases are logged when created, producing logs like:
Aug 24 17:40:03 localhost ignition[9655]: disks: createFilesystems: created device alias for "/dev/disk/by-partlabel/FOO": "/dev_aliases/dev/disk/by-partlabel/FOO" -> "/dev/sdb1"