### PR TITLE
exec/engine: allow commandline options to override

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -21,6 +21,8 @@ The configuration must be passed to Ignition through the designated data source.
 }
 ```
 
+This data source can be overriden by specifying a configuration URL via the kernel command-line options.
+
 ## Troubleshooting
 
 ### Gathering Logs

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coreos/ignition/internal/exec/util"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers"
+	"github.com/coreos/ignition/internal/providers/cmdline"
 	"github.com/coreos/ignition/internal/resource"
 
 	"golang.org/x/net/context"
@@ -114,11 +115,18 @@ func (e Engine) acquireConfig() (cfg types.Config, err error) {
 	return
 }
 
-// fetchProviderConfig returns the configuration from the engine's provider
-// returning an error if the provider is unavailable. This will also render the
-// config (see renderConfig) before returning.
+// fetchProviderConfig returns the externally-provided configuration. It first
+// checks to see if the command-line option is present. If so, it uses that
+// source for the configuration. If the command-line option is not present, it
+// check's the engine's provider. An error is returned if the provider is
+// unavailable. This will also render the config (see renderConfig) before
+// returning.
 func (e Engine) fetchProviderConfig() (types.Config, error) {
-	cfg, r, err := e.FetchFunc(e.Logger, &e.client)
+	cfg, r, err := cmdline.FetchConfig(e.Logger, &e.client)
+	if err == providers.ErrNoProvider {
+		cfg, r, err = e.FetchFunc(e.Logger, &e.client)
+	}
+
 	e.logReport(r)
 	if err != nil {
 		return types.Config{}, err

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -20,7 +20,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/azure"
-	"github.com/coreos/ignition/internal/providers/cmdline"
 	"github.com/coreos/ignition/internal/providers/digitalocean"
 	"github.com/coreos/ignition/internal/providers/ec2"
 	"github.com/coreos/ignition/internal/providers/file"
@@ -153,7 +152,7 @@ alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) >
 	})
 	configs.Register(Config{
 		name:  "pxe",
-		fetch: cmdline.FetchConfig,
+		fetch: noop.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "rackspace",

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -38,8 +39,12 @@ const (
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
 	url, err := readCmdline(logger)
-	if err != nil || url == nil {
+	if err != nil {
 		return types.Config{}, report.Report{}, err
+	}
+
+	if url == nil {
+		return types.Config{}, report.Report{}, providers.ErrNoProvider
 	}
 
 	data, err := resource.FetchConfig(logger, client, context.Background(), *url)

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -43,9 +42,9 @@ func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config,
 		return types.Config{}, report.Report{}, err
 	}
 
-	data := resource.FetchConfig(logger, client, context.Background(), *url)
-	if data == nil {
-		return types.Config{}, report.Report{}, providers.ErrNoProvider
+	data, err := resource.FetchConfig(logger, client, context.Background(), *url)
+	if err != nil {
+		return types.Config{}, report.Report{}, err
 	}
 
 	return util.ParseConfig(logger, data)

--- a/internal/providers/digitalocean/digitalocean.go
+++ b/internal/providers/digitalocean/digitalocean.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -39,9 +38,9 @@ var (
 )
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
-	data := resource.FetchConfig(logger, client, context.Background(), userdataUrl)
-	if data == nil {
-		return types.Config{}, report.Report{}, providers.ErrNoProvider
+	data, err := resource.FetchConfig(logger, client, context.Background(), userdataUrl)
+	if err != nil {
+		return types.Config{}, report.Report{}, err
 	}
 
 	return util.ParseConfig(logger, data)

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -39,9 +38,9 @@ var (
 )
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
-	data := resource.FetchConfig(logger, client, context.Background(), userdataUrl)
-	if data == nil {
-		return types.Config{}, report.Report{}, providers.ErrNoProvider
+	data, err := resource.FetchConfig(logger, client, context.Background(), userdataUrl)
+	if err != nil {
+		return types.Config{}, report.Report{}, err
 	}
 
 	return util.ParseConfig(logger, data)

--- a/internal/providers/gce/gce.go
+++ b/internal/providers/gce/gce.go
@@ -24,7 +24,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -41,9 +40,9 @@ var (
 )
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
-	data := resource.FetchConfigWithHeader(logger, client, context.Background(), userdataUrl, metadataHeader)
-	if data == nil {
-		return types.Config{}, report.Report{}, providers.ErrNoProvider
+	data, err := resource.FetchConfigWithHeader(logger, client, context.Background(), userdataUrl, metadataHeader)
+	if err != nil {
+		return types.Config{}, report.Report{}, err
 	}
 
 	return util.ParseConfig(logger, data)

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -126,5 +126,5 @@ func fetchConfigFromConfigDrive(logger *log.Logger, ctx context.Context) ([]byte
 }
 
 func fetchConfigFromMetadataService(logger *log.Logger, client *resource.HttpClient, ctx context.Context) ([]byte, error) {
-	return resource.FetchConfig(logger, client, context.Background(), metadataServiceUrl), nil
+	return resource.FetchConfig(logger, client, context.Background(), metadataServiceUrl)
 }

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -43,7 +42,7 @@ func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config,
 	// with the default headers. For now, just do a regular fetch.
 	data, err := resource.Fetch(logger, client, context.Background(), userdataUrl)
 	if err != nil {
-		return types.Config{}, report.Report{}, providers.ErrNoProvider
+		return types.Config{}, report.Report{}, err
 	}
 
 	return util.ParseConfig(logger, data)

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -47,7 +47,7 @@ const (
 )
 
 // FetchConfig fetches a raw config from the provided URL.
-func FetchConfig(l *log.Logger, c *HttpClient, ctx context.Context, u url.URL) []byte {
+func FetchConfig(l *log.Logger, c *HttpClient, ctx context.Context, u url.URL) ([]byte, error) {
 	return FetchConfigWithHeader(l, c, ctx, u, http.Header{})
 }
 
@@ -55,7 +55,7 @@ func FetchConfig(l *log.Logger, c *HttpClient, ctx context.Context, u url.URL) [
 // the response body on success or nil on failure. The HTTP response must be
 // OK, otherwise an empty (v.s. nil) config is returned. The provided headers
 // are merged with a set of default headers.
-func FetchConfigWithHeader(l *log.Logger, c *HttpClient, ctx context.Context, u url.URL, h http.Header) []byte {
+func FetchConfigWithHeader(l *log.Logger, c *HttpClient, ctx context.Context, u url.URL, h http.Header) ([]byte, error) {
 	header := http.Header{
 		"Accept-Encoding": []string{"identity"},
 		"Accept":          []string{"application/vnd.coreos.ignition+json; version=2.0.0, application/vnd.coreos.ignition+json; version=1; q=0.5, */*; q=0.1"},
@@ -70,11 +70,11 @@ func FetchConfigWithHeader(l *log.Logger, c *HttpClient, ctx context.Context, u 
 	data, err := FetchWithHeader(l, c, ctx, u, header)
 	switch err {
 	case nil:
-		return data
+		return data, nil
 	case ErrNotFound:
-		return []byte{}
+		return []byte{}, nil
 	default:
-		return nil
+		return nil, err
 	}
 }
 


### PR DESCRIPTION
This allows the `coreos.config.url` command-line option to override the
specified provider.