### PR TITLE
stages: filesystems, skip format if filesystem already exists

### DIFF
--- a/internal/exec/util/device.go
+++ b/internal/exec/util/device.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/coreos/ignition/config/types"
+)
+
+// BlockDeviceInfo information extracted from blkid command
+type BlockDeviceInfo struct {
+	Name  string
+	Label string
+	Type  string
+}
+
+// BlockDevice returns the BlockDeviceInfo for a given device
+func BlockDevice(dev types.Path) (*BlockDeviceInfo, error) {
+	args := []string{
+		"-o", "export",
+		string(dev),
+	}
+
+	command := exec.Command("blkid", args...)
+	output, err := command.Output()
+	if err != nil && len(output) != 0 {
+		return nil, fmt.Errorf("error retrieving %q information: %s", dev, err)
+	}
+
+	if len(output) == 0 {
+		return nil, nil
+	}
+
+	return parseBlkidOutput(string(output)), nil
+}
+
+func parseBlkidOutput(stdout string) *BlockDeviceInfo {
+	blk := &BlockDeviceInfo{}
+
+	for _, line := range strings.Split(stdout, "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) < 2 {
+			continue
+		}
+
+		switch parts[0] {
+		case "DEVNAME":
+			blk.Name = parts[1]
+		case "LABEL":
+			blk.Label = parts[1]
+		case "TYPE":
+			blk.Type = parts[1]
+		}
+	}
+
+	return blk
+}


### PR DESCRIPTION
This PR solve the problem when a filesystems with `force` equals `false` is being formatted and a previous filesystem already exists.

When `mkfs.ext4` is called with `-p` (added by https://github.com/coreos/ignition/commit/176482943df81f3fd512576daf7797377a537346) the command exits with an error, and the boot aborts.

This is fixed checking if a previous filesystem exists at the device with the command `blkid` and if exists and `force` is equals to `false` the format phase is skipped. 

If this PR is something that could be merge, I will need guidance to make some tests.