### PR TITLE
providers/file: rename config file

### DIFF
--- a/internal/providers/file/file.go
+++ b/internal/providers/file/file.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	name     = "file"
-	fileName = "config.json"
+	fileName = "config.ign"
 )
 
 func FetchConfig(logger *log.Logger, _ *resource.HttpClient) (types.Config, report.Report, error) {


### PR DESCRIPTION
The 'ign' extension should be used for Ignition configs, per the IANA
registration.