### PR TITLE
doc/raid: document how to assemble raid arrays on subsequent boots

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -159,7 +159,7 @@ In many scenarios, it may be useful to have an external data volume. This config
 
 ```json ignition
 {
-  "ignition": { "version": "2.0.0" },
+  "ignition": { "version": "2.1.0-experimental" },
   "storage": {
     "disks": [
       {
@@ -169,7 +169,8 @@ In many scenarios, it may be useful to have an external data volume. This config
           "label": "raid.1.1",
           "number": 1,
           "size": 20480,
-          "start": 0
+          "start": 0,
+          "typeGuid": "A19D880F-05FC-4D3B-A006-743F0F84911E"
         }]
       },
       {
@@ -179,7 +180,8 @@ In many scenarios, it may be useful to have an external data volume. This config
           "label": "raid.1.2",
           "number": 1,
           "size": 20480,
-          "start": 0
+          "start": 0,
+          "typeGuid": "A19D880F-05FC-4D3B-A006-743F0F84911E"
         }]
       }
     ],
@@ -197,6 +199,20 @@ In many scenarios, it may be useful to have an external data volume. This config
         "format": "ext4",
         "create": { "options": [ "-L", "DATA" ] }
       }
+    }, {
+      "name": "oem",
+      "mount": {
+        "device": "/dev/disk/by-partlabel/OEM",
+	"format": "ext4"
+      }
+    }],
+    "files": [{
+      "filesystem": "oem",
+      "path": "/grub.cfg",
+      "contents": {
+        "source": "data:,set%20oem_id%3D%22digitalocean%22%0Aset%20linux_append%3D%22rd.auto%22%0A"
+      },
+      "mode": 420
     }]
   },
   "systemd": {

--- a/doc/raid.md
+++ b/doc/raid.md
@@ -1,0 +1,30 @@
+# Working with raid arrays
+
+Ignition can be used to create and assemble a software raid array. This is done
+with the `raid` section of the schema under `storage`. There's an example of how
+to do this in the [examples document][1].
+
+On the first boot, Ignition will make sure that the raid array gets assembled
+after it's created. This is necessary for the array to be used. On subsequent
+boots however, Ignition doesn't run and won't assemble the array.
+
+The arrays can be detected and automatically assembled by [dracut][2] with a
+little configuration. First and foremost, the partitions that are part of the
+raid array must have the correct [type GUID][3] to signify that they are raid
+partitions. This can be done by setting the `typeGuid` field in the Ignition
+config to `A19D880F-05FC-4D3B-A006-743F0F84911E` for the partitions. This is
+supported in Ignition configs of at least version 2.1.0.
+
+With the correct type GUID set, the only remaining thing to be done is to append
+the following snippet to the grub config:
+
+```
+set linux_append="rd.auto"
+```
+
+On a typical disk install, the grub config will be located at
+`/usr/share/oem/grub.cfg`.
+
+[1]: examples.md
+[2]: http://man7.org/linux/man-pages/man7/dracut.cmdline.7.html
+[3]: https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs


### PR DESCRIPTION
Adds documentation for how to assemble a raid array on subsequent boots

Fixes https://github.com/coreos/bugs/issues/1688