### PR TITLE
internal/exec/stages/files: fix node creation to properly error

### DIFF
--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -146,6 +146,9 @@ func (tmp dirEntry) create(l *log.Logger, u util.Util) error {
 	d := types.Directory(tmp)
 
 	d.User.ID, d.Group.ID = u.GetUserGroupID(l, d.User, d.Group)
+	if d.User.ID == nil || d.Group.ID == nil {
+		return fmt.Errorf("failed to resolve directory %q", d.Path)
+	}
 
 	err := l.LogOp(func() error {
 		path := filepath.Clean(u.JoinPath(string(d.Path)))
@@ -193,6 +196,9 @@ func (tmp linkEntry) create(l *log.Logger, u util.Util) error {
 	s := types.Link(tmp)
 
 	s.User.ID, s.Group.ID = u.GetUserGroupID(l, s.User, s.Group)
+	if s.User.ID == nil || s.Group.ID == nil {
+		return fmt.Errorf("failed to resolve link %q", s.Path)
+	}
 
 	if err := l.LogOp(
 		func() error { return u.WriteLink(s) },

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -86,6 +86,9 @@ func (u Util) PrepareFetch(l *log.Logger, f types.File) *FetchOp {
 	}
 
 	f.User.ID, f.Group.ID = u.GetUserGroupID(l, f.User, f.Group)
+	if f.User.ID == nil || f.Group.ID == nil {
+		return nil
+	}
 
 	return &FetchOp{
 		Path: f.Path,


### PR DESCRIPTION
The commit to introduce a new utility function to determine the
user and group caused an issue where if the user wasn't determined
by ignition the runtime would segfault for directories & links and
files wouldn't error out properly. This has been changed to now
properly error out.