### PR TITLE
internal/oem: mask user-configdrive.service on brightbox and openstack

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -113,14 +113,30 @@ func init() {
 		defaultUserConfig: types.Config{Systemd: types.Systemd{Units: []types.Unit{userCloudInit("DigitalOcean", "digitalocean")}}},
 	})
 	configs.Register(Config{
-		name:              "brightbox",
-		fetch:             openstack.FetchConfig,
-		defaultUserConfig: types.Config{Systemd: types.Systemd{Units: []types.Unit{userCloudInit("BrightBox", "ec2-compat")}}},
+		name:  "brightbox",
+		fetch: openstack.FetchConfig,
+		defaultUserConfig: types.Config{
+			Systemd: types.Systemd{
+				Units: []types.Unit{
+					{Mask: true, Name: "user-configdrive.service"},
+					{Mask: true, Name: "user-configvirtfs.service"},
+					userCloudInit("BrightBox", "ec2-compat"),
+				},
+			},
+		},
 	})
 	configs.Register(Config{
-		name:              "openstack",
-		fetch:             openstack.FetchConfig,
-		defaultUserConfig: types.Config{Systemd: types.Systemd{Units: []types.Unit{userCloudInit("OpenStack", "ec2-compat")}}},
+		name:  "openstack",
+		fetch: openstack.FetchConfig,
+		defaultUserConfig: types.Config{
+			Systemd: types.Systemd{
+				Units: []types.Unit{
+					{Mask: true, Name: "user-configdrive.service"},
+					{Mask: true, Name: "user-configvirtfs.service"},
+					userCloudInit("OpenStack", "ec2-compat"),
+				},
+			},
+		},
 	})
 	configs.Register(Config{
 		name:       "ec2",


### PR DESCRIPTION
Fixes https://github.com/coreos/bugs/issues/2017