### PR TITLE
stages/disks: fix handling of legacy force flag

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -292,6 +292,7 @@ func (s stage) createFilesystem(fs types.Mount) error {
 	if info.format == fs.Format &&
 		(fs.Label == nil || info.label == *fs.Label) &&
 		(fs.UUID == nil || info.uuid == *fs.UUID) &&
+		(fs.Create == nil || !fs.Create.Force) &&
 		!fs.WipeFilesystem {
 		s.Logger.Info("filesystem at %q is already formatted. Skipping mkfs...", fs.Device)
 		return nil


### PR DESCRIPTION
This was broken by bb701519b. Both the new WipeFilesystems flag and the
legacy Force flag need to be checked.

This should fix https://github.com/coreos/bugs/issues/2061, but I haven't tested it yet.