### PR TITLE
providers/openstack: check upper and lower case

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 NAME="ignition"
 ORG_PATH="github.com/coreos"

--- a/test
+++ b/test
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 source ./build
 


### PR DESCRIPTION
It's been observed that the config drive has the label "CONFIG-2"
instead of "config-2". This checks for both locations since we don't
know which one will be used.

Tested on VEXXHOST with the network metadata service:

```
$ journalctl -t ignition
-- Logs begin at Thu 2017-02-23 03:12:09 UTC, end at Thu 2017-02-23 03:12:37 UTC. --
Feb 23 03:12:11 localhost ignition[357]: Ignition v0.12.1-46-gb197bbe-dirty
Feb 23 03:12:11 localhost ignition[357]: parsed url from cmdline: ""
Feb 23 03:12:11 localhost ignition[357]: no config URL provided
Feb 23 03:12:11 localhost ignition[357]: GET http://169.254.169.254/openstack/latest/user_data: attempt #1
Feb 23 03:12:11 localhost ignition[357]: config drive ("/dev/disk/by-label/config-2") not found. Waiting...
Feb 23 03:12:11 localhost ignition[357]: config drive ("/dev/disk/by-label/CONFIG-2") not found. Waiting...
Feb 23 03:12:11 localhost ignition[357]: GET result: OK
Feb 23 03:12:11 localhost ignition[412]: Ignition v0.12.1-46-gb197bbe-dirty
```

...and config-drive:

```
$ journalctl -t ignition
-- Logs begin at Thu 2017-02-23 03:12:11 UTC, end at Thu 2017-02-23 03:13:03 UTC. --
Feb 23 03:12:13 localhost ignition[350]: Ignition v0.12.1-46-gb197bbe-dirty
Feb 23 03:12:13 localhost ignition[350]: parsed url from cmdline: ""
Feb 23 03:12:13 localhost ignition[350]: no config URL provided
Feb 23 03:12:13 localhost ignition[350]: config drive ("/dev/disk/by-label/config-2") not found. Waiting...
Feb 23 03:12:13 localhost ignition[350]: creating temporary mount point
Feb 23 03:12:13 localhost ignition[350]: op(1): [started]  mounting config drive
Feb 23 03:12:13 localhost ignition[350]: op(1): executing: "/usr/bin/mount" "-o" "ro" "-t" "auto" "/dev/disk/by-label/CONFIG-2" "/tmp/ignition-configdrive050113767"
Feb 23 03:12:13 localhost ignition[350]: op(1): GET http://169.254.169.254/openstack/latest/user_data: attempt #1
Feb 23 03:12:13 localhost ignition[350]: op(1): [finished] mounting config drive
Feb 23 03:12:13 localhost ignition[350]: op(2): [started]  unmounting "/dev/disk/by-label/CONFIG-2" at "/tmp/ignition-configdrive050113767"
Feb 23 03:12:13 localhost ignition[350]: op(2): [finished] unmounting "/dev/disk/by-label/CONFIG-2" at "/tmp/ignition-configdrive050113767"
Feb 23 03:12:13 localhost ignition[417]: Ignition v0.12.1-46-gb197bbe-dirty
```

/cc @s-urbaniak 