### PR TITLE
config/type/passwd: deprecate user create object

### DIFF
--- a/config/types/passwd.go
+++ b/config/types/passwd.go
@@ -1,0 +1,82 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+var (
+	ErrPasswdCreateDeprecated      = errors.New("the create object has been deprecated in favor of user-level options")
+	ErrPasswdCreateAndGecos        = errors.New("cannot use both the create object and the user-level gecos field")
+	ErrPasswdCreateAndGroups       = errors.New("cannot use both the create object and the user-level groups field")
+	ErrPasswdCreateAndHomeDir      = errors.New("cannot use both the create object and the user-level homeDir field")
+	ErrPasswdCreateAndNoCreateHome = errors.New("cannot use both the create object and the user-level noCreateHome field")
+	ErrPasswdCreateAndNoLogInit    = errors.New("cannot use both the create object and the user-level noLogInit field")
+	ErrPasswdCreateAndNoUserGroup  = errors.New("cannot use both the create object and the user-level noUserGroup field")
+	ErrPasswdCreateAndPrimaryGroup = errors.New("cannot use both the create object and the user-level primaryGroup field")
+	ErrPasswdCreateAndShell        = errors.New("cannot use both the create object and the user-level shell field")
+	ErrPasswdCreateAndSystem       = errors.New("cannot use both the create object and the user-level system field")
+	ErrPasswdCreateAndUID          = errors.New("cannot use both the create object and the user-level uid field")
+)
+
+func (p PasswdUser) Validate() report.Report {
+	r := report.Report{}
+	if p.Create != nil {
+		r.Add(report.Entry{
+			Message: ErrPasswdCreateDeprecated.Error(),
+			Kind:    report.EntryWarning,
+		})
+		addErr := func(err error) {
+			r.Add(report.Entry{
+				Message: err.Error(),
+				Kind:    report.EntryError,
+			})
+		}
+		if p.Gecos != "" {
+			addErr(ErrPasswdCreateAndGecos)
+		}
+		if len(p.Groups) > 0 {
+			addErr(ErrPasswdCreateAndGroups)
+		}
+		if p.HomeDir != "" {
+			addErr(ErrPasswdCreateAndHomeDir)
+		}
+		if p.NoCreateHome {
+			addErr(ErrPasswdCreateAndNoCreateHome)
+		}
+		if p.NoLogInit {
+			addErr(ErrPasswdCreateAndNoLogInit)
+		}
+		if p.NoUserGroup {
+			addErr(ErrPasswdCreateAndNoUserGroup)
+		}
+		if p.PrimaryGroup != "" {
+			addErr(ErrPasswdCreateAndPrimaryGroup)
+		}
+		if p.Shell != "" {
+			addErr(ErrPasswdCreateAndShell)
+		}
+		if p.System {
+			addErr(ErrPasswdCreateAndSystem)
+		}
+		if p.UID != nil {
+			addErr(ErrPasswdCreateAndUID)
+		}
+	}
+	return r
+}

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -140,10 +140,22 @@ type PasswdGroup struct {
 
 type PasswdUser struct {
 	Create            *Usercreate        `json:"create,omitempty"`
+	Gecos             string             `json:"gecos,omitempty"`
+	Groups            []PasswdUserGroup  `json:"groups,omitempty"`
+	HomeDir           string             `json:"homeDir,omitempty"`
 	Name              string             `json:"name,omitempty"`
+	NoCreateHome      bool               `json:"noCreateHome,omitempty"`
+	NoLogInit         bool               `json:"noLogInit,omitempty"`
+	NoUserGroup       bool               `json:"noUserGroup,omitempty"`
 	PasswordHash      string             `json:"passwordHash,omitempty"`
+	PrimaryGroup      string             `json:"primaryGroup,omitempty"`
 	SSHAuthorizedKeys []SSHAuthorizedKey `json:"sshAuthorizedKeys,omitempty"`
+	Shell             string             `json:"shell,omitempty"`
+	System            bool               `json:"system,omitempty"`
+	UID               *int               `json:"uid,omitempty"`
 }
+
+type PasswdUserGroup string
 
 type Raid struct {
 	Devices []Device `json:"devices,omitempty"`

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -87,11 +87,21 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **name** (string): the name of the file. This must be suffixed with a valid unit type (e.g. "00-eth0.network").
     * **_contents_** (string): the contents of the networkd file.
 * **_passwd_** (object): describes the desired additions to the passwd database.
-  * **_users_** (list of objects): the list of accounts to be added.
+  * **_users_** (list of objects): the list of accounts that shall exist.
     * **name** (string): the username for the account.
     * **_passwordHash_** (string): the encrypted password for the account.
     * **_sshAuthorizedKeys_** (list of strings): a list of SSH keys to be added to the user's authorized_keys.
-    * **_create_** (object): contains the set of options to be used when creating the user. A non-null entry indicates that the user account shall be created.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_homeDir_** (string): the home directory of the account.
+    * **_noCreateHome_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primaryGroup_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_noUserGroup_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_noLogInit_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_system_** (bool): whether or not to make the account a system account. This only has an effect if the account doesn't exist yet.
+    * **_create_** (object, DEPRECATED): contains the set of options to be used when creating the user. A non-null entry indicates that the user account shall be created. This object has been marked for deprecation, please use the **_users_** level fields instead.
       * **_uid_** (integer): the user ID of the new account.
       * **_gecos_** (string): the GECOS field of the new account.
       * **_homeDir_** (string): the home directory of the new account.

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -212,7 +212,7 @@ func (s stage) createRaids(config types.Config) error {
 			args = append(args, util.DeviceAlias(string(dev)))
 		}
 
-		if err := s.Logger.LogCmd(
+		if _, err := s.Logger.LogCmd(
 			exec.Command("/sbin/mdadm", args...),
 			"creating %q", md.Name,
 		); err != nil {
@@ -274,7 +274,7 @@ func (s stage) createFilesystems(config types.Config) error {
 	// be the slow one, so this should be good enough.
 	//
 	// Test case: boot failure in coreos.ignition.*.btrfsroot kola test.
-	if err := s.Logger.LogCmd(
+	if _, err := s.Logger.LogCmd(
 		exec.Command("/bin/udevadm", "settle"),
 		"waiting for udev to settle",
 	); err != nil {
@@ -319,7 +319,7 @@ func (s stage) createFilesystem(fs types.Mount) error {
 
 	devAlias := util.DeviceAlias(string(fs.Device))
 	args = append(args, devAlias)
-	if err := s.Logger.LogCmd(
+	if _, err := s.Logger.LogCmd(
 		exec.Command(mkfs, args...),
 		"creating %q filesystem on %q",
 		fs.Format, devAlias,

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -403,7 +403,7 @@ func (s stage) createUsers(config types.Config) error {
 	defer s.Logger.PopPrefix()
 
 	for _, u := range config.Passwd.Users {
-		if err := s.CreateUser(u); err != nil {
+		if err := s.EnsureUser(u); err != nil {
 			return fmt.Errorf("failed to create user %q: %v",
 				u.Name, err)
 		}

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -85,8 +85,9 @@ func (u Util) CreateUser(c types.PasswdUser) error {
 
 	args = append(args, c.Name)
 
-	return u.LogCmd(exec.Command("useradd", args...),
+	_, err := u.LogCmd(exec.Command("useradd", args...),
 		"creating user %q", c.Name)
+	return err
 }
 
 // golang--
@@ -161,8 +162,9 @@ func (u Util) SetPasswordHash(c types.PasswdUser) error {
 
 	args = append(args, c.Name)
 
-	return u.LogCmd(exec.Command("usermod", args...),
+	_, err := u.LogCmd(exec.Command("usermod", args...),
 		"setting password for %q", c.Name)
+	return err
 }
 
 // CreateGroup creates the group as described.
@@ -186,6 +188,7 @@ func (u Util) CreateGroup(g types.PasswdGroup) error {
 
 	args = append(args, g.Name)
 
-	return u.LogCmd(exec.Command("groupadd", args...),
+	_, err := u.LogCmd(exec.Command("groupadd", args...),
 		"adding group %q", g.Name)
+	return err
 }

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -115,7 +115,7 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	defer os.Remove(mnt)
 
 	cmd := exec.Command("/usr/bin/mount", "-o", "ro", "-t", "auto", path, mnt)
-	if err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
+	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
 		return nil, err
 	}
 	defer logger.LogOp(

--- a/internal/providers/qemu/qemu.go
+++ b/internal/providers/qemu/qemu.go
@@ -34,7 +34,7 @@ const (
 )
 
 func FetchConfig(logger *log.Logger, _ *resource.HttpClient) (types.Config, report.Report, error) {
-	err := logger.LogCmd(exec.Command("modprobe", "qemu_fw_cfg"), "loading QEMU firmware config module")
+	_, err := logger.LogCmd(exec.Command("modprobe", "qemu_fw_cfg"), "loading QEMU firmware config module")
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/sgdisk/sgdisk.go
+++ b/internal/sgdisk/sgdisk.go
@@ -59,10 +59,10 @@ func (op *Operation) WipeTable(wipe bool) {
 func (op *Operation) Commit() error {
 	if op.wipe {
 		cmd := exec.Command(sgdiskPath, "--zap-all", op.dev)
-		if err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
+		if _, err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
 			op.logger.Info("potential error encountered while wiping table... retrying")
 			cmd = exec.Command(sgdiskPath, "--zap-all", op.dev)
-			if err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
+			if _, err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
 				return fmt.Errorf("wipe failed: %v", err)
 			}
 		}
@@ -82,7 +82,7 @@ func (op *Operation) Commit() error {
 		}
 		opts = append(opts, op.dev)
 		cmd := exec.Command(sgdiskPath, opts...)
-		if err := op.logger.LogCmd(cmd, "creating %d partitions on %q", len(op.parts), op.dev); err != nil {
+		if _, err := op.logger.LogCmd(cmd, "creating %d partitions on %q", len(op.parts), op.dev); err != nil {
 			return fmt.Errorf("create partitions failed: %v", err)
 		}
 	}

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -418,6 +418,39 @@
                 "type": "string"
               }
             },
+            "uid": {
+              "type": ["integer", "null"]
+            },
+            "gecos": {
+              "type": "string"
+            },
+            "homeDir": {
+              "type": "string"
+            },
+            "noCreateHome": {
+              "type": "boolean"
+            },
+            "primaryGroup": {
+              "type": "string"
+            },
+            "groups": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "noUserGroup": {
+              "type": "boolean"
+            },
+            "system": {
+              "type": "boolean"
+            },
+            "noLogInit": {
+              "type": "boolean"
+            },
+            "shell": {
+              "type": "string"
+            },
             "create": {
               "$ref": "#/definitions/passwd/definitions/usercreate"
             }


### PR DESCRIPTION
This commit moves all fields in the user create object up one level
directly into the user object. Using the create object and any of these
copied fields is an error. Using the create object generates a
deprecation warning.

When running the files stage, now ignition will first determine if the
described user exists. If the user exists, `usermod` will be used to
change the user to the desired state, and if the user does not exist
`useradd` will be used to create the user.

Dependent on https://github.com/coreos/bootengine/pull/113