### PR TITLE
types/url: add data as a valid url scheme

### DIFF
--- a/config/v2_0/types/url.go
+++ b/config/v2_0/types/url.go
@@ -58,7 +58,7 @@ func (u Url) Validate() report.Report {
 		return report.Report{}
 	}
 	switch url.URL(u).Scheme {
-	case "http", "https", "oem":
+	case "http", "https", "oem", "data":
 		return report.Report{}
 	}
 


### PR DESCRIPTION
Currently the following ignition config fails on Openstack:
```
{
  "ignition": {
    "version": "2.0.0",
    "config": {}
  },
  "storage": {
    "files": [
      {
        "filesystem": "root",
        "path": "/etc/kubernetes/kubelet.env",
        "contents": {
          "source": "data:text/plain;charset=utf-8;base64,S1VCRUxFVF9JTUFHRV9VUkw9cXVheS5pby9jb3Jlb3MvaHlwZXJrdWJlIEtVQkVMRVRfSU1BR0VfVEFHPWZvb2Jhcg==",
          "verification": {}
        },
        "mode": 420,
        "user": {},
        "group": {}
      }
    ]
  }
}
```

with the following validation error:

```
$ journalctl -t ignition
Feb 27 13:21:35 t460s ignition[8459]: GET http://169.254.169.254/openstack/latest/user_data: attempt #1
Feb 27 13:21:35 t460s ignition[8459]: config drive ("/dev/disk/by-label/config-2") not found. Waiting...
Feb 27 13:21:35 t460s ignition[8459]: config drive ("/dev/disk/by-label/CONFIG-2") not found. Waiting...
Feb 27 13:21:35 t460s ignition[8459]: GET result: OK
Feb 27 13:21:35 t460s ignition[8459]: error at line 12, column 154
                                         11:           "contents": {
                                         12:             "source": "data:text/plain;charset=utf-8;base64,S1VCRUxFVF9JTUFHRV9VUkw9cXVheS5pby9jb3Jlb3MvaHlwZXJrdWJlIEtVQkVMRVRfSU1BR0VfVEFHPWZvb2Jhcg=="
                                                                                                                                                                                                     ^
                                      invalid url scheme
Feb 27 13:21:35 t460s ignition[8459]: failed to fetch config: config is not valid
Feb 27 13:21:35 t460s ignition[8459]: failed to acquire config: config is not valid
```

This fixes it

/cc @crawford @alexsomesan