### PR TITLE
User group names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ language: go
 go_import_path: github.com/coreos/ignition
 
 go:
-  - 1.5.4
-  - 1.6.3
   - 1.7
+  - 1.8
 
 env:
   global:

--- a/config/translate.go
+++ b/config/translate.go
@@ -26,6 +26,10 @@ import (
 	"github.com/vincent-petithory/dataurl"
 )
 
+func intToPtr(x int) *int {
+	return &x
+}
+
 func TranslateFromV1(old v1.Config) types.Config {
 	config := types.Config{
 		Ignition: types.Ignition{
@@ -89,8 +93,8 @@ func TranslateFromV1(old v1.Config) types.Config {
 				Node: types.Node{
 					Filesystem: filesystem.Name,
 					Path:       string(oldFile.Path),
-					User:       types.NodeUser{ID: oldFile.Uid},
-					Group:      types.NodeGroup{ID: oldFile.Gid},
+					User:       types.NodeUser{ID: intToPtr(oldFile.Uid)},
+					Group:      types.NodeGroup{ID: intToPtr(oldFile.Gid)},
 				},
 				FileEmbedded1: types.FileEmbedded1{
 					Mode: int(oldFile.Mode),
@@ -305,8 +309,8 @@ func TranslateFromV2_0(old v2_0.Config) types.Config {
 			Node: types.Node{
 				Filesystem: oldFile.Filesystem,
 				Path:       string(oldFile.Path),
-				User:       types.NodeUser{ID: oldFile.User.Id},
-				Group:      types.NodeGroup{ID: oldFile.Group.Id},
+				User:       types.NodeUser{ID: intToPtr(oldFile.User.Id)},
+				Group:      types.NodeGroup{ID: intToPtr(oldFile.Group.Id)},
 			},
 			FileEmbedded1: types.FileEmbedded1{
 				Mode: int(oldFile.Mode),

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -194,8 +194,8 @@ func TestTranslateFromV1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "_translate-filesystem-0",
 								Path:       "/opt/file1",
-								User:       types.NodeUser{ID: 500},
-								Group:      types.NodeGroup{ID: 501},
+								User:       types.NodeUser{ID: intToPtr(500)},
+								Group:      types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: 0664,
@@ -211,8 +211,8 @@ func TestTranslateFromV1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "_translate-filesystem-0",
 								Path:       "/opt/file2",
-								User:       types.NodeUser{ID: 502},
-								Group:      types.NodeGroup{ID: 503},
+								User:       types.NodeUser{ID: intToPtr(502)},
+								Group:      types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: 0644,
@@ -228,8 +228,8 @@ func TestTranslateFromV1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "_translate-filesystem-1",
 								Path:       "/opt/file3",
-								User:       types.NodeUser{ID: 1000},
-								Group:      types.NodeGroup{ID: 1001},
+								User:       types.NodeUser{ID: intToPtr(1000)},
+								Group:      types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: 0400,
@@ -705,8 +705,8 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-0",
 								Path:       "/opt/file1",
-								User:       types.NodeUser{ID: 500},
-								Group:      types.NodeGroup{ID: 501},
+								User:       types.NodeUser{ID: intToPtr(500)},
+								Group:      types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: 0664,
@@ -722,8 +722,8 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-0",
 								Path:       "/opt/file2",
-								User:       types.NodeUser{ID: 502},
-								Group:      types.NodeGroup{ID: 503},
+								User:       types.NodeUser{ID: intToPtr(502)},
+								Group:      types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: 0644,
@@ -739,8 +739,8 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-1",
 								Path:       "/opt/file3",
-								User:       types.NodeUser{ID: 1000},
-								Group:      types.NodeGroup{ID: 1001},
+								User:       types.NodeUser{ID: intToPtr(1000)},
+								Group:      types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: 0400,

--- a/config/types/node.go
+++ b/config/types/node.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	ErrNoFilesystem = errors.New("no filesystem specified")
+	ErrNoFilesystem     = errors.New("no filesystem specified")
+	ErrBothIDAndNameSet = errors.New("cannot set both id and name")
 )
 
 func (n Node) ValidateFilesystem() report.Report {
@@ -53,4 +54,25 @@ func (n Node) Depth() int {
 		p = filepath.Dir(p)
 	}
 	return count
+}
+
+func (nu NodeUser) Validate() report.Report {
+	r := report.Report{}
+	if nu.ID != nil && nu.Name != "" {
+		r.Add(report.Entry{
+			Message: ErrBothIDAndNameSet.Error(),
+			Kind:    report.EntryError,
+		})
+	}
+	return r
+}
+func (ng NodeGroup) Validate() report.Report {
+	r := report.Report{}
+	if ng.ID != nil && ng.Name != "" {
+		r.Add(report.Entry{
+			Message: ErrBothIDAndNameSet.Error(),
+			Kind:    report.EntryError,
+		})
+	}
+	return r
 }

--- a/config/types/node_test.go
+++ b/config/types/node_test.go
@@ -49,3 +49,69 @@ func TestNodeValidateFilesystem(t *testing.T) {
 		}
 	}
 }
+
+func intToPtr(x int) *int {
+	return &x
+}
+
+func TestNodeValidateUser(t *testing.T) {
+	tests := []struct {
+		in  NodeUser
+		out report.Report
+	}{
+		{
+			in:  NodeUser{intToPtr(0), ""},
+			out: report.Report{},
+		},
+		{
+			in:  NodeUser{intToPtr(1000), ""},
+			out: report.Report{},
+		},
+		{
+			in:  NodeUser{nil, "core"},
+			out: report.Report{},
+		},
+		{
+			in:  NodeUser{intToPtr(1000), "core"},
+			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+		},
+	}
+
+	for i, test := range tests {
+		report := test.in.Validate()
+		if !reflect.DeepEqual(test.out, report) {
+			t.Errorf("#%d: bad report: want %v got %v", i, test.out, report)
+		}
+	}
+}
+
+func TestNodeValidateGroup(t *testing.T) {
+	tests := []struct {
+		in  NodeGroup
+		out report.Report
+	}{
+		{
+			in:  NodeGroup{intToPtr(0), ""},
+			out: report.Report{},
+		},
+		{
+			in:  NodeGroup{intToPtr(1000), ""},
+			out: report.Report{},
+		},
+		{
+			in:  NodeGroup{nil, "core"},
+			out: report.Report{},
+		},
+		{
+			in:  NodeGroup{intToPtr(1000), "core"},
+			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+		},
+	}
+
+	for i, test := range tests {
+		report := test.in.Validate()
+		if !reflect.DeepEqual(test.out, report) {
+			t.Errorf("#%d: bad report: want %v got %v", i, test.out, report)
+		}
+	}
+}

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -108,11 +108,13 @@ type Node struct {
 }
 
 type NodeGroup struct {
-	ID int `json:"id,omitempty"`
+	ID   *int   `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 type NodeUser struct {
-	ID int `json:"id,omitempty"`
+	ID   *int   `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 type Option string

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -54,23 +54,29 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
     * **_group_** (object): specifies the group of the owner.
       * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
   * **_directories_** (list of objects): the list of directories to be created.
     * **filesystem** (string): the internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the directory.
     * **_mode_** (integer): the directory's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0755 -> 493).
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
     * **_group_** (object): specifies the group of the owner.
       * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
   * **_links_** (list of objects): the list of links to be created
     * **filesystem** (string): the internal identifier of the filesystem in which to write the link. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the link
     * **_user_** (object): specifies the symbolic links's owner.
       * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
     * **_group_** (object): specifies the group of the owner.
       * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
 * **_systemd_** (object): describes the desired state of the systemd units.

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -163,7 +163,7 @@ func (tmp dirEntry) create(l *log.Logger, _ *resource.HttpClient, u util.Util) e
 			if err := os.Chmod(newPath, os.FileMode(d.Mode)); err != nil {
 				return err
 			}
-			if err := os.Chown(newPath, d.User.ID, d.Group.ID); err != nil {
+			if err := os.Chown(newPath, *d.User.ID, *d.Group.ID); err != nil {
 				return err
 			}
 		}

--- a/internal/exec/stages/files/files_test.go
+++ b/internal/exec/stages/files/files_test.go
@@ -56,7 +56,7 @@ func TestMapEntriesToFilesystems(t *testing.T) {
 					{Node: types.Node{Filesystem: "fs1", Path: "/bar"}},
 				},
 			}}},
-			out: out{files: map[types.Filesystem][]filesystemEntry{types.Filesystem{Name: "fs1"}: {
+			out: out{files: map[types.Filesystem][]filesystemEntry{{Name: "fs1"}: {
 				fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}}),
 				fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/bar"}}),
 			}}},
@@ -70,8 +70,8 @@ func TestMapEntriesToFilesystems(t *testing.T) {
 				},
 			}}},
 			out: out{files: map[types.Filesystem][]filesystemEntry{
-				types.Filesystem{Name: "fs1", Path: &fs1}: {fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}})},
-				types.Filesystem{Name: "fs2", Path: &fs2}: {fileEntry(types.File{Node: types.Node{Filesystem: "fs2", Path: "/bar"}})},
+				{Name: "fs1", Path: &fs1}: {fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}})},
+				{Name: "fs2", Path: &fs2}: {fileEntry(types.File{Node: types.Node{Filesystem: "fs2", Path: "/bar"}})},
 			}},
 		},
 		{
@@ -83,7 +83,7 @@ func TestMapEntriesToFilesystems(t *testing.T) {
 				},
 			}}},
 			out: out{files: map[types.Filesystem][]filesystemEntry{
-				types.Filesystem{Name: "fs1", Path: &fs1}: {
+				{Name: "fs1", Path: &fs1}: {
 					fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/foo"}}),
 					fileEntry(types.File{Node: types.Node{Filesystem: "fs1", Path: "/bar"}}),
 				},

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/internal/log"
@@ -112,13 +113,42 @@ func RenderFile(l *log.Logger, c *resource.HttpClient, f types.File) *File {
 		return nil
 	}
 
+	if f.User.Name != "" {
+		u, err := Util{DestDir: "/sysroot"}.userLookup(f.User.Name)
+		if err != nil {
+			l.Crit("No such user %q: %v", f.User.Name, err)
+			return nil
+		}
+		uid, err := strconv.ParseInt(u.Uid, 0, 0)
+		if err != nil {
+			l.Crit("Couldn't parse uid %q: %v", u.Uid, err)
+			return nil
+		}
+		tmp := int(uid)
+		f.User.ID = &tmp
+	}
+	if f.Group.Name != "" {
+		g, err := Util{DestDir: "/sysroot"}.groupLookup(f.Group.Name)
+		if err != nil {
+			l.Crit("No such group %q: %v", f.Group.Name, err)
+			return nil
+		}
+		gid, err := strconv.ParseInt(g.Gid, 0, 0)
+		if err != nil {
+			l.Crit("Couldn't parse gid %q: %v", g.Gid, err)
+			return nil
+		}
+		tmp := int(gid)
+		f.Group.ID = &tmp
+	}
+
 	return &File{
 		Path:        f.Path,
 		ReadCloser:  reader,
 		Hash:        fileHash,
 		Mode:        os.FileMode(f.Mode),
-		Uid:         f.User.ID,
-		Gid:         f.Group.ID,
+		Uid:         *f.User.ID,
+		Gid:         *f.Group.ID,
 		expectedSum: expectedSum,
 	}
 }

--- a/internal/exec/util/user_group_lookup.go
+++ b/internal/exec/util/user_group_lookup.go
@@ -16,7 +16,7 @@
 
 package util
 
-// #include "user_lookup.h"
+// #include "user_group_lookup.h"
 import "C"
 
 import (
@@ -26,7 +26,7 @@ import (
 
 // userLookup looks up the user in u.DestDir.
 func (u Util) userLookup(name string) (*user.User, error) {
-	res := &C.user_lookup_res_t{}
+	res := &C.lookup_res_t{}
 
 	if ret, err := C.user_lookup(C.CString(u.DestDir),
 		C.CString(name), res); ret < 0 {
@@ -47,4 +47,27 @@ func (u Util) userLookup(name string) (*user.User, error) {
 	C.user_lookup_res_free(res)
 
 	return usr, nil
+}
+
+// groupLookup looks up the group in u.DestDir.
+func (u Util) groupLookup(name string) (*user.Group, error) {
+	res := &C.lookup_res_t{}
+
+	if ret, err := C.group_lookup(C.CString(u.DestDir),
+		C.CString(name), res); ret < 0 {
+		return nil, fmt.Errorf("lookup failed: %v", err)
+	}
+
+	if res.name == nil {
+		return nil, fmt.Errorf("user %q not found", name)
+	}
+
+	grp := &user.Group{
+		Name: C.GoString(res.name),
+		Gid:  fmt.Sprintf("%d", int(res.gid)),
+	}
+
+	C.group_lookup_res_free(res)
+
+	return grp, nil
 }

--- a/internal/exec/util/user_group_lookup.h
+++ b/internal/exec/util/user_group_lookup.h
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-typedef struct user_lookup_res {
+typedef struct lookup_res {
 	int	uid;
 	int	gid;
 	char	*home;
 	char	*name;
-} user_lookup_res_t;
+} lookup_res_t;
 
-int user_lookup(const char *, const char *, user_lookup_res_t *);
-void user_lookup_res_free(user_lookup_res_t *);
+int user_lookup(const char *, const char *, lookup_res_t *);
+int group_lookup(const char *, const char *, lookup_res_t *);
+void user_lookup_res_free(lookup_res_t *);
+void group_lookup_res_free(lookup_res_t *);

--- a/internal/exec/util/user_group_lookup_test.go
+++ b/internal/exec/util/user_group_lookup_test.go
@@ -69,6 +69,7 @@ func TestUserLookup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("temp base error: %v", err)
 	}
+	defer os.RemoveAll(td)
 
 	logger := log.New()
 	defer logger.Close()
@@ -93,5 +94,38 @@ func TestUserLookup(t *testing.T) {
 
 	if usr.Gid != "4242" {
 		t.Fatalf("unexpected gid: %q", usr.Gid)
+	}
+}
+
+func TestGroupLookup(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root for chroot(), skipping")
+	}
+
+	td, err := tempBase()
+	if err != nil {
+		t.Fatalf("temp base error: %v", err)
+	}
+	defer os.RemoveAll(td)
+
+	logger := log.New()
+	defer logger.Close()
+
+	u := &Util{
+		DestDir: td,
+		Logger:  &logger,
+	}
+
+	grp, err := u.groupLookup("foo")
+	if err != nil {
+		t.Fatalf("lookup error: %v", err)
+	}
+
+	if grp.Name != "foo" {
+		t.Fatalf("unexpected name: %q", grp.Name)
+	}
+
+	if grp.Gid != "4242" {
+		t.Fatalf("unexpected gid: %q", grp.Gid)
 	}
 }

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -299,7 +299,10 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
+                },
+                "name": {
+                    "type": "string"
                 }
               }
             },
@@ -307,7 +310,10 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
+                },
+                "name": {
+                    "type": "string"
                 }
               }
             }


### PR DESCRIPTION
This commit adds support for referencing a user or group by name instead of ID when creating a node (as in, a directory or file). The uid/gid is resolved using the `os/user` package.

This will be unable to reference users added by `systemd-sysusers`, as is described here: https://github.com/coreos/bugs/issues/1267

Fixes https://github.com/coreos/bugs/issues/1104

Dependent on https://github.com/coreos/bootengine/pull/113