### PR TITLE
internal/exec/stages/disks: add --homehost any to mdadm creation

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -206,6 +206,7 @@ func (s stage) createRaids(config types.Config) error {
 			"--create", md.Name,
 			"--force",
 			"--run",
+			"--homehost", "any",
 			"--level", md.Level,
 			"--raid-devices", fmt.Sprintf("%d", len(md.Devices)-md.Spares),
 		}


### PR DESCRIPTION
To prevent inconsistent /dev/md device labels, create raid arrays with
the --homehost any flag which will prevent the system hostname from
being prepended to device labels.

Fixes https://github.com/coreos/bugs/issues/2104

cc @bgilbert 