### PR TITLE
oem: fix oem definition for brightbox

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -101,7 +101,7 @@ func init() {
 	})
 	configs.Register(Config{
 		name:              "brightbox",
-		fetch:             noop.FetchConfig,
+		fetch:             openstack.FetchConfig,
 		defaultUserConfig: types.Config{Systemd: types.Systemd{Units: []types.Unit{userCloudInit("BrightBox", "ec2-compat")}}},
 	})
 	configs.Register(Config{


### PR DESCRIPTION
The initial support was implemented in 51b7f16, but neglected to update
the fetch function.