### PR TITLE
stages/disks: added support for filesystems of type "swap"

### DIFF
--- a/config/types/filesystem.go
+++ b/config/types/filesystem.go
@@ -52,7 +52,7 @@ func (f Filesystem) ValidatePath() report.Report {
 func (m Mount) Validate() report.Report {
 	r := report.Report{}
 	switch m.Format {
-	case "ext4", "btrfs", "xfs":
+	case "ext4", "btrfs", "xfs", "swap":
 	default:
 		r.Add(report.Entry{
 			Message: ErrFilesystemInvalidFormat.Error(),

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -38,7 +38,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_name_** (string): the identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the "files" section.
     * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.
       * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
-      * **format** (string): the filesystem format (ext4, btrfs, or xfs).
+      * **format** (string): the filesystem format (ext4, btrfs, xfs, or swap).
       * **_create_** (object): contains the set of options to be used when creating the filesystem. A non-null entry indicates that the filesystem shall be created.
         * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
         * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -280,6 +280,11 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		if fs.Create.Force {
 			args = append(args, "-f")
 		}
+	case "swap":
+		mkfs = "/sbin/mkswap"
+		if fs.Create.Force {
+			args = append(args, "-f")
+		}
 	default:
 		return fmt.Errorf("unsupported filesystem format: %q", fs.Format)
 	}


### PR DESCRIPTION
This commit adds support for creating swap devices. Here's an example config that now works with this commit:

```
{
  "ignition": {
    "version": "2.1.0-experimental"
  },
  "storage": {
    "filesystems": [
      {
        "mount": {
          "device": "/dev/vda6",
          "format": "swap",
          "create": {
            "options": [
              "--label=SWAP"
            ]
          }
        }
      }
    ]
  }
}
```

Fixes https://github.com/coreos/bugs/issues/1407