### PR TITLE
config/config.go: parse unknown configs to generate json errors

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -64,7 +64,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.2.0"}}`)},
-			out: out{err: ErrUnknownVersion},
+			out: out{err: ErrInvalid},
+		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "2.0.0"},}`)},
+			out: out{err: ErrInvalid},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "invalid.semver"}}`)},
@@ -72,7 +76,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: ErrUnknownVersion},
+			out: out{err: ErrInvalid},
 		},
 		{
 			in:  in{config: []byte{}},


### PR DESCRIPTION
Fix an issue with config parsing where if a config's version was
indeterminable, it wasn't a cloud config, it wasn't empty, and it wasn't
a script, a generic "invalid version" message was emitted. The solution
is to run the unknown thing through ParseFromLatest to generate parse
errors.

cc @bgilbert 

Fixes https://github.com/coreos/bugs/issues/2115