### PR TITLE
types: unit validator

### DIFF
--- a/config/types/unit_test.go
+++ b/config/types/unit_test.go
@@ -22,6 +22,44 @@ import (
 	"github.com/coreos/ignition/config/validate/report"
 )
 
+func TestSystemdUnitValidate(t *testing.T) {
+	type in struct {
+		unit SystemdUnit
+	}
+	type out struct {
+		err error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{unit: SystemdUnit{Contents: "[Foo]\nQux=Bar"}},
+			out: out{err: nil},
+		},
+		{
+			in:  in{unit: SystemdUnit{Contents: "[Foo"}},
+			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+		},
+		{
+			in:  in{unit: SystemdUnit{Contents: ""}},
+			out: out{err: errors.New("invalid or empty unit content")},
+		},
+		{
+			in:  in{unit: SystemdUnit{Contents: "", DropIns: []SystemdUnitDropIn{{}}}},
+			out: out{err: nil},
+		},
+	}
+
+	for i, test := range tests {
+		err := test.in.unit.Validate()
+		if !reflect.DeepEqual(report.ReportFromError(test.out.err, report.EntryError), err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+	}
+}
+
 func TestSystemdUnitNameValidate(t *testing.T) {
 	type in struct {
 		unit SystemdUnitName
@@ -45,6 +83,40 @@ func TestSystemdUnitNameValidate(t *testing.T) {
 		{
 			in:  in{unit: SystemdUnitName("test.blah")},
 			out: out{err: errors.New("invalid systemd unit extension")},
+		},
+	}
+
+	for i, test := range tests {
+		err := test.in.unit.Validate()
+		if !reflect.DeepEqual(report.ReportFromError(test.out.err, report.EntryError), err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+	}
+}
+
+func TestSystemdUnitDropInValidate(t *testing.T) {
+	type in struct {
+		unit SystemdUnitDropIn
+	}
+	type out struct {
+		err error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{unit: SystemdUnitDropIn{Contents: "[Foo]\nQux=Bar"}},
+			out: out{err: nil},
+		},
+		{
+			in:  in{unit: SystemdUnitDropIn{Contents: "[Foo"}},
+			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+		},
+		{
+			in:  in{unit: SystemdUnitDropIn{Contents: ""}},
+			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 
@@ -83,6 +155,40 @@ func TestNetworkdUnitNameValidate(t *testing.T) {
 		{
 			in:  in{unit: NetworkdUnitName("test.blah")},
 			out: out{err: errors.New("invalid networkd unit extension")},
+		},
+	}
+
+	for i, test := range tests {
+		err := test.in.unit.Validate()
+		if !reflect.DeepEqual(report.ReportFromError(test.out.err, report.EntryError), err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+	}
+}
+
+func TestNetworkdUnitValidate(t *testing.T) {
+	type in struct {
+		unit NetworkdUnit
+	}
+	type out struct {
+		err error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{unit: NetworkdUnit{Contents: "[Foo]\nQux=Bar"}},
+			out: out{err: nil},
+		},
+		{
+			in:  in{unit: NetworkdUnit{Contents: "[Foo"}},
+			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+		},
+		{
+			in:  in{unit: NetworkdUnit{Contents: ""}},
+			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 

--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -93,9 +93,16 @@ func TestValidate(t *testing.T) {
 		{
 			in: in{cfg: Config{
 				Ignition: Ignition{Version: IgnitionVersion{Major: 2}},
-				Systemd:  Systemd{Units: []SystemdUnit{{Name: "foo.bar"}}},
+				Systemd:  Systemd{Units: []SystemdUnit{{Name: "foo.bar", Contents: "[Foo]\nfoo=qux"}}},
 			}},
 			out: out{err: errors.New("invalid systemd unit extension")},
+		},
+		{
+			in: in{cfg: Config{
+				Ignition: Ignition{Version: IgnitionVersion{Major: 2}},
+				Networkd: Networkd{Units: []NetworkdUnit{{Name: "foo.link", Contents: ""}}},
+			}},
+			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 

--- a/config/vendor.manifest
+++ b/config/vendor.manifest
@@ -4,3 +4,4 @@ github.com/ajeddeloh/go-json                           73d058cf8437a1989030afe57
 github.com/coreos/go-semver                            294930c1e79c64e7dbe360054274fdad492c8cf5
 github.com/vincent-petithory/dataurl                   9a301d65acbb728fcc3ace14f45f511a4cfeea9c
 go4.org/errorutil                                      03efcb870d84809319ea509714dd6d19a1498483
+github.com/coreos/go-systemd/unit                      7c9533367ef925dc1078d75e5b7141e10da2c4e8

--- a/config/vendor/github.com/coreos/go-systemd/LICENSE
+++ b/config/vendor/github.com/coreos/go-systemd/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/config/vendor/github.com/coreos/go-systemd/unit/deserialize.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/deserialize.go
@@ -1,0 +1,276 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+)
+
+const (
+	// SYSTEMD_LINE_MAX mimics the maximum line length that systemd can use.
+	// On typical systemd platforms (i.e. modern Linux), this will most
+	// commonly be 2048, so let's use that as a sanity check.
+	// Technically, we should probably pull this at runtime:
+	//    SYSTEMD_LINE_MAX = int(C.sysconf(C.__SC_LINE_MAX))
+	// but this would introduce an (unfortunate) dependency on cgo
+	SYSTEMD_LINE_MAX = 2048
+
+	// characters that systemd considers indicate a newline
+	SYSTEMD_NEWLINE = "\r\n"
+)
+
+var (
+	ErrLineTooLong = fmt.Errorf("line too long (max %d bytes)", SYSTEMD_LINE_MAX)
+)
+
+// Deserialize parses a systemd unit file into a list of UnitOption objects.
+func Deserialize(f io.Reader) (opts []*UnitOption, err error) {
+	lexer, optchan, errchan := newLexer(f)
+	go lexer.lex()
+
+	for opt := range optchan {
+		opts = append(opts, &(*opt))
+	}
+
+	err = <-errchan
+	return opts, err
+}
+
+func newLexer(f io.Reader) (*lexer, <-chan *UnitOption, <-chan error) {
+	optchan := make(chan *UnitOption)
+	errchan := make(chan error, 1)
+	buf := bufio.NewReader(f)
+
+	return &lexer{buf, optchan, errchan, ""}, optchan, errchan
+}
+
+type lexer struct {
+	buf     *bufio.Reader
+	optchan chan *UnitOption
+	errchan chan error
+	section string
+}
+
+func (l *lexer) lex() {
+	var err error
+	defer func() {
+		close(l.optchan)
+		close(l.errchan)
+	}()
+	next := l.lexNextSection
+	for next != nil {
+		if l.buf.Buffered() >= SYSTEMD_LINE_MAX {
+			// systemd truncates lines longer than LINE_MAX
+			// https://bugs.freedesktop.org/show_bug.cgi?id=85308
+			// Rather than allowing this to pass silently, let's
+			// explicitly gate people from encountering this
+			line, err := l.buf.Peek(SYSTEMD_LINE_MAX)
+			if err != nil {
+				l.errchan <- err
+				return
+			}
+			if bytes.IndexAny(line, SYSTEMD_NEWLINE) == -1 {
+				l.errchan <- ErrLineTooLong
+				return
+			}
+		}
+
+		next, err = next()
+		if err != nil {
+			l.errchan <- err
+			return
+		}
+	}
+}
+
+type lexStep func() (lexStep, error)
+
+func (l *lexer) lexSectionName() (lexStep, error) {
+	sec, err := l.buf.ReadBytes(']')
+	if err != nil {
+		return nil, errors.New("unable to find end of section")
+	}
+
+	return l.lexSectionSuffixFunc(string(sec[:len(sec)-1])), nil
+}
+
+func (l *lexer) lexSectionSuffixFunc(section string) lexStep {
+	return func() (lexStep, error) {
+		garbage, _, err := l.toEOL()
+		if err != nil {
+			return nil, err
+		}
+
+		garbage = bytes.TrimSpace(garbage)
+		if len(garbage) > 0 {
+			return nil, fmt.Errorf("found garbage after section name %s: %v", l.section, garbage)
+		}
+
+		return l.lexNextSectionOrOptionFunc(section), nil
+	}
+}
+
+func (l *lexer) ignoreLineFunc(next lexStep) lexStep {
+	return func() (lexStep, error) {
+		for {
+			line, _, err := l.toEOL()
+			if err != nil {
+				return nil, err
+			}
+
+			line = bytes.TrimSuffix(line, []byte{' '})
+
+			// lack of continuation means this line has been exhausted
+			if !bytes.HasSuffix(line, []byte{'\\'}) {
+				break
+			}
+		}
+
+		// reached end of buffer, safe to exit
+		return next, nil
+	}
+}
+
+func (l *lexer) lexNextSection() (lexStep, error) {
+	r, _, err := l.buf.ReadRune()
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		return nil, err
+	}
+
+	if r == '[' {
+		return l.lexSectionName, nil
+	} else if isComment(r) {
+		return l.ignoreLineFunc(l.lexNextSection), nil
+	}
+
+	return l.lexNextSection, nil
+}
+
+func (l *lexer) lexNextSectionOrOptionFunc(section string) lexStep {
+	return func() (lexStep, error) {
+		r, _, err := l.buf.ReadRune()
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return nil, err
+		}
+
+		if unicode.IsSpace(r) {
+			return l.lexNextSectionOrOptionFunc(section), nil
+		} else if r == '[' {
+			return l.lexSectionName, nil
+		} else if isComment(r) {
+			return l.ignoreLineFunc(l.lexNextSectionOrOptionFunc(section)), nil
+		}
+
+		l.buf.UnreadRune()
+		return l.lexOptionNameFunc(section), nil
+	}
+}
+
+func (l *lexer) lexOptionNameFunc(section string) lexStep {
+	return func() (lexStep, error) {
+		var partial bytes.Buffer
+		for {
+			r, _, err := l.buf.ReadRune()
+			if err != nil {
+				return nil, err
+			}
+
+			if r == '\n' || r == '\r' {
+				return nil, errors.New("unexpected newline encountered while parsing option name")
+			}
+
+			if r == '=' {
+				break
+			}
+
+			partial.WriteRune(r)
+		}
+
+		name := strings.TrimSpace(partial.String())
+		return l.lexOptionValueFunc(section, name, bytes.Buffer{}), nil
+	}
+}
+
+func (l *lexer) lexOptionValueFunc(section, name string, partial bytes.Buffer) lexStep {
+	return func() (lexStep, error) {
+		for {
+			line, eof, err := l.toEOL()
+			if err != nil {
+				return nil, err
+			}
+
+			if len(bytes.TrimSpace(line)) == 0 {
+				break
+			}
+
+			partial.Write(line)
+
+			// lack of continuation means this value has been exhausted
+			idx := bytes.LastIndex(line, []byte{'\\'})
+			if idx == -1 || idx != (len(line)-1) {
+				break
+			}
+
+			if !eof {
+				partial.WriteRune('\n')
+			}
+
+			return l.lexOptionValueFunc(section, name, partial), nil
+		}
+
+		val := partial.String()
+		if strings.HasSuffix(val, "\n") {
+			// A newline was added to the end, so the file didn't end with a backslash.
+			// => Keep the newline
+			val = strings.TrimSpace(val) + "\n"
+		} else {
+			val = strings.TrimSpace(val)
+		}
+		l.optchan <- &UnitOption{Section: section, Name: name, Value: val}
+
+		return l.lexNextSectionOrOptionFunc(section), nil
+	}
+}
+
+// toEOL reads until the end-of-line or end-of-file.
+// Returns (data, EOFfound, error)
+func (l *lexer) toEOL() ([]byte, bool, error) {
+	line, err := l.buf.ReadBytes('\n')
+	// ignore EOF here since it's roughly equivalent to EOL
+	if err != nil && err != io.EOF {
+		return nil, false, err
+	}
+
+	line = bytes.TrimSuffix(line, []byte{'\r'})
+	line = bytes.TrimSuffix(line, []byte{'\n'})
+
+	return line, err == io.EOF, nil
+}
+
+func isComment(r rune) bool {
+	return r == '#' || r == ';'
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/deserialize_test.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/deserialize_test.go
@@ -1,0 +1,381 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestDeserialize(t *testing.T) {
+	tests := []struct {
+		input  []byte
+		output []*UnitOption
+	}{
+		// multiple options underneath a section
+		{
+			[]byte(`[Unit]
+Description=Foo
+Description=Bar
+Requires=baz.service
+After=baz.service
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Unit", "Description", "Bar"},
+				&UnitOption{"Unit", "Requires", "baz.service"},
+				&UnitOption{"Unit", "After", "baz.service"},
+			},
+		},
+
+		// multiple sections
+		{
+			[]byte(`[Unit]
+Description=Foo
+
+[Service]
+ExecStart=/usr/bin/sleep infinity
+
+[X-Third-Party]
+Pants=on
+
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Service", "ExecStart", "/usr/bin/sleep infinity"},
+				&UnitOption{"X-Third-Party", "Pants", "on"},
+			},
+		},
+
+		// multiple sections with no options
+		{
+			[]byte(`[Unit]
+[Service]
+[X-Third-Party]
+`),
+			[]*UnitOption{},
+		},
+
+		// multiple values not special-cased
+		{
+			[]byte(`[Service]
+Environment= "FOO=BAR" "BAZ=QUX"
+`),
+			[]*UnitOption{
+				&UnitOption{"Service", "Environment", "\"FOO=BAR\" \"BAZ=QUX\""},
+			},
+		},
+
+		// line continuations unmodified
+		{
+			[]byte(`[Unit]
+Description= Unnecessarily wrapped \
+    words here
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", `Unnecessarily wrapped \
+    words here`},
+			},
+		},
+
+		// comments ignored
+		{
+			[]byte(`; comment alpha
+# comment bravo
+[Unit]
+; comment charlie
+# comment delta
+#Description=Foo
+Description=Bar
+; comment echo
+# comment foxtrot
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Bar"},
+			},
+		},
+
+		// apparent comment lines inside of line continuations not ignored
+		{
+			[]byte(`[Unit]
+Description=Bar\
+# comment alpha
+
+Description=Bar\
+# comment bravo \
+Baz
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Bar\\\n# comment alpha"},
+				&UnitOption{"Unit", "Description", "Bar\\\n# comment bravo \\\nBaz"},
+			},
+		},
+
+		// options outside of sections are ignored
+		{
+			[]byte(`Description=Foo
+[Unit]
+Description=Bar
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Bar"},
+			},
+		},
+
+		// garbage outside of sections are ignored
+		{
+			[]byte(`<<<<<<<<
+[Unit]
+Description=Bar
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Bar"},
+			},
+		},
+
+		// garbage used as unit option
+		{
+			[]byte(`[Unit]
+<<<<<<<<=Bar
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "<<<<<<<<", "Bar"},
+			},
+		},
+
+		// option name with spaces are valid
+		{
+			[]byte(`[Unit]
+Some Thing = Bar
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Some Thing", "Bar"},
+			},
+		},
+
+		// lack of trailing newline doesn't cause problem for non-continued file
+		{
+			[]byte(`[Unit]
+Description=Bar`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Bar"},
+			},
+		},
+
+		// unit file with continuation but no following line is ok, too
+		{
+			[]byte(`[Unit]
+Description=Bar \`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Bar \\"},
+			},
+		},
+
+		// Assert utf8 characters are preserved
+		{
+			[]byte(`[©]
+µ☃=ÇôrèÕ$`),
+			[]*UnitOption{
+				&UnitOption{"©", "µ☃", "ÇôrèÕ$"},
+			},
+		},
+
+		// whitespace removed around option name
+		{
+			[]byte(`[Unit]
+ Description   =words here
+`),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "words here"},
+			},
+		},
+
+		// whitespace around option value stripped
+		{
+			[]byte(`[Unit]
+Description= words here `),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "words here"},
+			},
+		},
+
+		// whitespace around option value stripped, regardless of continuation
+		{
+			[]byte(`[Unit]
+Description= words here \
+  `),
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "words here \\\n"},
+			},
+		},
+
+		// backslash not considered continuation if followed by text
+		{
+			[]byte(`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`),
+			[]*UnitOption{
+				&UnitOption{"Service", "ExecStart", `/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"`},
+			},
+		},
+
+		// backslash not considered continuation if followed by whitespace, but still trimmed
+		{
+			[]byte(`[Service]
+ExecStart=/bin/bash echo poof \  `),
+			[]*UnitOption{
+				&UnitOption{"Service", "ExecStart", `/bin/bash echo poof \`},
+			},
+		},
+		// a long unit file line that's just equal to the maximum permitted length
+		{
+			[]byte(`[Service]
+ExecStart=/bin/bash -c "echo ................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."`),
+			[]*UnitOption{
+				&UnitOption{"Service", "ExecStart", `/bin/bash -c "echo ................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."`},
+			},
+		},
+		// the same, but with a trailing newline
+		{
+			[]byte(`[Service]
+ExecStart=/bin/bash -c "echo ................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."
+Option=value
+`),
+			[]*UnitOption{
+				&UnitOption{"Service", "ExecStart", `/bin/bash -c "echo ................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."`},
+				&UnitOption{"Service", "Option", "value"},
+			},
+		},
+	}
+
+	assert := func(expect, output []*UnitOption) error {
+		if len(expect) != len(output) {
+			return fmt.Errorf("expected %d items, got %d", len(expect), len(output))
+		}
+
+		for i, _ := range expect {
+			if !reflect.DeepEqual(expect[i], output[i]) {
+				return fmt.Errorf("item %d: expected %v, got %v", i, expect[i], output[i])
+			}
+		}
+
+		return nil
+	}
+
+	for i, tt := range tests {
+		output, err := Deserialize(bytes.NewReader(tt.input))
+		if err != nil {
+			t.Errorf("case %d: unexpected error parsing unit: %v", i, err)
+			continue
+		}
+
+		err = assert(tt.output, output)
+		if err != nil {
+			t.Errorf("case %d: %v", i, err)
+			t.Log("Expected options:")
+			logUnitOptionSlice(t, tt.output)
+			t.Log("Actual options:")
+			logUnitOptionSlice(t, output)
+		}
+	}
+}
+
+func TestDeserializeFail(t *testing.T) {
+	tests := [][]byte{
+		// malformed section header
+		[]byte(`[Unit
+Description=Foo
+`),
+
+		// garbage following section header
+		[]byte(`[Unit] pants
+Description=Foo
+`),
+
+		// option without value
+		[]byte(`[Unit]
+Description
+`),
+
+		// garbage inside of section
+		[]byte(`[Unit]
+<<<<<<
+Description=Foo
+`),
+	}
+
+	for i, tt := range tests {
+		output, err := Deserialize(bytes.NewReader(tt))
+		if err == nil {
+			t.Errorf("case %d: unexpected nil error", i)
+			t.Log("Output:")
+			logUnitOptionSlice(t, output)
+		}
+	}
+}
+
+func logUnitOptionSlice(t *testing.T, opts []*UnitOption) {
+	for idx, opt := range opts {
+		t.Logf("%d: %v", idx, opt)
+	}
+}
+
+func TestDeserializeLineTooLong(t *testing.T) {
+	tests := [][]byte{
+		// section header that's far too long
+		[]byte(`[Seeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeervice]
+`),
+		// sane-looking unit file with a line just greater than the maximum allowed (currently, 2048)
+		[]byte(`[Service]
+ExecStart=/bin/bash -c "echo ..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."
+`),
+		// sane-looking unit file with option value way too long
+		[]byte(`
+# test unit file
+
+[Service]
+ExecStartPre=-/usr/bin/docker rm %p
+ExecStartPre=-/usr/bin/docker pull busybox
+ExecStart=/usr/bin/docker run --rm --name %p --net=host \
+  -e "test=1123t" \
+  -e "test=1123t" \
+  -e "fiz=1123t" \
+  -e "buz=1123t" \
+  -e "FOO=BARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBABARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARRBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBAR"BARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBABARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARRBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBARBAR" \
+  busybox sleep 10
+ExecStop=-/usr/bin/docker kill %p
+SyslogIdentifier=busybox
+Restart=always
+RestartSec=10s
+`),
+		// single arbitrary line that's way too long
+		[]byte(`arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 character arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 character arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 character arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 character arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters arbitrary and extraordinarily long line that is far greater than 2048 characters`),
+		// sane-looking unit file with option name way too long
+		[]byte(`[Service]
+ExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStartExecStart=/bin/true
+`),
+	}
+
+	for i, tt := range tests {
+		output, err := Deserialize(bytes.NewReader(tt))
+		if err != ErrLineTooLong {
+			t.Errorf("case %d: unexpected err: %v", i, err)
+			t.Log("Output:")
+			logUnitOptionSlice(t, output)
+		}
+	}
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/end_to_end_test.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/end_to_end_test.go
@@ -1,0 +1,88 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestDeserializeAndReserialize(t *testing.T) {
+	tests := []struct {
+		in   string
+		wout string
+	}{
+		{
+			`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`,
+			`[Service]
+ExecStart=/bin/bash -c "while true; do echo \"ping\"; sleep 1; done"
+`},
+		{
+			`[Unit]
+Description= Unnecessarily wrapped \
+    words here`,
+			`[Unit]
+Description=Unnecessarily wrapped \
+    words here
+`,
+		},
+		{
+			`[Unit]
+Description=Demo \
+
+Requires=docker.service
+`,
+			`[Unit]
+Description=Demo \
+
+Requires=docker.service
+`,
+		},
+		{
+			`; comment alpha
+# comment bravo
+[Unit]
+; comment charlie
+# comment delta
+#Description=Foo
+Description=Bar
+; comment echo
+# comment foxtrot
+`,
+			`[Unit]
+Description=Bar
+`},
+	}
+	for i, tt := range tests {
+		ds, err := Deserialize(bytes.NewBufferString(tt.in))
+		if err != nil {
+			t.Errorf("case %d: unexpected error parsing unit: %v", i, err)
+			continue
+		}
+		out, err := ioutil.ReadAll(Serialize(ds))
+		if err != nil {
+			t.Errorf("case %d: unexpected error serializing unit: %v", i, err)
+			continue
+		}
+		if g := string(out); g != tt.wout {
+			t.Errorf("case %d: incorrect output", i)
+			t.Logf("Expected:\n%#v", tt.wout)
+			t.Logf("Actual:\n%#v", g)
+		}
+	}
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/escape.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/escape.go
@@ -1,0 +1,116 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements systemd-escape [--unescape] [--path]
+
+package unit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	allowed = `:_.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`
+)
+
+// If isPath is true:
+//   We remove redundant '/'s, the leading '/', and trailing '/'.
+//   If the result is empty, a '/' is inserted.
+//
+// We always:
+//  Replace the following characters with `\x%x`:
+//   Leading `.`
+//   `-`, `\`, and anything not in this set: `:-_.\[0-9a-zA-Z]`
+//  Replace '/' with '-'.
+func escape(unescaped string, isPath bool) string {
+	e := []byte{}
+	inSlashes := false
+	start := true
+	for i := 0; i < len(unescaped); i++ {
+		c := unescaped[i]
+		if isPath {
+			if c == '/' {
+				inSlashes = true
+				continue
+			} else if inSlashes {
+				inSlashes = false
+				if !start {
+					e = append(e, '-')
+				}
+			}
+		}
+
+		if c == '/' {
+			e = append(e, '-')
+		} else if start && c == '.' || strings.IndexByte(allowed, c) == -1 {
+			e = append(e, []byte(fmt.Sprintf(`\x%x`, c))...)
+		} else {
+			e = append(e, c)
+		}
+		start = false
+	}
+	if isPath && len(e) == 0 {
+		e = append(e, '-')
+	}
+	return string(e)
+}
+
+// If isPath is true:
+//   We always return a string beginning with '/'.
+//
+// We always:
+//  Replace '-' with '/'.
+//  Replace `\x%x` with the value represented in hex.
+func unescape(escaped string, isPath bool) string {
+	u := []byte{}
+	for i := 0; i < len(escaped); i++ {
+		c := escaped[i]
+		if c == '-' {
+			c = '/'
+		} else if c == '\\' && len(escaped)-i >= 4 && escaped[i+1] == 'x' {
+			n, err := strconv.ParseInt(escaped[i+2:i+4], 16, 8)
+			if err == nil {
+				c = byte(n)
+				i += 3
+			}
+		}
+		u = append(u, c)
+	}
+	if isPath && (len(u) == 0 || u[0] != '/') {
+		u = append([]byte("/"), u...)
+	}
+	return string(u)
+}
+
+// UnitNameEscape escapes a string as `systemd-escape` would
+func UnitNameEscape(unescaped string) string {
+	return escape(unescaped, false)
+}
+
+// UnitNameUnescape unescapes a string as `systemd-escape --unescape` would
+func UnitNameUnescape(escaped string) string {
+	return unescape(escaped, false)
+}
+
+// UnitNamePathEscape escapes a string as `systemd-escape --path` would
+func UnitNamePathEscape(unescaped string) string {
+	return escape(unescaped, true)
+}
+
+// UnitNamePathUnescape unescapes a string as `systemd-escape --path --unescape` would
+func UnitNamePathUnescape(escaped string) string {
+	return unescape(escaped, true)
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/escape_test.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/escape_test.go
@@ -1,0 +1,211 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"testing"
+)
+
+func TestUnitNameEscape(t *testing.T) {
+	tests := []struct {
+		in     string
+		out    string
+		isPath bool
+	}{
+		// turn empty string path into escaped /
+		{
+			in:     "",
+			out:    "-",
+			isPath: true,
+		},
+		// turn redundant ////s into single escaped /
+		{
+			in:     "/////////",
+			out:    "-",
+			isPath: true,
+		},
+		// remove all redundant ////s
+		{
+			in:     "///foo////bar/////tail//////",
+			out:    "foo-bar-tail",
+			isPath: true,
+		},
+		// leave empty string empty
+		{
+			in:     "",
+			out:    "",
+			isPath: false,
+		},
+		// escape leading dot
+		{
+			in:     ".",
+			out:    `\x2e`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     "/.",
+			out:    `\x2e`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     "/////////.",
+			out:    `\x2e`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     "/////////.///////////////",
+			out:    `\x2e`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     ".....",
+			out:    `\x2e....`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     "/.foo/.bar",
+			out:    `\x2efoo-.bar`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     ".foo/.bar",
+			out:    `\x2efoo-.bar`,
+			isPath: true,
+		},
+		// escape leading dot
+		{
+			in:     ".foo/.bar",
+			out:    `\x2efoo-.bar`,
+			isPath: false,
+		},
+		// escape disallowed
+		{
+			in:     `///..\-!#??///`,
+			out:    `---..\x5c\x2d\x21\x23\x3f\x3f---`,
+			isPath: false,
+		},
+		// escape disallowed
+		{
+			in:     `///..\-!#??///`,
+			out:    `\x2e.\x5c\x2d\x21\x23\x3f\x3f`,
+			isPath: true,
+		},
+		// escape real-world example
+		{
+			in:     `user-cloudinit@/var/lib/coreos/vagrant/vagrantfile-user-data.service`,
+			out:    `user\x2dcloudinit\x40-var-lib-coreos-vagrant-vagrantfile\x2duser\x2ddata.service`,
+			isPath: false,
+		},
+	}
+
+	for i, tt := range tests {
+		var s string
+		if tt.isPath {
+			s = UnitNamePathEscape(tt.in)
+		} else {
+			s = UnitNameEscape(tt.in)
+		}
+		if s != tt.out {
+			t.Errorf("case %d: failed escaping %v isPath: %v - expected %v, got %v", i, tt.in, tt.isPath, tt.out, s)
+		}
+	}
+}
+
+func TestUnitNameUnescape(t *testing.T) {
+	tests := []struct {
+		in     string
+		out    string
+		isPath bool
+	}{
+		// turn empty string path into /
+		{
+			in:     "",
+			out:    "/",
+			isPath: true,
+		},
+		// leave empty string empty
+		{
+			in:     "",
+			out:    "",
+			isPath: false,
+		},
+		// turn ////s into
+		{
+			in:     "---------",
+			out:    "/////////",
+			isPath: true,
+		},
+		// unescape hex
+		{
+			in:     `---..\x5c\x2d\x21\x23\x3f\x3f---`,
+			out:    `///..\-!#??///`,
+			isPath: false,
+		},
+		// unescape hex
+		{
+			in:     `\x2e.\x5c\x2d\x21\x23\x3f\x3f`,
+			out:    `/..\-!#??`,
+			isPath: true,
+		},
+		// unescape hex, retain invalids
+		{
+			in:     `\x2e.\x5c\x2d\xaZ\x.o\x21\x23\x3f\x3f`,
+			out:    `/..\-\xaZ\x.o!#??`,
+			isPath: true,
+		},
+		// unescape hex, retain invalids, partial tail
+		{
+			in:     `\x2e.\x5c\x\x2d\xaZ\x.o\x21\x23\x3f\x3f\x3`,
+			out:    `/..\\x-\xaZ\x.o!#??\x3`,
+			isPath: true,
+		},
+		// unescape hex, retain invalids, partial tail
+		{
+			in:     `\x2e.\x5c\x\x2d\xaZ\x.o\x21\x23\x3f\x3f\x`,
+			out:    `/..\\x-\xaZ\x.o!#??\x`,
+			isPath: true,
+		},
+		// unescape hex, retain invalids, partial tail
+		{
+			in:     `\x2e.\x5c\x\x2d\xaZ\x.o\x21\x23\x3f\x3f\`,
+			out:    `/..\\x-\xaZ\x.o!#??\`,
+			isPath: true,
+		},
+		// unescape real-world example
+		{
+			in:     `user\x2dcloudinit\x40-var-lib-coreos-vagrant-vagrantfile\x2duser\x2ddata.service`,
+			out:    `user-cloudinit@/var/lib/coreos/vagrant/vagrantfile-user-data.service`,
+			isPath: false,
+		},
+	}
+
+	for i, tt := range tests {
+		var s string
+		if tt.isPath {
+			s = UnitNamePathUnescape(tt.in)
+		} else {
+			s = UnitNameUnescape(tt.in)
+		}
+		if s != tt.out {
+			t.Errorf("case %d: failed unescaping %v isPath: %v - expected %v, got %v", i, tt.in, tt.isPath, tt.out, s)
+		}
+	}
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/option.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/option.go
@@ -1,0 +1,54 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"fmt"
+)
+
+type UnitOption struct {
+	Section string
+	Name    string
+	Value   string
+}
+
+func NewUnitOption(section, name, value string) *UnitOption {
+	return &UnitOption{Section: section, Name: name, Value: value}
+}
+
+func (uo *UnitOption) String() string {
+	return fmt.Sprintf("{Section: %q, Name: %q, Value: %q}", uo.Section, uo.Name, uo.Value)
+}
+
+func (uo *UnitOption) Match(other *UnitOption) bool {
+	return uo.Section == other.Section &&
+		uo.Name == other.Name &&
+		uo.Value == other.Value
+}
+
+func AllMatch(u1 []*UnitOption, u2 []*UnitOption) bool {
+	length := len(u1)
+	if length != len(u2) {
+		return false
+	}
+
+	for i := 0; i < length; i++ {
+		if !u1[i].Match(u2[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/option_test.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/option_test.go
@@ -1,0 +1,214 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"testing"
+)
+
+func TestAllMatch(t *testing.T) {
+	tests := []struct {
+		u1    []*UnitOption
+		u2    []*UnitOption
+		match bool
+	}{
+		// empty lists match
+		{
+			u1:    []*UnitOption{},
+			u2:    []*UnitOption{},
+			match: true,
+		},
+
+		// simple match of a single option
+		{
+			u1: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+			},
+			u2: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+			},
+			match: true,
+		},
+
+		// single option mismatched
+		{
+			u1: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+			},
+			u2: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "BAR"},
+			},
+			match: false,
+		},
+
+		// multiple options match
+		{
+			u1: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Unit", Name: "BindsTo", Value: "bar.service"},
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+			},
+			u2: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Unit", Name: "BindsTo", Value: "bar.service"},
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+			},
+			match: true,
+		},
+
+		// mismatch length
+		{
+			u1: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Unit", Name: "BindsTo", Value: "bar.service"},
+			},
+			u2: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Unit", Name: "BindsTo", Value: "bar.service"},
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+			},
+			match: false,
+		},
+
+		// multiple options misordered
+		{
+			u1: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+			},
+			u2: []*UnitOption{
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+			},
+			match: false,
+		},
+
+		// interleaved sections mismatch
+		{
+			u1: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Unit", Name: "BindsTo", Value: "bar.service"},
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+				{Section: "Service", Name: "ExecStop", Value: "/bin/true"},
+			},
+			u2: []*UnitOption{
+				{Section: "Unit", Name: "Description", Value: "FOO"},
+				{Section: "Service", Name: "ExecStart", Value: "/bin/true"},
+				{Section: "Unit", Name: "BindsTo", Value: "bar.service"},
+				{Section: "Service", Name: "ExecStop", Value: "/bin/true"},
+			},
+			match: false,
+		},
+	}
+
+	for i, tt := range tests {
+		match := AllMatch(tt.u1, tt.u2)
+		if match != tt.match {
+			t.Errorf("case %d: failed comparing u1 to u2 - expected match=%t, got %t", i, tt.match, match)
+		}
+
+		match = AllMatch(tt.u2, tt.u1)
+		if match != tt.match {
+			t.Errorf("case %d: failed comparing u2 to u1 - expected match=%t, got %t", i, tt.match, match)
+		}
+	}
+}
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		o1    *UnitOption
+		o2    *UnitOption
+		match bool
+	}{
+		// empty options match
+		{
+			o1:    &UnitOption{},
+			o2:    &UnitOption{},
+			match: true,
+		},
+
+		// all fields match
+		{
+			o1: &UnitOption{
+				Section: "Unit",
+				Name:    "Description",
+				Value:   "FOO",
+			},
+			o2: &UnitOption{
+				Section: "Unit",
+				Name:    "Description",
+				Value:   "FOO",
+			},
+			match: true,
+		},
+
+		// Section mismatch
+		{
+			o1: &UnitOption{
+				Section: "Unit",
+				Name:    "Description",
+				Value:   "FOO",
+			},
+			o2: &UnitOption{
+				Section: "X-Other",
+				Name:    "Description",
+				Value:   "FOO",
+			},
+			match: false,
+		},
+
+		// Name mismatch
+		{
+			o1: &UnitOption{
+				Section: "Unit",
+				Name:    "Description",
+				Value:   "FOO",
+			},
+			o2: &UnitOption{
+				Section: "Unit",
+				Name:    "BindsTo",
+				Value:   "FOO",
+			},
+			match: false,
+		},
+
+		// Value mismatch
+		{
+			o1: &UnitOption{
+				Section: "Unit",
+				Name:    "Description",
+				Value:   "FOO",
+			},
+			o2: &UnitOption{
+				Section: "Unit",
+				Name:    "Description",
+				Value:   "BAR",
+			},
+			match: false,
+		},
+	}
+
+	for i, tt := range tests {
+		match := tt.o1.Match(tt.o2)
+		if match != tt.match {
+			t.Errorf("case %d: failed comparing o1 to o2 - expected match=%t, got %t", i, tt.match, match)
+		}
+
+		match = tt.o2.Match(tt.o1)
+		if match != tt.match {
+			t.Errorf("case %d: failed comparing o2 to o1 - expected match=%t, got %t", i, tt.match, match)
+		}
+	}
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/serialize.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/serialize.go
@@ -1,0 +1,75 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"bytes"
+	"io"
+)
+
+// Serialize encodes all of the given UnitOption objects into a
+// unit file. When serialized the options are sorted in their
+// supplied order but grouped by section.
+func Serialize(opts []*UnitOption) io.Reader {
+	var buf bytes.Buffer
+
+	if len(opts) == 0 {
+		return &buf
+	}
+
+	// Index of sections -> ordered options
+	idx := map[string][]*UnitOption{}
+	// Separately preserve order in which sections were seen
+	sections := []string{}
+	for _, opt := range opts {
+		sec := opt.Section
+		if _, ok := idx[sec]; !ok {
+			sections = append(sections, sec)
+		}
+		idx[sec] = append(idx[sec], opt)
+	}
+
+	for i, sect := range sections {
+		writeSectionHeader(&buf, sect)
+		writeNewline(&buf)
+
+		opts := idx[sect]
+		for _, opt := range opts {
+			writeOption(&buf, opt)
+			writeNewline(&buf)
+		}
+		if i < len(sections)-1 {
+			writeNewline(&buf)
+		}
+	}
+
+	return &buf
+}
+
+func writeNewline(buf *bytes.Buffer) {
+	buf.WriteRune('\n')
+}
+
+func writeSectionHeader(buf *bytes.Buffer, section string) {
+	buf.WriteRune('[')
+	buf.WriteString(section)
+	buf.WriteRune(']')
+}
+
+func writeOption(buf *bytes.Buffer, opt *UnitOption) {
+	buf.WriteString(opt.Name)
+	buf.WriteRune('=')
+	buf.WriteString(opt.Value)
+}

--- a/config/vendor/github.com/coreos/go-systemd/unit/serialize_test.go
+++ b/config/vendor/github.com/coreos/go-systemd/unit/serialize_test.go
@@ -1,0 +1,170 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unit
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestSerialize(t *testing.T) {
+	tests := []struct {
+		input  []*UnitOption
+		output string
+	}{
+		// no options results in empty file
+		{
+			[]*UnitOption{},
+			``,
+		},
+
+		// options with same section share the header
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Unit", "BindsTo", "bar.service"},
+			},
+			`[Unit]
+Description=Foo
+BindsTo=bar.service
+`,
+		},
+
+		// options with same name are not combined
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Unit", "Description", "Bar"},
+			},
+			`[Unit]
+Description=Foo
+Description=Bar
+`,
+		},
+
+		// multiple options printed under different section headers
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Service", "ExecStart", "/usr/bin/sleep infinity"},
+			},
+			`[Unit]
+Description=Foo
+
+[Service]
+ExecStart=/usr/bin/sleep infinity
+`,
+		},
+
+		// options are grouped into sections
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Service", "ExecStart", "/usr/bin/sleep infinity"},
+				&UnitOption{"Unit", "BindsTo", "bar.service"},
+			},
+			`[Unit]
+Description=Foo
+BindsTo=bar.service
+
+[Service]
+ExecStart=/usr/bin/sleep infinity
+`,
+		},
+
+		// options are ordered within groups, and sections are ordered in the order in which they were first seen
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Foo"},
+				&UnitOption{"Service", "ExecStart", "/usr/bin/sleep infinity"},
+				&UnitOption{"Unit", "BindsTo", "bar.service"},
+				&UnitOption{"X-Foo", "Bar", "baz"},
+				&UnitOption{"Service", "ExecStop", "/usr/bin/sleep 1"},
+				&UnitOption{"Unit", "Documentation", "https://foo.com"},
+			},
+			`[Unit]
+Description=Foo
+BindsTo=bar.service
+Documentation=https://foo.com
+
+[Service]
+ExecStart=/usr/bin/sleep infinity
+ExecStop=/usr/bin/sleep 1
+
+[X-Foo]
+Bar=baz
+`,
+		},
+
+		// utf8 characters are not a problem
+		{
+			[]*UnitOption{
+				&UnitOption{"©", "µ☃", "ÇôrèÕ$"},
+			},
+			`[©]
+µ☃=ÇôrèÕ$
+`,
+		},
+
+		// no verification is done on section names
+		{
+			[]*UnitOption{
+				&UnitOption{"Un\nit", "Description", "Foo"},
+			},
+			`[Un
+it]
+Description=Foo
+`,
+		},
+
+		// no verification is done on option names
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Desc\nription", "Foo"},
+			},
+			`[Unit]
+Desc
+ription=Foo
+`,
+		},
+
+		// no verification is done on option values
+		{
+			[]*UnitOption{
+				&UnitOption{"Unit", "Description", "Fo\no"},
+			},
+			`[Unit]
+Description=Fo
+o
+`,
+		},
+	}
+
+	for i, tt := range tests {
+		outReader := Serialize(tt.input)
+		outBytes, err := ioutil.ReadAll(outReader)
+		if err != nil {
+			t.Errorf("case %d: encountered error while reading output: %v", i, err)
+			continue
+		}
+
+		output := string(outBytes)
+		if tt.output != output {
+			t.Errorf("case %d: incorrect output", i)
+			t.Logf("Expected:\n%s", tt.output)
+			t.Logf("Actual:\n%s", output)
+		}
+	}
+}


### PR DESCRIPTION
After use cloud-config during a long time and now with ignition, I really know that one of the most common pains working with, is the malformed units. 

So I think that could be a good idea validate the content, al least the format. The names are being validated so I don't see wait not the content.

I am using `coreos/go-systemd` deserializer, so this check just that the format is correct, is not checking the systax of the units, something that is very inserting too. 

BTW A good improvement can be also do the validator in a pattern that be extended by third-parties, now is totally imposible do this without modding the ignition code base, or create a complete different algorithm 