### PR TITLE
type/path: Fix isAbs() validation on Windows.

### DIFF
--- a/config/types/path.go
+++ b/config/types/path.go
@@ -16,7 +16,7 @@ package types
 
 import (
 	"errors"
-	"path/filepath"
+	"path"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -32,7 +32,7 @@ func (p Path) MarshalJSON() ([]byte, error) {
 }
 
 func (p Path) Validate() report.Report {
-	if !filepath.IsAbs(string(p)) {
+	if !path.IsAbs(string(p)) {
 		return report.ReportFromError(ErrPathRelative, report.EntryError)
 	}
 	return report.Report{}


### PR DESCRIPTION
filepath's isAbs() is platform-specific and reports paths like '/opt/local' as not absolute when run on Windows. The path package behaves the same on all platforms.

Fixes the root cause of https://github.com/coreos/bugs/issues/1876 and https://github.com/coreos/tectonic-forum/issues/81