### PR TITLE
providers/packet: fix userdata fetch

### DIFF
--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -35,10 +35,12 @@ var (
 )
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
-	// TODO: Packet's metadata service returns "Not Acceptable" when queried
-	// with the default headers. For now, just do a regular fetch.
+	// Packet's metadata service returns "Not Acceptable" when queried
+	// with the default Accept header.
+	headers := resource.ConfigHeaders
+	headers.Set("Accept", "*/*")
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
+		Headers: headers,
 	})
 	if err != nil {
 		return types.Config{}, report.Report{}, err


### PR DESCRIPTION
8f6e802753404e5bac805cb46054243fe72005ab reintroduced the Accept header which the Packet metadata server finds 406 Not Acceptable. Switch to an Accept header that accepts anything.