### PR TITLE
config/types/raid: fix device validation

### DIFF
--- a/config/types/raid.go
+++ b/config/types/raid.go
@@ -46,7 +46,7 @@ func (n Raid) ValidateLevel() report.Report {
 
 func (n Raid) ValidateDevices() report.Report {
 	r := report.Report{}
-	for d := range n.Devices {
+	for _, d := range n.Devices {
 		if err := validatePath(string(d)); err != nil {
 			r.Add(report.Entry{
 				Message: fmt.Sprintf("array %q: device path not absolute: %q", n.Name, d),


### PR DESCRIPTION
Device path validation for raid arrays was accidentally checking the
index of the device's location in the list, and not the device's path
itself, for path validation. This commit fixes that.