### PR TITLE
internal/exec/util/file: use lchown chown when working with links

### DIFF
--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -121,7 +121,7 @@ func (u Util) WriteLink(s types.Link) error {
 		return err
 	}
 
-	if err := os.Chown(path, *s.User.ID, *s.Group.ID); err != nil {
+	if err := os.Lchown(path, *s.User.ID, *s.Group.ID); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit switches the logic for creating a link to call `os.Lchown` instead of `os.Chown`, since we want to change the owner of the symlink and not the symlink's target