### PR TITLE
config: rename dev prelease to experimental

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,6 +49,10 @@ func TestParse(t *testing.T) {
 			out: out{config: types.Config{Ignition: types.Ignition{Version: types.IgnitionVersion(types.MaxVersion)}}},
 		},
 		{
+			in:  in{config: []byte(`{"ignition": {"version": "2.1.0-experimental"}}`)},
+			out: out{config: types.Config{Ignition: types.Ignition{Version: types.IgnitionVersion(types.MaxVersion)}}},
+		},
+		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.1.0"}}`)},
 			out: out{err: ErrInvalid},
 		},

--- a/config/types/config.go
+++ b/config/types/config.go
@@ -26,7 +26,7 @@ var (
 	MaxVersion = semver.Version{
 		Major:      2,
 		Minor:      1,
-		PreRelease: "dev",
+		PreRelease: "experimental",
 	}
 )
 


### PR DESCRIPTION
The intent is to expose this version to end users to allow for testing.
Ignition will continue to only advertise tagged versions, but will
optionally accept experimental pre-releases as well.