### PR TITLE
config/types/url: allow tftp urls during validation

### DIFF
--- a/config/types/url.go
+++ b/config/types/url.go
@@ -36,7 +36,7 @@ func validateURL(s string) error {
 	}
 
 	switch u.Scheme {
-	case "http", "https", "oem":
+	case "http", "https", "oem", "tftp":
 		return nil
 	case "data":
 		if _, err := dataurl.DecodeString(s); err != nil {

--- a/config/types/url_test.go
+++ b/config/types/url_test.go
@@ -48,6 +48,10 @@ func TestURLValidate(t *testing.T) {
 			out: out{},
 		},
 		{
+			in:  in{u: "tftp://example.com:69/foobar.txt"},
+			out: out{},
+		},
+		{
 			in:  in{u: "data:,example%20file%0A"},
 			out: out{},
 		},

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -80,7 +80,7 @@ func FetchConfigWithHeader(l *log.Logger, c *HttpClient, u url.URL, h http.Heade
 }
 
 // Fetch fetches a resource given a URL. The supported schemes are
-// http, data, and oem.
+// http, data, tftp, and oem.
 func Fetch(l *log.Logger, c *HttpClient, u url.URL) ([]byte, error) {
 	return FetchWithHeader(l, c, u, http.Header{})
 }


### PR DESCRIPTION
The earlier commit that added support for TFTP urls never added tftp to
the list of supported schemas when validating URLs. This means that
Ignition configs were able to be fetched from TFTP sources, but any TFTP
URLs in the config would cause an error.