### PR TITLE
internal/vendor: bump update-ssh-keys to latest master

### DIFF
--- a/internal/vendor.manifest
+++ b/internal/vendor.manifest
@@ -2,7 +2,7 @@
 # pkg                                                  version
 github.com/coreos/go-systemd/dbus                      9b2f329b69ae0292a30f426867494f38af617a42
 github.com/coreos/go-systemd/unit                      9b2f329b69ae0292a30f426867494f38af617a42
-github.com/coreos/update-ssh-keys/authorized_keys_d    539317dc5100bc599dab125b1e644a2b017b2b35
+github.com/coreos/update-ssh-keys/authorized_keys_d    96fe9efc1f6eb103d34fdfa5902cb3bb47ebaa81
 github.com/godbus/dbus                                 41608027bdce7bfa8959d653a00b954591220e67
 github.com/sigma/vmw-guestinfo                         95dd4126d6e8b4ef1970b3f3fe2e8cdd470d2903
 github.com/sigma/bdoor                                 babf2a4017b020d4ce04e8167076186e82645dd1

--- a/internal/vendor/github.com/coreos/update-ssh-keys/.gitignore
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/.gitignore
@@ -1,0 +1,3 @@
+bin/
+gopath/
+*.swp

--- a/internal/vendor/github.com/coreos/update-ssh-keys/.travis.yml
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/.travis.yml
@@ -1,0 +1,17 @@
+# Configures tests at Travis CI (https://travis-ci.org).
+
+language: go
+
+go:
+ - 1.3
+
+before_install:
+ - sudo apt-get update -qq
+
+install:
+ - go get code.google.com/p/go.tools/cmd/cover
+ - go get code.google.com/p/go.tools/cmd/vet
+
+script:
+ - ./test
+

--- a/internal/vendor/github.com/coreos/update-ssh-keys/CONTRIBUTING.md
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# How to Contribute
+
+CoreOS projects are [Apache 2.0 licensed](LICENSE) and accept contributions via
+GitHub pull requests.  This document outlines some of the conventions on
+development workflow, commit message formatting, contact points and other
+resources to make it easier to get your contribution accepted.
+
+# Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+
+# Email and Chat
+
+The project currently uses the general CoreOS email list and IRC channel:
+- Email: [coreos-dev](https://groups.google.com/forum/#!forum/coreos-dev)
+- IRC: #[coreos](irc://irc.freenode.org:6667/#coreos) IRC channel on freenode.org
+
+Please avoid emailing maintainers found in the MAINTAINERS file directly. They
+are very busy and read the mailing lists.
+
+## Getting Started
+
+- Fork the repository on GitHub
+- Read the [README](README.md) for build and test instructions
+- Play with the project, submit bugs, submit patches!
+
+## Contribution Flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+- Create a topic branch from where you want to base your work (usually master).
+- Make commits of logical units.
+- Make sure your commit messages are in the proper format (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Make sure the tests pass, and add any new tests as appropriate.
+- Submit a pull request to the original repository.
+
+Thanks for your contributions!
+
+### Format of the Commit Message
+
+We follow a rough convention for commit messages that is designed to answer two
+questions: what changed and why. The subject line should feature the what and
+the body of the commit should describe the why.
+
+```
+scripts: add the test-cluster command
+
+this uses tmux to setup a test cluster that you can easily kill and
+start for debugging.
+
+Fixes #38
+```
+
+The format can be described more formally as follows:
+
+```
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+The first line is the subject and should be no longer than 70 characters, the
+second line is always blank, and other lines should be wrapped at 80 characters.
+This allows the message to be easier to read on GitHub as well as in various
+git tools.

--- a/internal/vendor/github.com/coreos/update-ssh-keys/DCO
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/internal/vendor/github.com/coreos/update-ssh-keys/LICENSE
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/internal/vendor/github.com/coreos/update-ssh-keys/NOTICE
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2014 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/internal/vendor/github.com/coreos/update-ssh-keys/build
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/build
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+ORG_PATH="github.com/coreos"
+REPO_PATH="${ORG_PATH}/update-ssh-keys"
+
+if [ ! -h gopath/src/${REPO_PATH} ]; then
+	mkdir -p gopath/src/${ORG_PATH}
+	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
+fi
+
+export GOBIN=${PWD}/bin
+export GOPATH=${PWD}/gopath
+
+eval $(go env)
+
+echo "Building update-ssh-keys..."
+go build -o ${GOBIN}/update-ssh-keys ${REPO_PATH}/src

--- a/internal/vendor/github.com/coreos/update-ssh-keys/src/authorized_keys_d/as_user/as_user.c
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/src/authorized_keys_d/as_user/as_user.c
@@ -14,6 +14,7 @@
 
 #define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdio.h>
@@ -21,6 +22,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "as_user.h"

--- a/internal/vendor/github.com/coreos/update-ssh-keys/src/authorized_keys_d/authorized_keys_d.go
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/src/authorized_keys_d/authorized_keys_d.go
@@ -318,6 +318,7 @@ func (akd *SSHAuthorizedKeysDir) Sync() error {
 			if err != nil {
 				return err
 			}
+			kb = append(kb, '\n')
 			if _, err := sf.Write(kb); err != nil {
 				return err
 			}

--- a/internal/vendor/github.com/coreos/update-ssh-keys/src/authorized_keys_d/authorized_keys_d_test.go
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/src/authorized_keys_d/authorized_keys_d_test.go
@@ -488,6 +488,7 @@ func TestSync(t *testing.T) {
 			return
 		}
 		bytes = append(bytes, b...)
+		bytes = append(bytes, '\n')
 	}
 
 	if err := akd.Sync(); err != nil {

--- a/internal/vendor/github.com/coreos/update-ssh-keys/src/main.go
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/src/main.go
@@ -1,0 +1,187 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+
+	keys "github.com/coreos/update-ssh-keys/authorized_keys_d"
+)
+
+var (
+	flagUser     = flag.String("u", "core", "Update the given user's authorized_keys file.")
+	flagAdd      = flag.String("a", "", "Add the given keys, using the given name to identify them.")
+	flagAddForce = flag.String("A", "", "Add the given keys, even if it was disabled with '-D'.")
+	flagDelete   = flag.String("d", "", "Delete keys identified by the given name.")
+	flagDisable  = flag.String("D", "", "Disable the given set from being added with '-a'.")
+	flagList     = flag.Bool("l", false, "List the names and number of keys currently installed.")
+	flagReplace  = flag.Bool("n", true, "When adding, don't replace an existing key with the given name.")
+	flagHelp     = flag.Bool("h", false, "This ;-)")
+)
+
+func stderr(f string, a ...interface{}) {
+	out := fmt.Sprintf(f, a...)
+	fmt.Fprintln(os.Stderr, strings.TrimSuffix(out, "\n"))
+}
+
+func stdout(f string, a ...interface{}) {
+	out := fmt.Sprintf(f, a...)
+	fmt.Fprintln(os.Stdout, strings.TrimSuffix(out, "\n"))
+}
+
+func panicf(f string, a ...interface{}) {
+	panic(fmt.Sprintf(f, a...))
+}
+
+// printKeys prints all the keys currently managed.
+func printKeys(akd *keys.SSHAuthorizedKeysDir) error {
+	stdout("All keys for %s", *flagUser)
+	return akd.WalkKeys(func(k *keys.SSHAuthorizedKey) error {
+		if !k.Disabled {
+			cmd := exec.Command("ssh-keygen", "-l", "-f", k.Path)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return err
+			}
+			stdout("%s: %s", k.Name, string(out))
+		}
+		return nil
+	})
+}
+
+// addKeys adds keys to akd as name.
+func addKeys(akd *keys.SSHAuthorizedKeysDir, name string, force bool) error {
+	k := []byte{}
+	files := []*os.File{}
+
+	if flag.NArg() > 0 {
+		// read from files
+		for _, fp := range flag.Args() {
+			f, err := os.Open(fp)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			files = append(files, f)
+		}
+	} else {
+		// read from stdin
+		files = append(files, os.Stdin)
+	}
+
+	for _, f := range files {
+		b, err := ioutil.ReadAll(f)
+		if err != nil {
+			return err
+		}
+		k = append(k, b...)
+	}
+
+	if !validKeys(k) {
+		return fmt.Errorf("key(s) invalid.")
+	}
+
+	return akd.Add(name, k, *flagReplace, force)
+}
+
+// validKeys validates a byte slice contains valid ssh keys.
+func validKeys(keys []byte) bool {
+	// we need to write out a temp file for ssh-keygen to consume.
+	tf, err := ioutil.TempFile("", "update-ssh-keys-")
+	if err != nil {
+		panicf("unable to create temporary file: %v", err)
+	}
+	defer func() {
+		os.Remove(tf.Name())
+		tf.Close()
+	}()
+
+	if _, err := tf.Write(keys); err != nil {
+		panicf("unable to write temporary file: %v", err)
+	}
+
+	cmd := exec.Command("ssh-keygen", "-l", "-f", tf.Name())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	stdout("%s", out)
+
+	return true
+}
+
+func main() {
+	flag.Parse()
+
+	if *flagHelp {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	usr, err := user.Lookup(*flagUser)
+	if err != nil {
+		stderr("Failed to lookup user: %v", *flagUser)
+		os.Exit(2)
+	}
+
+	akd, err := keys.Open(usr, true)
+	if err != nil {
+		stderr("Failed to open: %v", err)
+		os.Exit(3)
+	}
+	defer akd.Close()
+
+	switch {
+	case *flagList:
+		if err := printKeys(akd); err != nil {
+			stderr("Failed to print keys: %v", err)
+			os.Exit(4)
+		}
+	case *flagAdd != "":
+		if err := addKeys(akd, *flagAdd, false); err != nil {
+			stderr("failed to add keys %q: %v", *flagAdd, err)
+			os.Exit(5)
+		}
+	case *flagAddForce != "":
+		if err := addKeys(akd, *flagAddForce, true); err != nil {
+			stderr("failed to add keys %q: %v", *flagAddForce, err)
+			os.Exit(6)
+		}
+	case *flagDelete != "":
+		if err := akd.Remove(*flagDelete); err != nil {
+			stderr("failed to delete key %q: %v", *flagDelete, err)
+			os.Exit(7)
+		}
+	case *flagDisable != "":
+		if err := akd.Disable(*flagDisable); err != nil {
+			stderr("failed to disable key %q: %v", *flagDisable, err)
+			os.Exit(8)
+		}
+	}
+
+	if err := akd.Sync(); err != nil {
+		stderr("Failed sync: %v", err)
+		os.Exit(9)
+	}
+	stdout("Updated %s", akd.KeysFilePath())
+
+	os.Exit(0)
+}

--- a/internal/vendor/github.com/coreos/update-ssh-keys/src/main_test.go
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/src/main_test.go
@@ -1,0 +1,23 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+	// TODO
+}

--- a/internal/vendor/github.com/coreos/update-ssh-keys/test
+++ b/internal/vendor/github.com/coreos/update-ssh-keys/test
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+source ./build
+
+SRC="src authorized_keys_d authorized_keys_d/as_user"
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -s -l $SRC)
+if [ -n "${fmtRes}" ]; then
+	echo -e "gofmt checking failed:\n${fmtRes}"
+	exit 255
+fi
+
+# split SRC into an array and prepend REPO_PATH to each local package for go vet
+split_vet=(${SRC// / })
+VET_TEST=${split_vet[@]/#/${REPO_PATH}/}
+
+echo "Checking govet..."
+vetRes=$(go vet $VET_TEST)
+if [ -n "${vetRes}" ]; then
+	echo -e "govet checking failed:\n${vetRes}"
+	exit 255
+fi
+
+echo "Running tests..."
+go test -timeout 60s -cover $@ ${VET_TEST} --race
+
+echo "Success"


### PR DESCRIPTION
@bgilbert had an issue where some C header files were not being imported in the update-ssh-keys vendored dependency. This dependency had been fixed some time ago, this commit updates the vendored copy here to include the fixes.