### PR TITLE
Add file url as file content

### DIFF
--- a/config/types/url.go
+++ b/config/types/url.go
@@ -59,7 +59,7 @@ func (u Url) Validate() report.Report {
 		return report.Report{}
 	}
 	switch url.URL(u).Scheme {
-	case "http", "https", "oem":
+	case "http", "https", "oem", "file":
 		return report.Report{}
 	case "data":
 		if _, err := dataurl.DecodeString(u.String()); err != nil {

--- a/config/types/url_test.go
+++ b/config/types/url_test.go
@@ -55,6 +55,10 @@ func TestURLValidate(t *testing.T) {
 			out: out{},
 		},
 		{
+			in:  in{u: "file:///foobar"},
+			out: out{},
+		},
+		{
 			in:  in{u: "bad://"},
 			out: out{err: ErrInvalidScheme},
 		},

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -47,7 +47,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **path** (string): the absolute path to the file.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip)
-      * **_source_** (string): the URL of the file contents. Supported schemes are http, https, and [data][rfc2397]. Note: When using http, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_source_** (string): the URL of the file contents. Supported schemes are http, https, file and [data][rfc2397]. Note: When using http, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is sha512.
     * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -149,6 +149,20 @@ func FetchAsReaderWithHeader(l *log.Logger, c *HttpClient, ctx context.Context, 
 		}
 		return ioutil.NopCloser(bytes.NewReader(url.Data)), nil
 
+	case "file":
+		path := filepath.Clean(u.Path)
+		if !filepath.IsAbs(path) {
+			l.Err("file path is not absolute: %q", u.Path)
+			return nil, ErrPathNotAbsolute
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			l.Err("failed to read file config: %v", err)
+			return nil, ErrFailed
+		}
+		return f, nil
+
 	case "oem":
 		path := filepath.Clean(u.Path)
 		if !filepath.IsAbs(path) {


### PR DESCRIPTION
coreos/bugs#1873

This is useful for example when using `/sys/` path:
```
  "storage": {
    "files": [{
      "filesystem": "root",
      "path": "/etc/hostname",
      "mode": 420,
      "contents": { "source": "file:///sys/devices/virtual/dmi/id/board_serial" }
    }]
  }
```