### PR TITLE
*: re-introduce timeouts

### DIFF
--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -29,8 +29,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/resource"
-
-	"golang.org/x/net/context"
 )
 
 const (
@@ -88,7 +86,7 @@ func RenderFile(l *log.Logger, c *resource.HttpClient, f types.File) *File {
 	// validated by this point
 	u, _ := url.Parse(f.Contents.Source)
 
-	reader, err = resource.FetchAsReader(l, c, context.Background(), *u)
+	reader, err = resource.FetchAsReader(l, c, *u)
 	if err != nil {
 		l.Crit("Error fetching file %q: %v", f.Path, err)
 		return nil

--- a/internal/main.go
+++ b/internal/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/coreos/ignition/internal/exec"
 	"github.com/coreos/ignition/internal/exec/stages"
@@ -30,16 +31,18 @@ import (
 
 func main() {
 	flags := struct {
-		clearCache  bool
-		configCache string
-		oem         oem.Name
-		root        string
-		stage       stages.Name
-		version     bool
+		clearCache   bool
+		configCache  string
+		fetchTimeout time.Duration
+		oem          oem.Name
+		root         string
+		stage        stages.Name
+		version      bool
 	}{}
 
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
 	flag.StringVar(&flags.configCache, "config-cache", "/run/ignition.json", "where to cache the config")
+	flag.DurationVar(&flags.fetchTimeout, "fetch-timeout", exec.DefaultFetchTimeout, "initial duration for which to wait for config")
 	flag.Var(&flags.oem, "oem", fmt.Sprintf("current oem. %v", oem.Names()))
 	flag.StringVar(&flags.root, "root", "/", "root of the filesystem")
 	flag.Var(&flags.stage, "stage", fmt.Sprintf("execution stage. %v", stages.Names()))
@@ -76,6 +79,7 @@ func main() {
 	oemConfig := oem.MustGet(flags.oem.String())
 	engine := exec.Engine{
 		Root:              flags.root,
+		FetchTimeout:      flags.fetchTimeout,
 		Logger:            &logger,
 		ConfigCache:       flags.configCache,
 		FetchFunc:         oemConfig.FetchFunc(),

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -28,8 +28,6 @@ import (
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
-
-	"golang.org/x/net/context"
 )
 
 const (
@@ -47,7 +45,7 @@ func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config,
 		return types.Config{}, report.Report{}, providers.ErrNoProvider
 	}
 
-	data, err := resource.FetchConfig(logger, client, context.Background(), *url)
+	data, err := resource.FetchConfig(logger, client, *url)
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/digitalocean/digitalocean.go
+++ b/internal/providers/digitalocean/digitalocean.go
@@ -25,8 +25,6 @@ import (
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
-
-	"golang.org/x/net/context"
 )
 
 var (
@@ -38,7 +36,7 @@ var (
 )
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
-	data, err := resource.FetchConfig(logger, client, context.Background(), userdataUrl)
+	data, err := resource.FetchConfig(logger, client, userdataUrl)
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -25,8 +25,6 @@ import (
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
-
-	"golang.org/x/net/context"
 )
 
 var (
@@ -38,7 +36,7 @@ var (
 )
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
-	data, err := resource.FetchConfig(logger, client, context.Background(), userdataUrl)
+	data, err := resource.FetchConfig(logger, client, userdataUrl)
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/gce/gce.go
+++ b/internal/providers/gce/gce.go
@@ -26,8 +26,6 @@ import (
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
-
-	"golang.org/x/net/context"
 )
 
 var (
@@ -40,7 +38,7 @@ var (
 )
 
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
-	data, err := resource.FetchConfigWithHeader(logger, client, context.Background(), userdataUrl, metadataHeader)
+	data, err := resource.FetchConfigWithHeader(logger, client, userdataUrl, metadataHeader)
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -131,5 +131,5 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 }
 
 func fetchConfigFromMetadataService(logger *log.Logger, client *resource.HttpClient, ctx context.Context) ([]byte, error) {
-	return resource.FetchConfig(logger, client, context.Background(), metadataServiceUrl)
+	return resource.FetchConfig(logger, client, metadataServiceUrl)
 }

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -25,8 +25,6 @@ import (
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
-
-	"golang.org/x/net/context"
 )
 
 var (
@@ -40,7 +38,7 @@ var (
 func FetchConfig(logger *log.Logger, client *resource.HttpClient) (types.Config, report.Report, error) {
 	// TODO: Packet's metadata service returns "Not Acceptable" when queried
 	// with the default headers. For now, just do a regular fetch.
-	data, err := resource.Fetch(logger, client, context.Background(), userdataUrl)
+	data, err := resource.Fetch(logger, client, userdataUrl)
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}


### PR DESCRIPTION
This functionality was lost in d34c2246. This commit reintroduces it as
well as exposing the initial timeout as a flag and removing the
restriction on the maximum number of attempts. The timeouts will control
the number of attempts that can be made.