### PR TITLE
deprecate create object, create wipeFilesystem flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,25 @@ addons:
     # install cross compilers for cgo support.
     - gcc-aarch64-linux-gnu
     - libc6-dev-arm64-cross
+    - libblkid-dev
 
 install:
-  -
+  # since libblkid-dev:arm64 cannot be installed, spoof it
+  -     if [ "${TARGET}" == "arm64" ]; then
+                echo "void blkid_new_probe_from_filename(void) {}" >> stub.c;
+                echo "void blkid_do_probe(void) {}"                >> stub.c;
+                echo "void blkid_probe_has_value(void) {}"         >> stub.c;
+                echo "void blkid_probe_lookup_value(void) {}"      >> stub.c;
+                echo "void blkid_free_probe(void) {}"              >> stub.c;
+                aarch64-linux-gnu-gcc-4.8 -c -o stub.o stub.c;
+                aarch64-linux-gnu-gcc-ar-4.8 cq libblkid.a stub.o;
+        fi
 
 script:
   -     if [ "${TARGET}" == "amd64" ]; then
                 GOARCH="${TARGET}" ./test;
         elif [ "${TARGET}" == "arm64" ]; then
+                export CGO_LDFLAGS="-L ${PWD}";
                 GOARCH="${TARGET}" ./build;
                 file "bin/${TARGET}/ignition" | egrep 'aarch64';
         fi

--- a/config/translate.go
+++ b/config/translate.go
@@ -192,10 +192,10 @@ func TranslateFromV1(old v1.Config) types.Config {
 }
 
 // golang--
-func translateV1MkfsOptionsToV2_1OptionSlice(opts v1.MkfsOptions) []types.Option {
-	newOpts := make([]types.Option, len(opts))
+func translateV1MkfsOptionsToV2_1OptionSlice(opts v1.MkfsOptions) []types.CreateOption {
+	newOpts := make([]types.CreateOption, len(opts))
 	for i, o := range opts {
-		newOpts[i] = types.Option(o)
+		newOpts[i] = types.CreateOption(o)
 	}
 	return newOpts
 }
@@ -405,10 +405,10 @@ func TranslateFromV2_0(old v2_0.Config) types.Config {
 }
 
 // golang--
-func translateV2_0MkfsOptionsToV2_1OptionSlice(opts v2_0.MkfsOptions) []types.Option {
-	newOpts := make([]types.Option, len(opts))
+func translateV2_0MkfsOptionsToV2_1OptionSlice(opts v2_0.MkfsOptions) []types.CreateOption {
+	newOpts := make([]types.CreateOption, len(opts))
 	for i, o := range opts {
-		newOpts[i] = types.Option(o)
+		newOpts[i] = types.CreateOption(o)
 	}
 	return newOpts
 }

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -177,7 +177,7 @@ func TestTranslateFromV1(t *testing.T) {
 								Format: "btrfs",
 								Create: &types.Create{
 									Force:   true,
-									Options: []types.Option{"-L", "ROOT"},
+									Options: []types.CreateOption{"-L", "ROOT"},
 								},
 							},
 						},
@@ -684,7 +684,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 								Format: "btrfs",
 								Create: &types.Create{
 									Force:   true,
-									Options: []types.Option{"-L", "ROOT"},
+									Options: []types.CreateOption{"-L", "ROOT"},
 								},
 							},
 						},

--- a/config/types/filesystem.go
+++ b/config/types/filesystem.go
@@ -22,11 +22,12 @@ import (
 )
 
 var (
-	ErrFilesystemInvalidFormat = errors.New("invalid filesystem format")
-	ErrFilesystemNoMountPath   = errors.New("filesystem is missing mount or path")
-	ErrFilesystemMountAndPath  = errors.New("filesystem has both mount and path defined")
-	ErrUsedCreateAndMountOpts  = errors.New("cannot use both create object and mount-level options fields")
-	ErrWarningCreateDeprecated = errors.New("the create object has been deprecated in favor of mount-level options")
+	ErrFilesystemInvalidFormat     = errors.New("invalid filesystem format")
+	ErrFilesystemNoMountPath       = errors.New("filesystem is missing mount or path")
+	ErrFilesystemMountAndPath      = errors.New("filesystem has both mount and path defined")
+	ErrUsedCreateAndMountOpts      = errors.New("cannot use both create object and mount-level options field")
+	ErrUsedCreateAndWipeFilesystem = errors.New("cannot use both create object and wipeFilesystem field")
+	ErrWarningCreateDeprecated     = errors.New("the create object has been deprecated in favor of mount-level options")
 )
 
 func (f Filesystem) Validate() report.Report {
@@ -45,6 +46,12 @@ func (f Filesystem) Validate() report.Report {
 			})
 		}
 		if f.Mount.Create != nil {
+			if f.Mount.WipeFilesystem {
+				r.Add(report.Entry{
+					Message: ErrUsedCreateAndWipeFilesystem.Error(),
+					Kind:    report.EntryError,
+				})
+			}
 			if len(f.Mount.Options) > 0 {
 				r.Add(report.Entry{
 					Message: ErrUsedCreateAndMountOpts.Error(),

--- a/config/types/filesystem.go
+++ b/config/types/filesystem.go
@@ -25,15 +25,37 @@ var (
 	ErrFilesystemInvalidFormat = errors.New("invalid filesystem format")
 	ErrFilesystemNoMountPath   = errors.New("filesystem is missing mount or path")
 	ErrFilesystemMountAndPath  = errors.New("filesystem has both mount and path defined")
+	ErrUsedCreateAndMountOpts  = errors.New("cannot use both create object and mount-level options fields")
+	ErrWarningCreateDeprecated = errors.New("the create object has been deprecated in favor of mount-level options")
 )
 
 func (f Filesystem) Validate() report.Report {
 	r := report.Report{}
 	if f.Mount == nil && f.Path == nil {
-		return report.ReportFromError(ErrFilesystemNoMountPath, report.EntryError)
+		r.Add(report.Entry{
+			Message: ErrFilesystemNoMountPath.Error(),
+			Kind:    report.EntryError,
+		})
 	}
-	if f.Mount != nil && f.Path != nil {
-		return report.ReportFromError(ErrFilesystemMountAndPath, report.EntryError)
+	if f.Mount != nil {
+		if f.Path != nil {
+			r.Add(report.Entry{
+				Message: ErrFilesystemMountAndPath.Error(),
+				Kind:    report.EntryError,
+			})
+		}
+		if f.Mount.Create != nil {
+			if len(f.Mount.Options) > 0 {
+				r.Add(report.Entry{
+					Message: ErrUsedCreateAndMountOpts.Error(),
+					Kind:    report.EntryError,
+				})
+			}
+			r.Add(report.Entry{
+				Message: ErrWarningCreateDeprecated.Error(),
+				Kind:    report.EntryWarning,
+			})
+		}
 	}
 	return r
 }

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -88,10 +88,11 @@ type LinkEmbedded1 struct {
 }
 
 type Mount struct {
-	Create  *Create       `json:"create,omitempty"`
-	Device  string        `json:"device,omitempty"`
-	Format  string        `json:"format,omitempty"`
-	Options []MountOption `json:"options,omitempty"`
+	Create         *Create       `json:"create,omitempty"`
+	Device         string        `json:"device,omitempty"`
+	Format         string        `json:"format,omitempty"`
+	Options        []MountOption `json:"options,omitempty"`
+	WipeFilesystem bool          `json:"wipeFilesystem,omitempty"`
 }
 
 type MountOption string

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -91,7 +91,9 @@ type Mount struct {
 	Create         *Create       `json:"create,omitempty"`
 	Device         string        `json:"device,omitempty"`
 	Format         string        `json:"format,omitempty"`
+	Label          *string       `json:"label,omitempty"`
 	Options        []MountOption `json:"options,omitempty"`
+	UUID           *string       `json:"uuid,omitempty"`
 	WipeFilesystem bool          `json:"wipeFilesystem,omitempty"`
 }
 

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -16,9 +16,11 @@ type ConfigReference struct {
 }
 
 type Create struct {
-	Force   bool     `json:"force,omitempty"`
-	Options []Option `json:"options,omitempty"`
+	Force   bool           `json:"force,omitempty"`
+	Options []CreateOption `json:"options,omitempty"`
 }
+
+type CreateOption string
 
 type Device string
 
@@ -86,10 +88,13 @@ type LinkEmbedded1 struct {
 }
 
 type Mount struct {
-	Create *Create `json:"create,omitempty"`
-	Device string  `json:"device,omitempty"`
-	Format string  `json:"format,omitempty"`
+	Create  *Create       `json:"create,omitempty"`
+	Device  string        `json:"device,omitempty"`
+	Format  string        `json:"format,omitempty"`
+	Options []MountOption `json:"options,omitempty"`
 }
+
+type MountOption string
 
 type Networkd struct {
 	Units []Networkdunit `json:"units,omitempty"`
@@ -116,8 +121,6 @@ type NodeUser struct {
 	ID   *int   `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 }
-
-type Option string
 
 type Partition struct {
 	GUID     string `json:"guid,omitempty"`

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -66,6 +66,8 @@ type Filesystem struct {
 	Path  *string `json:"path,omitempty"`
 }
 
+type Group string
+
 type Ignition struct {
 	Config   IgnitionConfig `json:"config,omitempty"`
 	Timeouts Timeouts       `json:"timeouts,omitempty"`
@@ -149,7 +151,7 @@ type PasswdGroup struct {
 type PasswdUser struct {
 	Create            *Usercreate        `json:"create,omitempty"`
 	Gecos             string             `json:"gecos,omitempty"`
-	Groups            []PasswdUserGroup  `json:"groups,omitempty"`
+	Groups            []Group            `json:"groups,omitempty"`
 	HomeDir           string             `json:"homeDir,omitempty"`
 	Name              string             `json:"name,omitempty"`
 	NoCreateHome      bool               `json:"noCreateHome,omitempty"`
@@ -162,8 +164,6 @@ type PasswdUser struct {
 	System            bool               `json:"system,omitempty"`
 	UID               *int               `json:"uid,omitempty"`
 }
-
-type PasswdUserGroup string
 
 type Raid struct {
 	Devices []Device `json:"devices,omitempty"`

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -39,9 +39,10 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.
       * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
       * **format** (string): the filesystem format (ext4, btrfs, xfs, or swap).
-      * **_create_** (object): contains the set of options to be used when creating the filesystem. A non-null entry indicates that the filesystem shall be created.
-        * **_force_** (boolean): whether or not the create operation shall overwrite an existing filesystem.
-        * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+      * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+      * **_create_** (object, DEPRECATED): contains the set of options to be used when creating the filesystem.
+        * **_force_** (boolean, DEPRECATED): whether or not the create operation shall overwrite an existing filesystem.
+        * **_options_** (list of strings, DEPRECATED): any additional options to be passed to the format-specific mkfs utility.
     * **_path_** (string): the mount-point of the filesystem. A non-null entry indicates that the filesystem has already been mounted by the system at the specified path. This is really only useful for "/sysroot".
   * **_files_** (list of objects): the list of files to be written.
     * **filesystem** (string): the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier.

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -40,6 +40,8 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
       * **format** (string): the filesystem format (ext4, btrfs, xfs, or swap).
       * **_wipeFilesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](filesystems.md) for more information.
+      * **_label_** (string): the label of the filesystem.
+      * **_uuid_** (string): the uuid of the filesystem.
       * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
       * **_create_** (object, DEPRECATED): contains the set of options to be used when creating the filesystem.
         * **_force_** (boolean, DEPRECATED): whether or not the create operation shall overwrite an existing filesystem.

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -39,6 +39,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.
       * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
       * **format** (string): the filesystem format (ext4, btrfs, xfs, or swap).
+      * **_wipeFilesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](filesystems.md) for more information.
       * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
       * **_create_** (object, DEPRECATED): contains the set of options to be used when creating the filesystem.
         * **_force_** (boolean, DEPRECATED): whether or not the create operation shall overwrite an existing filesystem.

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -72,10 +72,8 @@ This example Ignition configuration will locate the device with the "ROOT" files
       "mount": {
         "device": "/dev/disk/by-label/ROOT",
         "format": "btrfs",
-        "create": {
-          "force": true,
-          "options": [ "--label=ROOT" ]
-        }
+        "wipeFilesystem": true,
+        "options": [ "--label=ROOT" ]
       }
     }]
   }
@@ -92,10 +90,8 @@ This example Ignition configuration will locate the device with the "ROOT" files
       "mount": {
         "device": "/dev/disk/by-label/ROOT",
         "format": "xfs",
-        "create": {
-          "force": true,
-          "options": [ "-L", "ROOT" ]
-        }
+        "wipeFilesystem": true,
+        "options": [ "-L", "ROOT" ]
       }
     }]
   }

--- a/doc/filesystems.md
+++ b/doc/filesystems.md
@@ -1,0 +1,17 @@
+# Filesystem reuse semantics
+
+When a Container Linux machine first boots, it's possible that an earlier installation or other process has already provisioned the disks. The Ignition config can specify the intended filesystem for a given device, and there are three possibilities when Ignition runs:
+
+- There is no preexisting filesystem.
+- There is a preexisting filesystem of the correct type (e.g. the Ignition config says `/dev/sda` should be `ext4`, and it is `ext4`).
+- There is a preexisting filesystem of an incorrect type (e.g. the Ignition config says `/dev/sda` should be `ext4`, and it is `btrfs`).
+
+In the first case, when there is no preexisting filesystem, Ignition will always create the desired filesystem.
+
+In the second two cases, where there is a preexisting filesystem, Ignition's behavior is controlled by the `wipeFilesystem` flag in the `filesystem` section.
+
+If `wipeFilesystem` is set to true, Ignition will always wipe any preexisting filesystem and create the desired filesystem. Note this will result in any data on the old filesystem being lost.
+
+If `wipeFilesystem` is set to false, Ignition will then attempt to reuse the existing filesystem. If the filesystem is of the correct type (e.g. `ext4`, `btrfs`, `xfs`, etc.), then Ignition will reuse the filesystem. Any preexisting data will be left on the device and will be available to the installation. If the preexisting filesystem is *not* of the correct type, then Ignition will fail, and the machine will fail to boot.
+
+When determining if a filesystem can be reused, *only* the filesystem type is considered. Any desired labels or other parameters on the filesystem are not checked. If `wipeFilesystem` is false, and a preexisting filesystem of the correct type exists, it's possible to get a machine without the desired filesystem labels.

--- a/doc/filesystems.md
+++ b/doc/filesystems.md
@@ -3,8 +3,8 @@
 When a Container Linux machine first boots, it's possible that an earlier installation or other process has already provisioned the disks. The Ignition config can specify the intended filesystem for a given device, and there are three possibilities when Ignition runs:
 
 - There is no preexisting filesystem.
-- There is a preexisting filesystem of the correct type (e.g. the Ignition config says `/dev/sda` should be `ext4`, and it is `ext4`).
-- There is a preexisting filesystem of an incorrect type (e.g. the Ignition config says `/dev/sda` should be `ext4`, and it is `btrfs`).
+- There is a preexisting filesystem of the correct type, label, or UUID (e.g. the Ignition config says `/dev/sda` should be `ext4`, and it is `ext4`).
+- There is a preexisting filesystem of an incorrect type, label, or UUID (e.g. the Ignition config says `/dev/sda` should be `ext4`, and it is `btrfs`).
 
 In the first case, when there is no preexisting filesystem, Ignition will always create the desired filesystem.
 
@@ -12,6 +12,5 @@ In the second two cases, where there is a preexisting filesystem, Ignition's beh
 
 If `wipeFilesystem` is set to true, Ignition will always wipe any preexisting filesystem and create the desired filesystem. Note this will result in any data on the old filesystem being lost.
 
-If `wipeFilesystem` is set to false, Ignition will then attempt to reuse the existing filesystem. If the filesystem is of the correct type (e.g. `ext4`, `btrfs`, `xfs`, etc.), then Ignition will reuse the filesystem. Any preexisting data will be left on the device and will be available to the installation. If the preexisting filesystem is *not* of the correct type, then Ignition will fail, and the machine will fail to boot.
-
-When determining if a filesystem can be reused, *only* the filesystem type is considered. Any desired labels or other parameters on the filesystem are not checked. If `wipeFilesystem` is false, and a preexisting filesystem of the correct type exists, it's possible to get a machine without the desired filesystem labels.
+If `wipeFilesystem` is set to false, Ignition will then attempt to reuse the existing filesystem. If the filesystem is of the correct type, has a matching label, and has a matching UUID, then Ignition will reuse the filesystem. If the label or UUID is not set in the Ignition config, they don't need to match for Ignition to reuse the filesystem. Any preexisting data will be left on the device and will be available to the installation. If the preexisting filesystem is *not* of the correct type, then Ignition will fail, and the machine will fail
+to boot.

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -290,27 +290,34 @@ func (s stage) createFilesystem(fs types.Mount) error {
 	}
 
 	mkfs := ""
-	args := translateV2_1OptionSliceToStringSlice(fs.Create.Options)
+	var force bool
+	var args []string
+	if fs.Create == nil {
+		args = translateMountOptionSliceToStringSlice(fs.Options)
+	} else {
+		force = fs.Create.Force
+		args = translateCreateOptionSliceToStringSlice(fs.Create.Options)
+	}
 	switch fs.Format {
 	case "btrfs":
 		mkfs = "/sbin/mkfs.btrfs"
-		if fs.Create.Force {
+		if force {
 			args = append(args, "--force")
 		}
 	case "ext4":
 		mkfs = "/sbin/mkfs.ext4"
 		args = append(args, "-p")
-		if fs.Create.Force {
+		if force {
 			args = append(args, "-F")
 		}
 	case "xfs":
 		mkfs = "/sbin/mkfs.xfs"
-		if fs.Create.Force {
+		if force {
 			args = append(args, "-f")
 		}
 	case "swap":
 		mkfs = "/sbin/mkswap"
-		if fs.Create.Force {
+		if force {
 			args = append(args, "-f")
 		}
 	default:
@@ -330,7 +337,17 @@ func (s stage) createFilesystem(fs types.Mount) error {
 	return nil
 }
 
-func translateV2_1OptionSliceToStringSlice(opts []types.Option) []string {
+// golang--
+func translateMountOptionSliceToStringSlice(opts []types.MountOption) []string {
+	newOpts := make([]string, len(opts))
+	for i, o := range opts {
+		newOpts[i] = string(o)
+	}
+	return newOpts
+}
+
+// golang--
+func translateCreateOptionSliceToStringSlice(opts []types.CreateOption) []string {
 	newOpts := make([]string, len(opts))
 	for i, o := range opts {
 		newOpts[i] = string(o)

--- a/internal/exec/util/blkid.c
+++ b/internal/exec/util/blkid.c
@@ -1,0 +1,39 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <blkid/blkid.h>
+#include "blkid.h"
+
+result_t filesystem_type(const char *device, char type[], size_t type_len)
+{
+	const char *type_name = "\0";
+
+	blkid_probe pr = blkid_new_probe_from_filename(device);
+	if (!pr)
+		return RESULT_OPEN_FAILED;
+
+	if (blkid_do_probe(pr) != 0)
+		return RESULT_PROBE_FAILED;
+
+	if (blkid_probe_has_value(pr, "TYPE"))
+		if (blkid_probe_lookup_value(pr, "TYPE", &type_name, NULL))
+			return RESULT_LOOKUP_FAILED;
+
+	strncpy(type, type_name, type_len);
+
+	blkid_free_probe(pr);
+
+	return RESULT_OK;
+}
+

--- a/internal/exec/util/blkid.c
+++ b/internal/exec/util/blkid.c
@@ -15,9 +15,9 @@
 #include <blkid/blkid.h>
 #include "blkid.h"
 
-result_t filesystem_type(const char *device, char type[], size_t type_len)
+result_t blkid_lookup(const char *device, const char *field_name, char buf[], size_t buf_len)
 {
-	const char *type_name = "\0";
+	const char *field_val = "\0";
 
 	blkid_probe pr = blkid_new_probe_from_filename(device);
 	if (!pr)
@@ -26,14 +26,13 @@ result_t filesystem_type(const char *device, char type[], size_t type_len)
 	if (blkid_do_probe(pr) != 0)
 		return RESULT_PROBE_FAILED;
 
-	if (blkid_probe_has_value(pr, "TYPE"))
-		if (blkid_probe_lookup_value(pr, "TYPE", &type_name, NULL))
+	if (blkid_probe_has_value(pr, field_name))
+		if (blkid_probe_lookup_value(pr, field_name, &field_val, NULL))
 			return RESULT_LOOKUP_FAILED;
 
-	strncpy(type, type_name, type_len);
+	strncpy(buf, field_val, buf_len);
 
 	blkid_free_probe(pr);
 
 	return RESULT_OK;
 }
-

--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -1,0 +1,57 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package util
+
+// #cgo LDFLAGS: -lblkid
+// #include <stdlib.h>
+// #include "blkid.h"
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func FilesystemType(device string) (string, error) {
+	var fsType [16]byte
+
+	cDevice := C.CString(device)
+	defer C.free(unsafe.Pointer(cDevice))
+
+	switch C.filesystem_type(cDevice, (*C.char)(unsafe.Pointer(&fsType[0])), C.size_t(len(fsType))) {
+	case C.RESULT_OK:
+		return string(trimZerosTail(fsType[:])), nil
+	case C.RESULT_OPEN_FAILED:
+		return "", fmt.Errorf("failed to open %q", device)
+	case C.RESULT_PROBE_FAILED:
+		// If the probe failed, there's no filesystem created yet on this device
+		return "", nil
+	case C.RESULT_LOOKUP_FAILED:
+		return "", fmt.Errorf("failed to lookup filesystem type of %q", device)
+	default:
+		return "", fmt.Errorf("unknown error")
+	}
+}
+
+func trimZerosTail(b []byte) []byte {
+	for i := range b {
+		if b[i] == 0 {
+			return b[:i]
+		}
+	}
+	return b
+}

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -1,0 +1,30 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _BLKID_H_
+#define _BLKID_H_
+
+#include <string.h>
+
+typedef enum {
+	RESULT_OK,
+	RESULT_OPEN_FAILED,
+	RESULT_PROBE_FAILED,
+	RESULT_LOOKUP_FAILED,
+} result_t;
+
+result_t filesystem_type(const char *device, char type[], size_t type_len);
+
+#endif // _BLKID_H_
+

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -24,7 +24,7 @@ typedef enum {
 	RESULT_LOOKUP_FAILED,
 } result_t;
 
-result_t filesystem_type(const char *device, char type[], size_t type_len);
+result_t blkid_lookup(const char *device, const char *field_name, char buf[], size_t buf_len);
 
 #endif // _BLKID_H_
 

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -122,10 +122,10 @@ func (u Util) EnsureUser(c types.PasswdUser) error {
 }
 
 // golang--
-func translateV2_1UsercreateGroupSliceToPasswdUserGroupSlice(groups []types.UsercreateGroup) []types.PasswdUserGroup {
-	newGroups := make([]types.PasswdUserGroup, len(groups))
+func translateV2_1UsercreateGroupSliceToPasswdUserGroupSlice(groups []types.UsercreateGroup) []types.Group {
+	newGroups := make([]types.Group, len(groups))
 	for i, g := range groups {
-		newGroups[i] = types.PasswdUserGroup(g)
+		newGroups[i] = types.Group(g)
 	}
 	return newGroups
 }
@@ -144,7 +144,7 @@ func (u Util) CheckIfUserExists(c types.PasswdUser) (bool, error) {
 }
 
 // golang--
-func translateV2_1PasswdUserGroupSliceToStringSlice(groups []types.PasswdUserGroup) []string {
+func translateV2_1PasswdUserGroupSliceToStringSlice(groups []types.Group) []string {
 	newGroups := make([]string, len(groups))
 	for i, g := range groups {
 		newGroups[i] = string(g)

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -256,6 +256,12 @@
             "format": {
               "type": "string"
             },
+            "options": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
             "create": {
               "type": ["object", "null"],
               "properties": {

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -263,7 +263,13 @@
                 }
             },
             "wipeFilesystem": {
-                "type": "boolean"
+              "type": "boolean"
+            },
+            "label": {
+              "type": ["string", "null"]
+            },
+            "uuid": {
+              "type": ["string", "null"]
             },
             "create": {
               "type": ["object", "null"],

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -262,6 +262,9 @@
                     "type": "string"
                 }
             },
+            "wipeFilesystem": {
+                "type": "boolean"
+            },
             "create": {
               "type": ["object", "null"],
               "properties": {


### PR DESCRIPTION
This PR has three commits. In order:
- the first commit moves the fields inside of the `create` object in the filesystem's mount section one level up, into the `mount` object itself. The `create` object is left in for backwards compatibility reasons, and will generate a warning when used. If the create object exists and the new `force` or `options` fields in the mount object are used, an error is generated
- the second commit adds a new field in the filesystem's mount object called `wipeFilesystem`. If this field is false, and a filesystem of the expected type exists on the device, the filesystem is reused. If this field is true any preexisting filesystem will be removed.
- the third commit adds the libblkid stub for arm64 builds

I can split this up into two PRs if desired.

I tested this with [this ignition config](https://gist.github.com/dgonyeo/adf337fc9ae013408dafa065b8972d75) in qemu, and it worked as expected.

Fixes https://github.com/coreos/bugs/issues/1911