### PR TITLE
config/type/passwd: support unspecified passwords

### DIFF
--- a/config/translate.go
+++ b/config/translate.go
@@ -30,6 +30,13 @@ func intToPtr(x int) *int {
 	return &x
 }
 
+func strToPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 func TranslateFromV1(old v1.Config) types.Config {
 	config := types.Config{
 		Ignition: types.Ignition{
@@ -139,7 +146,7 @@ func TranslateFromV1(old v1.Config) types.Config {
 	for _, oldUser := range old.Passwd.Users {
 		user := types.PasswdUser{
 			Name:              oldUser.Name,
-			PasswordHash:      oldUser.PasswordHash,
+			PasswordHash:      strToPtr(oldUser.PasswordHash),
 			SSHAuthorizedKeys: translateStringSliceToV2_1SSHAuthorizedKeySlice(oldUser.SSHAuthorizedKeys),
 		}
 
@@ -353,7 +360,7 @@ func TranslateFromV2_0(old v2_0.Config) types.Config {
 	for _, oldUser := range old.Passwd.Users {
 		user := types.PasswdUser{
 			Name:              oldUser.Name,
-			PasswordHash:      oldUser.PasswordHash,
+			PasswordHash:      strToPtr(oldUser.PasswordHash),
 			SSHAuthorizedKeys: translateStringSliceToV2_1SSHAuthorizedKeySlice(oldUser.SSHAuthorizedKeys),
 		}
 

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -384,12 +384,12 @@ func TestTranslateFromV1(t *testing.T) {
 					Users: []types.PasswdUser{
 						{
 							Name:              "user 1",
-							PasswordHash:      "password 1",
+							PasswordHash:      strToPtr("password 1"),
 							SSHAuthorizedKeys: []types.SSHAuthorizedKey{"key1", "key2"},
 						},
 						{
 							Name:              "user 2",
-							PasswordHash:      "password 2",
+							PasswordHash:      strToPtr("password 2"),
 							SSHAuthorizedKeys: []types.SSHAuthorizedKey{"key3", "key4"},
 							Create: &types.Usercreate{
 								UID:          func(i int) *int { return &i }(123),
@@ -406,7 +406,7 @@ func TestTranslateFromV1(t *testing.T) {
 						},
 						{
 							Name:              "user 3",
-							PasswordHash:      "password 3",
+							PasswordHash:      strToPtr("password 3"),
 							SSHAuthorizedKeys: []types.SSHAuthorizedKey{"key5", "key6"},
 							Create:            &types.Usercreate{},
 						},
@@ -506,7 +506,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 									Opaque: ",file2",
 								}).String(),
 								Verification: types.Verification{
-									Hash: func(s string) *string { return &s }("func2-sum2"),
+									Hash: strToPtr("func2-sum2"),
 								},
 							},
 						},
@@ -516,7 +516,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 								Opaque: ",file3",
 							}).String(),
 							Verification: types.Verification{
-								Hash: func(s string) *string { return &s }("func3-sum3"),
+								Hash: strToPtr("func3-sum3"),
 							},
 						},
 					},
@@ -895,12 +895,12 @@ func TestTranslateFromV2_0(t *testing.T) {
 					Users: []types.PasswdUser{
 						{
 							Name:              "user 1",
-							PasswordHash:      "password 1",
+							PasswordHash:      strToPtr("password 1"),
 							SSHAuthorizedKeys: []types.SSHAuthorizedKey{"key1", "key2"},
 						},
 						{
 							Name:              "user 2",
-							PasswordHash:      "password 2",
+							PasswordHash:      strToPtr("password 2"),
 							SSHAuthorizedKeys: []types.SSHAuthorizedKey{"key3", "key4"},
 							Create: &types.Usercreate{
 								UID:          func(i int) *int { return &i }(123),
@@ -917,7 +917,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 						},
 						{
 							Name:              "user 3",
-							PasswordHash:      "password 3",
+							PasswordHash:      strToPtr("password 3"),
 							SSHAuthorizedKeys: []types.SSHAuthorizedKey{"key5", "key6"},
 							Create:            &types.Usercreate{},
 						},

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -149,7 +149,7 @@ type PasswdUser struct {
 	NoCreateHome      bool               `json:"noCreateHome,omitempty"`
 	NoLogInit         bool               `json:"noLogInit,omitempty"`
 	NoUserGroup       bool               `json:"noUserGroup,omitempty"`
-	PasswordHash      string             `json:"passwordHash,omitempty"`
+	PasswordHash      *string            `json:"passwordHash,omitempty"`
 	PrimaryGroup      string             `json:"primaryGroup,omitempty"`
 	SSHAuthorizedKeys []SSHAuthorizedKey `json:"sshAuthorizedKeys,omitempty"`
 	Shell             string             `json:"shell,omitempty"`

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -81,9 +81,15 @@ func (u Util) EnsureUser(c types.PasswdUser) error {
 		}
 	}
 
-	if c.PasswordHash != "" {
-		args = append(args, "--password", c.PasswordHash)
-	} else {
+	if c.PasswordHash != nil {
+		if *c.PasswordHash != "" {
+			args = append(args, "--password", *c.PasswordHash)
+		} else {
+			args = append(args, "--password", "*")
+		}
+	} else if !exists {
+		// Set the user's password to "*" if they don't exist yet and one wasn't
+		// set to disable password logins
 		args = append(args, "--password", "*")
 	}
 
@@ -198,13 +204,18 @@ func translateV2_1SSHAuthorizedKeySliceToStringSlice(keys []types.SSHAuthorizedK
 
 // SetPasswordHash sets the password hash of the specified user.
 func (u Util) SetPasswordHash(c types.PasswdUser) error {
-	if c.PasswordHash == "" {
+	if c.PasswordHash == nil {
 		return nil
+	}
+
+	pwhash := *c.PasswordHash
+	if *c.PasswordHash == "" {
+		pwhash = "*"
 	}
 
 	args := []string{
 		"--root", u.DestDir,
-		"--password", c.PasswordHash,
+		"--password", pwhash,
 	}
 
 	args = append(args, c.Name)

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -416,7 +416,7 @@
               "type": "string"
             },
             "passwordHash": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "sshAuthorizedKeys": {
               "type": "array",


### PR DESCRIPTION
The password for an existing user shouldn't be touched if it isn't
specified in the config. An empty but specified password results in
password login for the user being disabled (the hash is set to "*").

The `coreos.ignition.v2.users` kola test fails without this fix.