### PR TITLE
internal/exec/util: hard link targets must have context path prepended

### DIFF
--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -136,7 +136,8 @@ func (u Util) WriteLink(s types.Link) error {
 	}
 
 	if s.Hard {
-		return os.Link(s.Target, path)
+		targetPath := u.JoinPath(s.Target)
+		return os.Link(targetPath, path)
 	}
 	return os.Symlink(s.Target, path)
 }


### PR DESCRIPTION
The target path for a hard link must have the context path for the
filesystem prepended, or the hard link creation will fail. This commit
fixes that.