### PR TITLE
systemd: fix potential deadlock in WaitOnDevices

### DIFF
--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -31,7 +31,7 @@ func WaitOnDevices(devs []string, stage string) error {
 	results := map[string]chan string{}
 	for _, dev := range devs {
 		unitName := unit.UnitNamePathEscape(dev + ".device")
-		results[unitName] = make(chan string)
+		results[unitName] = make(chan string, 1)
 
 		if _, err = conn.StartUnit(unitName, "replace", results[unitName]); err != nil {
 			return fmt.Errorf("failed starting device unit %s: %v", unitName, err)


### PR DESCRIPTION
When waiting on multiple devices multiple result channels are supplied
to go-systemd.  These channels are then consumed from serially in the
order they were submitted.  If we get unlucky and
systemd/dbus/go-systemd come back with results in a different order,
then go-systemd will get deadlocked in jobComplete() because the channel
is unbuffered and we're not receiving on the other end.

This change simply makes the result channels buffered so jobComplete()
doesn't block on us while we wait on a different channel.