### PR TITLE
oem: add vagrant-virtualbox oem-id

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -247,6 +247,10 @@ alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) >
 		fetch: noop.FetchConfig,
 	})
 	configs.Register(Config{
+		name:  "vagrant-virtualbox",
+		fetch: virtualbox.FetchConfig,
+	})
+	configs.Register(Config{
 		name:  "virtualbox",
 		fetch: virtualbox.FetchConfig,
 	})


### PR DESCRIPTION
The vagrant-virtualbox oem will now have its own id instead of
using the virtualbox id, which will allow some expanded functionality.
This commit allows Ignition to recognize that new id.