### PR TITLE
exec: propogate root parameter to baseconfig

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -30,22 +30,11 @@ import (
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/cmdline"
 	"github.com/coreos/ignition/internal/resource"
+	internalUtil "github.com/coreos/ignition/internal/util"
 )
 
 const (
 	DefaultFetchTimeout = time.Minute
-)
-
-var (
-	baseConfig = types.Config{
-		Ignition: types.Ignition{Version: types.MaxVersion.String()},
-		Storage: types.Storage{
-			Filesystems: []types.Filesystem{{
-				Name: "root",
-				Path: func(p string) *string { return &p }("/sysroot"),
-			}},
-		},
-	}
 )
 
 // Engine represents the entity that fetches and executes a configuration.
@@ -75,6 +64,17 @@ func (e Engine) Run(stageName string) bool {
 
 	e.Logger.PushPrefix(stageName)
 	defer e.Logger.PopPrefix()
+
+	baseConfig := types.Config{
+		Ignition: types.Ignition{Version: types.MaxVersion.String()},
+		Storage: types.Storage{
+			Filesystems: []types.Filesystem{{
+				Name: "root",
+				Path: internalUtil.StringToPtr(e.Root),
+			}},
+		},
+	}
+
 	return stages.Get(stageName).Create(e.Logger, e.Root, f).Run(config.Append(baseConfig, config.Append(e.OEMConfig.BaseConfig(), cfg)))
 }
 

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -85,21 +85,21 @@ func (u Util) PrepareFetch(l *log.Logger, c *resource.HttpClient, f types.File) 
 	}
 
 	if f.User.Name != "" {
-		u, err := Util{DestDir: "/sysroot"}.userLookup(f.User.Name)
+		user, err := u.userLookup(f.User.Name)
 		if err != nil {
 			l.Crit("No such user %q: %v", f.User.Name, err)
 			return nil
 		}
-		uid, err := strconv.ParseInt(u.Uid, 0, 0)
+		uid, err := strconv.ParseInt(user.Uid, 0, 0)
 		if err != nil {
-			l.Crit("Couldn't parse uid %q: %v", u.Uid, err)
+			l.Crit("Couldn't parse uid %q: %v", user.Uid, err)
 			return nil
 		}
 		tmp := int(uid)
 		f.User.ID = &tmp
 	}
 	if f.Group.Name != "" {
-		g, err := Util{DestDir: "/sysroot"}.groupLookup(f.Group.Name)
+		g, err := u.groupLookup(f.Group.Name)
 		if err != nil {
 			l.Crit("No such group %q: %v", f.Group.Name, err)
 			return nil

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -21,3 +21,7 @@ func IntToPtr(i int) *int {
 func BoolToPtr(b bool) *bool {
 	return &b
 }
+
+func StringToPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
If a value is passed to root other than the default of '/' then
the baseConfig will be updated to point to the given value rather
than '/sysroot'.

Also updates the RenderFile function from
'internal/exec/util/file.go' to be a member function of Util to
allow the given root parameter to be used rather than always using
'/sysroot'.