### PR TITLE
internal/providers/{gce,ec2}: ignore 404 errors

### DIFF
--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -43,7 +43,7 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
 		Headers: resource.ConfigHeaders,
 	})
-	if err != nil {
+	if err != nil && err != resource.ErrNotFound {
 		return types.Config{}, report.Report{}, err
 	}
 

--- a/internal/providers/gce/gce.go
+++ b/internal/providers/gce/gce.go
@@ -42,7 +42,7 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
 		Headers: headers,
 	})
-	if err != nil {
+	if err != nil && err != resource.ErrNotFound {
 		return types.Config{}, report.Report{}, err
 	}
 


### PR DESCRIPTION
EC2 and GCE return an HTTP 404 error when Ignition attempts to fetch
its config and the user has not provided any user data. The recent
refactor of the fetching logic had a regression where this is no longer
handled, and the 404 would cause Ignition to fail. This commit makes
these providers ignore any 404 errors.

Fixes https://github.com/coreos/bugs/issues/2043