### PR TITLE
config: don't parse as latest version when version isn't recognized

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,8 +55,16 @@ func TestParse(t *testing.T) {
 			out: out{config: types.Config{Ignition: types.Ignition{Version: types.MaxVersion.String()}}},
 		},
 		{
+			in:  in{config: []byte(`{"ignition": {"version": "2.2.0-experimental"}}`)},
+			out: out{config: types.Config{Ignition: types.Ignition{Version: types.MaxVersion.String()}}},
+		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "2.1.0-experimental"}}`)},
+			out: out{err: ErrUnknownVersion},
+		},
+		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.2.0"}}`)},
-			out: out{err: ErrInvalid},
+			out: out{err: ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "invalid.semver"}}`)},
@@ -64,7 +72,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: ErrInvalid},
+			out: out{err: ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte{}},


### PR DESCRIPTION
Before this commit Ignition would parse any config with an unrecognized
version as the latest version of the spec. This commit changes this
behavior to instead return an error.