### PR TITLE
oem: fix gce gcloud alias

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -132,7 +132,7 @@ func init() {
 							Mode:       0444,
 						},
 						Contents: contentsFromString(`#!/bin/sh
-alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/doker.sock google/cloud-sdk gcloud"
+alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/doker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
 alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gcutil"
 alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gsutil"
 `),


### PR DESCRIPTION
The newest versions of google/cloud-sdk require the docker binary to be
mounted into the container from the host.

Fixes https://github.com/coreos/bugs/issues/1770.