### PR TITLE
config/*: correct unit validation logic

### DIFF
--- a/config/types/unit.go
+++ b/config/types/unit.go
@@ -35,9 +35,7 @@ type SystemdUnit struct {
 
 func (u SystemdUnit) Validate() report.Report {
 	if err := validateUnitContent(u.Contents); err != nil {
-		if err != errEmptyUnit || (err == errEmptyUnit && len(u.DropIns) == 0) {
-			return report.ReportFromError(err, report.EntryError)
-		}
+		return report.ReportFromError(err, report.EntryError)
 	}
 
 	return report.Report{}
@@ -102,17 +100,11 @@ func (n NetworkdUnitName) Validate() report.Report {
 	}
 }
 
-var errEmptyUnit = fmt.Errorf("invalid or empty unit content")
-
 func validateUnitContent(content string) error {
 	c := bytes.NewBufferString(content)
-	unit, err := unit.Deserialize(c)
+	_, err := unit.Deserialize(c)
 	if err != nil {
 		return fmt.Errorf("invalid unit content: %s", err)
-	}
-
-	if len(unit) == 0 {
-		return errEmptyUnit
 	}
 
 	return nil

--- a/config/types/unit_test.go
+++ b/config/types/unit_test.go
@@ -43,10 +43,6 @@ func TestSystemdUnitValidate(t *testing.T) {
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
 		},
 		{
-			in:  in{unit: SystemdUnit{Contents: ""}},
-			out: out{err: errors.New("invalid or empty unit content")},
-		},
-		{
 			in:  in{unit: SystemdUnit{Contents: "", DropIns: []SystemdUnitDropIn{{}}}},
 			out: out{err: nil},
 		},
@@ -113,10 +109,6 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		{
 			in:  in{unit: SystemdUnitDropIn{Contents: "[Foo"}},
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
-		},
-		{
-			in:  in{unit: SystemdUnitDropIn{Contents: ""}},
-			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 
@@ -185,10 +177,6 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		{
 			in:  in{unit: NetworkdUnit{Contents: "[Foo"}},
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
-		},
-		{
-			in:  in{unit: NetworkdUnit{Contents: ""}},
-			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 

--- a/config/v2_0/types/unit.go
+++ b/config/v2_0/types/unit.go
@@ -35,9 +35,7 @@ type SystemdUnit struct {
 
 func (u SystemdUnit) Validate() report.Report {
 	if err := validateUnitContent(u.Contents); err != nil {
-		if err != errEmptyUnit || (err == errEmptyUnit && len(u.DropIns) == 0) {
-			return report.ReportFromError(err, report.EntryError)
-		}
+		return report.ReportFromError(err, report.EntryError)
 	}
 
 	return report.Report{}
@@ -102,17 +100,11 @@ func (n NetworkdUnitName) Validate() report.Report {
 	}
 }
 
-var errEmptyUnit = fmt.Errorf("invalid or empty unit content")
-
 func validateUnitContent(content string) error {
 	c := bytes.NewBufferString(content)
-	unit, err := unit.Deserialize(c)
+	_, err := unit.Deserialize(c)
 	if err != nil {
 		return fmt.Errorf("invalid unit content: %s", err)
-	}
-
-	if len(unit) == 0 {
-		return errEmptyUnit
 	}
 
 	return nil

--- a/config/v2_0/types/unit_test.go
+++ b/config/v2_0/types/unit_test.go
@@ -43,10 +43,6 @@ func TestSystemdUnitValidate(t *testing.T) {
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
 		},
 		{
-			in:  in{unit: SystemdUnit{Contents: ""}},
-			out: out{err: errors.New("invalid or empty unit content")},
-		},
-		{
 			in:  in{unit: SystemdUnit{Contents: "", DropIns: []SystemdUnitDropIn{{}}}},
 			out: out{err: nil},
 		},
@@ -113,10 +109,6 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		{
 			in:  in{unit: SystemdUnitDropIn{Contents: "[Foo"}},
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
-		},
-		{
-			in:  in{unit: SystemdUnitDropIn{Contents: ""}},
-			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 
@@ -185,10 +177,6 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		{
 			in:  in{unit: NetworkdUnit{Contents: "[Foo"}},
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
-		},
-		{
-			in:  in{unit: NetworkdUnit{Contents: ""}},
-			out: out{err: errors.New("invalid or empty unit content")},
 		},
 	}
 

--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -97,13 +97,6 @@ func TestValidate(t *testing.T) {
 			}},
 			out: out{err: errors.New("invalid systemd unit extension")},
 		},
-		{
-			in: in{cfg: Config{
-				Ignition: Ignition{Version: IgnitionVersion{Major: 2}},
-				Networkd: Networkd{Units: []NetworkdUnit{{Name: "foo.link", Contents: ""}}},
-			}},
-			out: out{err: errors.New("invalid or empty unit content")},
-		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
It is valid for a unit to be empty.