### PR TITLE
stages/files: fix regression affecting file paths

### DIFF
--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -305,8 +305,14 @@ func (s stage) createEntries(fs types.Filesystem, files []filesystemEntry) error
 		mnt = *fs.Path
 	}
 
+	u := util.Util{
+		DestDir: mnt,
+		Fetcher: s.Util.Fetcher,
+		Logger:  s.Logger,
+	}
+
 	for _, e := range files {
-		if err := e.create(s.Logger, s.client, s.Util); err != nil {
+		if err := e.create(s.Logger, s.client, u); err != nil {
 			return err
 		}
 	}

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -61,8 +61,6 @@ func (creator) Name() string {
 
 type stage struct {
 	util.Util
-
-	client *resource.HttpClient
 }
 
 func (stage) Name() string {
@@ -112,12 +110,12 @@ func (s stage) createFilesystemsEntries(config types.Config) error {
 
 // filesystemEntry represent a thing that knows how to create itself.
 type filesystemEntry interface {
-	create(l *log.Logger, c *resource.HttpClient, u util.Util) error
+	create(l *log.Logger, u util.Util) error
 }
 
 type fileEntry types.File
 
-func (tmp fileEntry) create(l *log.Logger, c *resource.HttpClient, u util.Util) error {
+func (tmp fileEntry) create(l *log.Logger, u util.Util) error {
 	f := types.File(tmp)
 
 	if f.User.ID == nil {
@@ -127,7 +125,7 @@ func (tmp fileEntry) create(l *log.Logger, c *resource.HttpClient, u util.Util) 
 		f.Group.ID = internalUtil.IntToPtr(0)
 	}
 
-	fetchOp := u.PrepareFetch(l, c, f)
+	fetchOp := u.PrepareFetch(l, f)
 	if fetchOp == nil {
 		return fmt.Errorf("failed to resolve file %q", f.Path)
 	}
@@ -144,7 +142,7 @@ func (tmp fileEntry) create(l *log.Logger, c *resource.HttpClient, u util.Util) 
 
 type dirEntry types.Directory
 
-func (tmp dirEntry) create(l *log.Logger, _ *resource.HttpClient, u util.Util) error {
+func (tmp dirEntry) create(l *log.Logger, u util.Util) error {
 	d := types.Directory(tmp)
 
 	if d.User.ID == nil {
@@ -195,7 +193,7 @@ func (tmp dirEntry) create(l *log.Logger, _ *resource.HttpClient, u util.Util) e
 
 type linkEntry types.Link
 
-func (tmp linkEntry) create(l *log.Logger, _ *resource.HttpClient, u util.Util) error {
+func (tmp linkEntry) create(l *log.Logger, u util.Util) error {
 	s := types.Link(tmp)
 
 	if s.User.ID == nil {
@@ -312,7 +310,7 @@ func (s stage) createEntries(fs types.Filesystem, files []filesystemEntry) error
 	}
 
 	for _, e := range files {
-		if err := e.create(s.Logger, s.client, u); err != nil {
+		if err := e.create(s.Logger, u); err != nil {
 			return err
 		}
 	}

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -59,7 +59,7 @@ func newHashedReader(reader io.ReadCloser, hasher hash.Hash) io.ReadCloser {
 // FetchOp. This includes operations such as parsing the source URL, generating
 // a hasher, and performing user/group name lookups. If an error is encountered,
 // the issue will be logged and nil will be returned.
-func (u Util) PrepareFetch(l *log.Logger, c *resource.HttpClient, f types.File) *FetchOp {
+func (u Util) PrepareFetch(l *log.Logger, f types.File) *FetchOp {
 	var err error
 	var expectedSum []byte
 


### PR DESCRIPTION
This was broken by 8f6e802753404e. We need to create a new Util object
which has the desired filesystem-root for this specific file instead of
using the root.

Fixes https://github.com/coreos/bugs/issues/2059.