### PR TITLE
Fix typo in gcloud alias

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -199,9 +199,9 @@ func init() {
 						FileEmbedded1: types.FileEmbedded1{
 							Mode: 0444,
 							Contents: contentsFromString(`#!/bin/sh
-alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
-alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gcutil"
-alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gsutil"
+alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
+alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config google/cloud-sdk gcutil"
+alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config google/cloud-sdk gsutil"
 `),
 						},
 					},

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -199,7 +199,7 @@ func init() {
 						FileEmbedded1: types.FileEmbedded1{
 							Mode: 0444,
 							Contents: contentsFromString(`#!/bin/sh
-alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/doker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
+alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
 alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gcutil"
 alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config google/cloud-sdk gsutil"
 `),


### PR DESCRIPTION
Fix a small typo in the name of the socket. Because of it we were facing an error 
```
Cannot connect to the Docker daemon. Is the docker daemon running on this host?
```

### Example

```
# Use the value 'doker.sock'
dgellow@my-vm ~ $ alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/doker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"

# Call a gcloud docker command, get an error
dgellow@my-vm ~ $ gcloud docker -- pull eu.gcr.io/my-org/alpine:latest
Cannot connect to the Docker daemon. Is the docker daemon running on this host?

# Use the value 'docker.sock'
dgellow@my-vm ~ $ alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/.config -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"

# Call a gcloud docker command, successfully
dgellow@my-vm ~ $ gcloud docker -- pull eu.gcr.io/my-org/alpine:latest
latest: Pulling from my-org/alpine
Digest: sha256:3245584c1ba705c61cfbf9190a23b1ddefa279bad6eff75367b5a1ca91f38a68
Status: Image is up to date for eu.gcr.io/my-org/alpine:latest
```

Edit: I updated the error, I initially pasted the wrong one ...
Edit2: Added example