### PR TITLE
config/types/partition: added GUID field

### DIFF
--- a/config/types/partition_test.go
+++ b/config/types/partition_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+func TestValidateLabel(t *testing.T) {
+	type in struct {
+		label string
+	}
+	type out struct {
+		report report.Report
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{"root"},
+			out{report.Report{}},
+		},
+		{
+			in{""},
+			out{report.Report{}},
+		},
+		{
+			in{"111111111111111111111111111111111111"},
+			out{report.Report{}},
+		},
+		{
+			in{"1111111111111111111111111111111111111"},
+			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
+		},
+	}
+	for i, test := range tests {
+		r := Partition{Label: test.in.label}.ValidateLabel()
+		if !reflect.DeepEqual(r, test.out.report) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out.report, r)
+		}
+	}
+}
+
+func TestValidateTypeGUID(t *testing.T) {
+	type in struct {
+		typeguid string
+	}
+	type out struct {
+		report report.Report
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{"5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6"},
+			out{report.Report{}},
+		},
+		{
+			in{""},
+			out{report.Report{}},
+		},
+		{
+			in{"not-a-valid-typeguid"},
+			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+		},
+	}
+	for i, test := range tests {
+		r := Partition{TypeGUID: test.in.typeguid}.ValidateTypeGUID()
+		if !reflect.DeepEqual(r, test.out.report) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out.report, r)
+		}
+	}
+}
+
+func TestValidateGUID(t *testing.T) {
+	type in struct {
+		guid string
+	}
+	type out struct {
+		report report.Report
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{"5DFBF5F4-2848-4BAC-AA5E-0D9A20B745A6"},
+			out{report.Report{}},
+		},
+		{
+			in{""},
+			out{report.Report{}},
+		},
+		{
+			in{"not-a-valid-typeguid"},
+			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+		},
+	}
+	for i, test := range tests {
+		r := Partition{GUID: test.in.guid}.ValidateGUID()
+		if !reflect.DeepEqual(r, test.out.report) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out.report, r)
+		}
+	}
+}

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -99,6 +99,7 @@ type NodeUser struct {
 type Option string
 
 type Partition struct {
+	GUID     string `json:"guid,omitempty"`
 	Label    string `json:"label,omitempty"`
 	Number   int    `json:"number,omitempty"`
 	Size     int    `json:"size,omitempty"`

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -28,6 +28,7 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_size_** (integer): the size of the partition (in sectors). If zero, the partition will fill the remainder of the disk.
       * **_start_** (integer): the start of the partition (in sectors). If zero, the partition will be positioned at the earliest available part of the disk.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **_guid_** (string): the GPT unique partition GUID.
   * **_raid_** (list of objects): the list of RAID arrays to be configured.
     * **name** (string): the name to use for the resulting md device.
     * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -157,6 +157,7 @@ func (s stage) createPartitions(config types.Config) error {
 					Offset:   uint64(part.Start),
 					Label:    string(part.Label),
 					TypeGUID: string(part.TypeGUID),
+					GUID:     string(part.GUID),
 				})
 			}
 

--- a/internal/sgdisk/sgdisk.go
+++ b/internal/sgdisk/sgdisk.go
@@ -36,6 +36,7 @@ type Partition struct {
 	Length   uint64 // 512-byte sectors
 	Label    string
 	TypeGUID string
+	GUID     string
 }
 
 // Begin begins an sgdisk operation
@@ -74,6 +75,9 @@ func (op *Operation) Commit() error {
 			opts = append(opts, fmt.Sprintf("--change-name=%d:%s", p.Number, p.Label))
 			if p.TypeGUID != "" {
 				opts = append(opts, fmt.Sprintf("--typecode=%d:%s", p.Number, p.TypeGUID))
+			}
+			if p.GUID != "" {
+				opts = append(opts, fmt.Sprintf("--partition-guid=%d:%s", p.Number, p.GUID))
 			}
 		}
 		opts = append(opts, op.dev)

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -202,6 +202,9 @@
             },
             "typeGuid": {
               "type": "string"
+            },
+            "guid": {
+              "type": "string"
             }
           }
         },


### PR DESCRIPTION
(This PR is based on https://github.com/coreos/ignition/pull/325, so ignore all but the final commit. Will rebase once that PR is merged)

This commit allows ignition configs to now also specify a "guid" field
for a partition, which will dictate what the unique GUID for that
partition will be set to when it is created.

Fixes https://github.com/coreos/bugs/issues/1603

Tested with [this config](https://gist.github.com/dgonyeo/e0e18bb9d306a7a479db8e768b78e053), which broke the machine in a way that prevented it from booting, but was able to run `blkid` in the initramfs prompt and see that the one partition's GUID was set properly.