### PR TITLE
internal/exec/util/file: fix nil pointer dereference

### DIFF
--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/ignition/internal/exec/util"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/resource"
+	internalUtil "github.com/coreos/ignition/internal/util"
 )
 
 const (
@@ -118,6 +119,14 @@ type fileEntry types.File
 
 func (tmp fileEntry) create(l *log.Logger, c *resource.HttpClient, u util.Util) error {
 	f := types.File(tmp)
+
+	if f.User.ID == nil {
+		f.User.ID = internalUtil.IntToPtr(0)
+	}
+	if f.Group.ID == nil {
+		f.Group.ID = internalUtil.IntToPtr(0)
+	}
+
 	file := util.RenderFile(l, c, f)
 	if file == nil {
 		return fmt.Errorf("failed to resolve file %q", f.Path)
@@ -137,6 +146,14 @@ type dirEntry types.Directory
 
 func (tmp dirEntry) create(l *log.Logger, _ *resource.HttpClient, u util.Util) error {
 	d := types.Directory(tmp)
+
+	if d.User.ID == nil {
+		d.User.ID = internalUtil.IntToPtr(0)
+	}
+	if d.Group.ID == nil {
+		d.Group.ID = internalUtil.IntToPtr(0)
+	}
+
 	err := l.LogOp(func() error {
 		path := filepath.Clean(u.JoinPath(string(d.Path)))
 
@@ -180,6 +197,13 @@ type linkEntry types.Link
 
 func (tmp linkEntry) create(l *log.Logger, _ *resource.HttpClient, u util.Util) error {
 	s := types.Link(tmp)
+
+	if s.User.ID == nil {
+		s.User.ID = internalUtil.IntToPtr(0)
+	}
+	if s.Group.ID == nil {
+		s.Group.ID = internalUtil.IntToPtr(0)
+	}
 
 	if err := l.LogOp(
 		func() error { return u.WriteLink(s) },

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,19 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+func IntToPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
Recent changes allowing file owners to be referenced by user/group names
changed the id field for the user and group to be a pointer, so that it
could be detected when it was left empty vs when it was specified to be
0. The simple example given to justify this was when a user provided a
config saying that the file should be owned by user "core" and uid "0",
if the id was not a pointer it would appear to Ignition as if they had
not provided a uid.

The logic dealing with setting the UID failed to properly handle nil
values here, and can cause nil pointer dereferences. This commit adds a
check and an assignment to fix this for both of these fields.

If a file's owner is unspecified, it will default to the root user and
group.