### PR TITLE
Remove ignition specification on code block so webpage renders correctly

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -10,7 +10,7 @@ Ignition will choose where to look for configuration based on the underlying pla
 
 The configuration must be passed to Ignition through the designated data source. Please refer to Ignition [config examples][examples] to learn about writing config files. The provided configuration will be appended to the universal base configuration:
 
-```json ignition
+```json
 {
   "storage": {
     "filesystems": [{


### PR DESCRIPTION
Currently the markdown on the [Getting Started](https://coreos.com/ignition/docs/latest/getting-started.html) is broken. This PR fixes it by just rendering it as pure `JSON`. 