### PR TITLE
providers/vmware: add support for ovf environments

### DIFF
--- a/config/vendor.manifest
+++ b/config/vendor.manifest
@@ -2,7 +2,7 @@
 # pkg                                                  version
 github.com/ajeddeloh/go-json                           73d058cf8437a1989030afe571eeab9f90eebbbd
 github.com/coreos/go-semver                            294930c1e79c64e7dbe360054274fdad492c8cf5
-github.com/vincent-petithory/dataurl                   9a301d65acbb728fcc3ace14f45f511a4cfeea9c
-go4.org/errorutil                                      03efcb870d84809319ea509714dd6d19a1498483
 github.com/coreos/go-systemd/unit                      7c9533367ef925dc1078d75e5b7141e10da2c4e8
 github.com/stretchr/testify                            4d4bfba8f1d1027c4fdbe371823030df51419987
+github.com/vincent-petithory/dataurl                   9a301d65acbb728fcc3ace14f45f511a4cfeea9c
+go4.org/errorutil                                      03efcb870d84809319ea509714dd6d19a1498483

--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -6,7 +6,7 @@ Ignition is currently only supported for the following platforms:
 * [PXE] - Use the `coreos.config.url` and `coreos.first_boot=1` (**in case of the very first PXE boot only**) kernel parameters to provide a URL to the configuration. The URL can use the `http://` or `tftp://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
 * [Amazon EC2] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
-* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64".
+* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment.
 * [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [QEMU] - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device.

--- a/internal/providers/vmware/vmware.go
+++ b/internal/providers/vmware/vmware.go
@@ -25,19 +25,24 @@ import (
 	"strings"
 )
 
-func decodeData(data string, encoding string) ([]byte, error) {
-	switch encoding {
+type config struct {
+	data     string
+	encoding string
+}
+
+func decodeConfig(config config) ([]byte, error) {
+	switch config.encoding {
 	case "":
-		return []byte(data), nil
+		return []byte(config.data), nil
 
 	case "b64", "base64":
-		return decodeBase64Data(data)
+		return decodeBase64Data(config.data)
 
 	case "gz", "gzip":
-		return decodeGzipData(data)
+		return decodeGzipData(config.data)
 
 	case "gz+base64", "gzip+base64", "gz+b64", "gzip+b64":
-		gz, err := decodeBase64Data(data)
+		gz, err := decodeBase64Data(config.data)
 
 		if err != nil {
 			return nil, err
@@ -46,7 +51,7 @@ func decodeData(data string, encoding string) ([]byte, error) {
 		return decodeGzipData(string(gz))
 	}
 
-	return nil, fmt.Errorf("unsupported encoding %q", encoding)
+	return nil, fmt.Errorf("unsupported encoding %q", config.encoding)
 }
 
 func decodeBase64Data(data string) ([]byte, error) {

--- a/internal/providers/vmware/vmware.go
+++ b/internal/providers/vmware/vmware.go
@@ -46,13 +46,13 @@ func decodeData(data string, encoding string) ([]byte, error) {
 		return decodeGzipData(string(gz))
 	}
 
-	return nil, fmt.Errorf("Unsupported encoding %q", encoding)
+	return nil, fmt.Errorf("unsupported encoding %q", encoding)
 }
 
 func decodeBase64Data(data string) ([]byte, error) {
 	decodedData, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to decode base64: %q", err)
+		return nil, fmt.Errorf("unable to decode base64: %q", err)
 	}
 
 	return decodedData, nil

--- a/internal/vendor.manifest
+++ b/internal/vendor.manifest
@@ -4,10 +4,10 @@ github.com/coreos/go-systemd/dbus                      9b2f329b69ae0292a30f42686
 github.com/coreos/go-systemd/unit                      9b2f329b69ae0292a30f426867494f38af617a42
 github.com/coreos/update-ssh-keys/authorized_keys_d    96fe9efc1f6eb103d34fdfa5902cb3bb47ebaa81
 github.com/godbus/dbus                                 41608027bdce7bfa8959d653a00b954591220e67
-github.com/sigma/vmw-guestinfo                         95dd4126d6e8b4ef1970b3f3fe2e8cdd470d2903
+github.com/pin/tftp                                    9ea92f6b1029bc1bf3072bba195c84bb9b0370e3
 github.com/sigma/bdoor                                 babf2a4017b020d4ce04e8167076186e82645dd1
+github.com/sigma/vmw-guestinfo                         95dd4126d6e8b4ef1970b3f3fe2e8cdd470d2903
+github.com/stretchr/testify                            4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/vincent-petithory/dataurl                   9a301d65acbb728fcc3ace14f45f511a4cfeea9c
 golang.org/golang.org/x/net/context                    075e191f18186a8ff2becaf64478e30f4545cdad
 golang.org/golang.org/x/net/context/ctxhttp            075e191f18186a8ff2becaf64478e30f4545cdad
-github.com/stretchr/testify                            4d4bfba8f1d1027c4fdbe371823030df51419987
-github.com/pin/tftp                                    9ea92f6b1029bc1bf3072bba195c84bb9b0370e3

--- a/internal/vendor.manifest
+++ b/internal/vendor.manifest
@@ -9,5 +9,6 @@ github.com/sigma/bdoor                                 babf2a4017b020d4ce04e8167
 github.com/sigma/vmw-guestinfo                         95dd4126d6e8b4ef1970b3f3fe2e8cdd470d2903
 github.com/stretchr/testify                            4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/vincent-petithory/dataurl                   9a301d65acbb728fcc3ace14f45f511a4cfeea9c
+github.com/vmware/vmw-ovflib                           1f217b9dc714d5f340d0a3cc3e9d49255c536f68
 golang.org/golang.org/x/net/context                    075e191f18186a8ff2becaf64478e30f4545cdad
 golang.org/golang.org/x/net/context/ctxhttp            075e191f18186a8ff2becaf64478e30f4545cdad

--- a/internal/vendor/github.com/vmware/vmw-ovflib/LICENSE
+++ b/internal/vendor/github.com/vmware/vmw-ovflib/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/internal/vendor/github.com/vmware/vmw-ovflib/README
+++ b/internal/vendor/github.com/vmware/vmw-ovflib/README
@@ -1,0 +1,1 @@
+minimal support for parsing OVF environment

--- a/internal/vendor/github.com/vmware/vmw-ovflib/ovf.go
+++ b/internal/vendor/github.com/vmware/vmw-ovflib/ovf.go
@@ -1,0 +1,54 @@
+// Copyright 2014-2015 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovf
+
+import (
+	"encoding/xml"
+)
+
+type environment struct {
+	Platform   platform   `xml:"PlatformSection"`
+	Properties []property `xml:"PropertySection>Property"`
+}
+
+type platform struct {
+	Kind    string `xml:"Kind"`
+	Version string `xml:"Version"`
+	Vendor  string `xml:"Vendor"`
+	Locale  string `xml:"Locale"`
+}
+
+type property struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type OvfEnvironment struct {
+	Platform   platform
+	Properties map[string]string
+}
+
+func ReadEnvironment(doc []byte) (OvfEnvironment, error) {
+	var env environment
+	if err := xml.Unmarshal(doc, &env); err != nil {
+		return OvfEnvironment{}, err
+	}
+
+	dict := make(map[string]string)
+	for _, p := range env.Properties {
+		dict[p.Key] = p.Value
+	}
+	return OvfEnvironment{Properties: dict, Platform: env.Platform}, nil
+}

--- a/internal/vendor/github.com/vmware/vmw-ovflib/ovf_test.go
+++ b/internal/vendor/github.com/vmware/vmw-ovflib/ovf_test.go
@@ -1,0 +1,128 @@
+// Copyright 2014-2015 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovf
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var data_vsphere = []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Environment
+     xmlns="http://schemas.dmtf.org/ovf/environment/1"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:oe="http://schemas.dmtf.org/ovf/environment/1"
+     xmlns:ve="http://www.vmware.com/schema/ovfenv"
+     oe:id=""
+     ve:vCenterId="vm-12345">
+   <PlatformSection>
+      <Kind>VMware ESXi</Kind>
+      <Version>5.5.0</Version>
+      <Vendor>VMware, Inc.</Vendor>
+      <Locale>en</Locale>
+   </PlatformSection>
+   <PropertySection>
+         <Property oe:key="foo" oe:value="42"/>
+         <Property oe:key="bar" oe:value="0"/>
+   </PropertySection>
+   <ve:EthernetAdapterSection>
+      <ve:Adapter ve:mac="00:00:00:00:00:00" ve:network="foo" ve:unitNumber="7"/>
+   </ve:EthernetAdapterSection>
+</Environment>`)
+
+var data_vapprun = []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Environment xmlns="http://schemas.dmtf.org/ovf/environment/1"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:oe="http://schemas.dmtf.org/ovf/environment/1"
+     oe:id="CoreOS-vmw">
+   <PlatformSection>
+      <Kind>vapprun</Kind>
+      <Version>1.0</Version>
+      <Vendor>VMware, Inc.</Vendor>
+      <Locale>en_US</Locale>
+   </PlatformSection>
+   <PropertySection>
+      <Property oe:key="foo" oe:value="42"/>
+      <Property oe:key="bar" oe:value="0"/>
+      <Property oe:key="guestinfo.user_data.url" oe:value="https://gist.githubusercontent.com/sigma/5a64aac1693da9ca70d2/raw/plop.yaml"/>
+      <Property oe:key="guestinfo.user_data.doc" oe:value=""/>
+      <Property oe:key="guestinfo.meta_data.url" oe:value=""/>
+      <Property oe:key="guestinfo.meta_data.doc" oe:value=""/>
+   </PropertySection>
+</Environment>`)
+
+func TestOvfEnvProperties(t *testing.T) {
+
+	var testerFunc = func(env_str []byte) func() {
+		return func() {
+			env, err := ReadEnvironment(env_str)
+			So(err, ShouldBeNil)
+			props := env.Properties
+
+			var val string
+			var ok bool
+			Convey(`Property "foo"`, func() {
+				val, ok = props["foo"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldEqual, "42")
+			})
+
+			Convey(`Property "bar"`, func() {
+				val, ok = props["bar"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldEqual, "0")
+			})
+		}
+	}
+
+	Convey("With vAppRun environment", t, testerFunc(data_vapprun))
+	Convey("With vSphere environment", t, testerFunc(data_vsphere))
+}
+
+func TestOvfEnvPlatform(t *testing.T) {
+	Convey("With vSphere environment", t, func() {
+		env, err := ReadEnvironment(data_vsphere)
+		So(err, ShouldBeNil)
+		platform := env.Platform
+
+		So(platform.Kind, ShouldEqual, "VMware ESXi")
+		So(platform.Version, ShouldEqual, "5.5.0")
+		So(platform.Vendor, ShouldEqual, "VMware, Inc.")
+		So(platform.Locale, ShouldEqual, "en")
+	})
+}
+
+func TestVappRunUserDataUrl(t *testing.T) {
+	Convey("With vAppRun environment", t, func() {
+		env, err := ReadEnvironment(data_vapprun)
+		So(err, ShouldBeNil)
+		props := env.Properties
+
+		var val string
+		var ok bool
+
+		val, ok = props["guestinfo.user_data.url"]
+		So(ok, ShouldBeTrue)
+		So(val, ShouldEqual, "https://gist.githubusercontent.com/sigma/5a64aac1693da9ca70d2/raw/plop.yaml")
+	})
+}
+
+func TestInvalidData(t *testing.T) {
+	Convey("With invalid data", t, func() {
+		_, err := ReadEnvironment(append(data_vsphere, []byte("garbage")...))
+		So(err, ShouldBeNil)
+	})
+}


### PR DESCRIPTION
When using VMware's OVF, an environment can optionally be provided
(sometimes done interactively when using tools like vSphere). When this
environment is provided, the guest variables are included in an XML
document at `guestinfo.ovfenv` instead of each of the keys being
directly added to the guest variables.

Still needs docs and testing.