### PR TITLE
providers/vmware: guest variables override ovfenv

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -6,7 +6,7 @@ Ignition is currently only supported for the following platforms:
 * [PXE] - Use the `coreos.config.url` and `coreos.first_boot=1` (**in case of the very first PXE boot only**) kernel parameters to provide a URL to the configuration. The URL can use the `http://` or `tftp://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
 * [Amazon EC2] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
-* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment.
+* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [QEMU] - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device.

--- a/internal/providers/vmware/vmware_amd64.go
+++ b/internal/providers/vmware/vmware_amd64.go
@@ -52,30 +52,30 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 func fetchRawConfig(f resource.Fetcher) (config, error) {
 	info := rpcvmx.NewConfig()
 
+	var ovfData string
+	var ovfEncoding string
+
 	ovfEnv, err := info.String("ovfenv", "")
 	if err != nil {
-		f.Logger.Debug("failed to fetch ovfenv: %v. Continuing...", err)
+		f.Logger.Warning("failed to fetch ovfenv: %v. Continuing...", err)
 	} else if ovfEnv != "" {
 		f.Logger.Debug("using OVF environment from guestinfo")
 		env, err := ovf.ReadEnvironment([]byte(ovfEnv))
 		if err != nil {
-			f.Logger.Err("failed to parse OVF environment: %v", err)
-			return config{}, err
+			f.Logger.Warning("failed to parse OVF environment: %v. Continuing...", err)
 		}
 
-		return config{
-			data:     env.Properties["guestinfo.coreos.config.data"],
-			encoding: env.Properties["guestinfo.coreos.config.data.encoding"],
-		}, nil
+		ovfData = env.Properties["guestinfo.coreos.config.data"]
+		ovfEncoding = env.Properties["guestinfo.coreos.config.data.encoding"]
 	}
 
-	data, err := info.String("coreos.config.data", "")
+	data, err := info.String("coreos.config.data", ovfData)
 	if err != nil {
 		f.Logger.Debug("failed to fetch config: %v", err)
 		return config{}, err
 	}
 
-	encoding, err := info.String("coreos.config.data.encoding", "")
+	encoding, err := info.String("coreos.config.data.encoding", ovfEncoding)
 	if err != nil {
 		f.Logger.Debug("failed to fetch config encoding: %v", err)
 		return config{}, err


### PR DESCRIPTION
This allows guest variables to override values specified in the OVF
environment. This is useful for Terraform in particular because it
does yet understand how to set vApp options instead of guest variables.

This also subtly changes the behavior when an OVF environment cannot be
parsed. Before this change, Ignition would fail with an error message.
Now, a warning is logged and execution continues.