### PR TITLE
Validate filesystem label length and add vfat support

### DIFF
--- a/config/types/filesystem.go
+++ b/config/types/filesystem.go
@@ -28,6 +28,10 @@ var (
 	ErrUsedCreateAndMountOpts      = errors.New("cannot use both create object and mount-level options field")
 	ErrUsedCreateAndWipeFilesystem = errors.New("cannot use both create object and wipeFilesystem field")
 	ErrWarningCreateDeprecated     = errors.New("the create object has been deprecated in favor of mount-level options")
+	ErrExt4LabelTooLong            = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
+	ErrBtrfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
+	ErrXfsLabelTooLong             = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")
+	ErrSwapLabelTooLong            = errors.New("filesystem labels cannot be longer than 15 characters when using swap")
 )
 
 func (f Filesystem) Validate() report.Report {
@@ -98,6 +102,50 @@ func (m Mount) ValidateDevice() report.Report {
 			Message: err.Error(),
 			Kind:    report.EntryError,
 		})
+	}
+	return r
+}
+
+func (m Mount) ValidateLabel() report.Report {
+	r := report.Report{}
+	if m.Label == nil {
+		return r
+	}
+	switch m.Format {
+	case "ext4":
+		if len(*m.Label) > 16 {
+			// source: man mkfs.ext4
+			r.Add(report.Entry{
+				Message: ErrExt4LabelTooLong.Error(),
+				Kind:    report.EntryError,
+			})
+		}
+	case "btrfs":
+		if len(*m.Label) > 256 {
+			// source: man mkfs.btrfs
+			r.Add(report.Entry{
+				Message: ErrBtrfsLabelTooLong.Error(),
+				Kind:    report.EntryError,
+			})
+		}
+	case "xfs":
+		if len(*m.Label) > 12 {
+			// source: man mkfs.xfs
+			r.Add(report.Entry{
+				Message: ErrXfsLabelTooLong.Error(),
+				Kind:    report.EntryError,
+			})
+		}
+	case "swap":
+		// mkswap's man page does not state a limit on label size, but through
+		// experimentation it appears that mkswap will truncate long labels to
+		// 15 characters, so let's enforce that.
+		if len(*m.Label) > 15 {
+			r.Add(report.Entry{
+				Message: ErrSwapLabelTooLong.Error(),
+				Kind:    report.EntryError,
+			})
+		}
 	}
 	return r
 }

--- a/config/types/filesystem.go
+++ b/config/types/filesystem.go
@@ -32,6 +32,7 @@ var (
 	ErrBtrfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
 	ErrXfsLabelTooLong             = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")
 	ErrSwapLabelTooLong            = errors.New("filesystem labels cannot be longer than 15 characters when using swap")
+	ErrVfatLabelTooLong            = errors.New("filesystem labels cannot be longer than 11 characters when using vfat")
 )
 
 func (f Filesystem) Validate() report.Report {
@@ -85,7 +86,7 @@ func (f Filesystem) ValidatePath() report.Report {
 func (m Mount) Validate() report.Report {
 	r := report.Report{}
 	switch m.Format {
-	case "ext4", "btrfs", "xfs", "swap":
+	case "ext4", "btrfs", "xfs", "swap", "vfat":
 	default:
 		r.Add(report.Entry{
 			Message: ErrFilesystemInvalidFormat.Error(),
@@ -143,6 +144,14 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 15 {
 			r.Add(report.Entry{
 				Message: ErrSwapLabelTooLong.Error(),
+				Kind:    report.EntryError,
+			})
+		}
+	case "vfat":
+		if len(*m.Label) > 11 {
+			// source: man mkfs.fat
+			r.Add(report.Entry{
+				Message: ErrVfatLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/types/filesystem_test.go
+++ b/config/types/filesystem_test.go
@@ -92,3 +92,87 @@ func TestFilesystemValidate(t *testing.T) {
 		}
 	}
 }
+
+func TestLabelValidate(t *testing.T) {
+	type in struct {
+		mount Mount
+	}
+	type out struct {
+		err error
+	}
+
+	strToPtr := func(p string) *string { return &p }
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{mount: Mount{Format: "ext4", Label: nil}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "ext4", Label: strToPtr("data")}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "ext4", Label: strToPtr("thislabelistoolong")}},
+			out: out{err: ErrExt4LabelTooLong},
+		},
+		{
+			in:  in{mount: Mount{Format: "btrfs", Label: nil}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "btrfs", Label: strToPtr("thislabelisnottoolong")}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "btrfs", Label: strToPtr("thislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolong")}},
+			out: out{err: ErrBtrfsLabelTooLong},
+		},
+		{
+			in:  in{mount: Mount{Format: "xfs", Label: nil}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "xfs", Label: strToPtr("data")}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "xfs", Label: strToPtr("thislabelistoolong")}},
+			out: out{err: ErrXfsLabelTooLong},
+		},
+		{
+			in:  in{mount: Mount{Format: "swap", Label: nil}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "swap", Label: strToPtr("data")}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "swap", Label: strToPtr("thislabelistoolong")}},
+			out: out{err: ErrSwapLabelTooLong},
+		},
+		{
+			in:  in{mount: Mount{Format: "vfat", Label: nil}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "vfat", Label: strToPtr("data")}},
+			out: out{},
+		},
+		{
+			in:  in{mount: Mount{Format: "vfat", Label: strToPtr("thislabelistoolong")}},
+			out: out{err: ErrVfatLabelTooLong},
+		},
+	}
+
+	for i, test := range tests {
+		err := test.in.mount.ValidateLabel()
+		if !reflect.DeepEqual(report.ReportFromError(test.out.err, report.EntryError), err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+	}
+}

--- a/doc/configuration-v2_1-experimental.md
+++ b/doc/configuration-v2_1-experimental.md
@@ -38,7 +38,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_name_** (string): the identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the "files" section.
     * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.
       * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
-      * **format** (string): the filesystem format (ext4, btrfs, xfs, or swap).
+      * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, or swap).
       * **_wipeFilesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](filesystems.md) for more information.
       * **_label_** (string): the label of the filesystem.
       * **_uuid_** (string): the uuid of the filesystem.

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -316,6 +316,9 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		if fs.UUID != nil {
 			args = append(args, []string{"-U", *fs.UUID}...)
 		}
+		if fs.Label != nil {
+			args = append(args, []string{"-L", *fs.Label}...)
+		}
 	case "ext4":
 		mkfs = "/sbin/mkfs.ext4"
 		args = append(args, "-p")
@@ -325,6 +328,9 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		if fs.UUID != nil {
 			args = append(args, []string{"-U", *fs.UUID}...)
 		}
+		if fs.Label != nil {
+			args = append(args, []string{"-L", *fs.Label}...)
+		}
 	case "xfs":
 		mkfs = "/sbin/mkfs.xfs"
 		if force {
@@ -332,6 +338,9 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		}
 		if fs.UUID != nil {
 			args = append(args, []string{"-m", "uuid=" + *fs.UUID}...)
+		}
+		if fs.Label != nil {
+			args = append(args, []string{"-L", *fs.Label}...)
 		}
 	case "swap":
 		mkfs = "/sbin/mkswap"
@@ -341,11 +350,11 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		if fs.UUID != nil {
 			args = append(args, []string{"-U", *fs.UUID}...)
 		}
+		if fs.Label != nil {
+			args = append(args, []string{"-L", *fs.Label}...)
+		}
 	default:
 		return fmt.Errorf("unsupported filesystem format: %q", fs.Format)
-	}
-	if fs.Label != nil {
-		args = append(args, []string{"-L", *fs.Label}...)
 	}
 
 	devAlias := util.DeviceAlias(string(fs.Device))

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -353,6 +353,16 @@ func (s stage) createFilesystem(fs types.Mount) error {
 		if fs.Label != nil {
 			args = append(args, []string{"-L", *fs.Label}...)
 		}
+	case "vfat":
+		mkfs = "/sbin/mkfs.vfat"
+		// There is no force flag for mkfs.vfat, it always destroys any data on
+		// the device at which it is pointed.
+		if fs.UUID != nil {
+			args = append(args, []string{"-i", *fs.UUID}...)
+		}
+		if fs.Label != nil {
+			args = append(args, []string{"-n", *fs.Label}...)
+		}
 	default:
 		return fmt.Errorf("unsupported filesystem format: %q", fs.Format)
 	}


### PR DESCRIPTION
This PR does two things:
- adds validation for filesystem label length, to ensure user entered filesystem labels will not be too long to be accepted by the relevant `mkfs` utility
- adds support for vfat filesystems

Tested in a QEMU instance with this config: https://gist.github.com/dgonyeo/f7ad90bcb845dfa02ce52f661be1ce82

Fixes https://github.com/coreos/bugs/issues/1990

These PRs are needed for this to work:
- https://github.com/coreos/bootengine/pull/115
- https://github.com/coreos/coreos-overlay/pull/2597