### PR TITLE
[WIP]: send health reports when running on Azure

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -89,7 +89,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, f resource.Fetcher, err erro
 		}
 		// Create an http client and fetcher with the timeouts from the cached
 		// config
-		e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts)
+		e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts, 0)
 		f, err = e.OEMConfig.NewFetcherFunc()(e.Logger, &e.client)
 		if err != nil {
 			e.Logger.Crit("failed to generate fetcher: %s", err)
@@ -101,7 +101,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, f resource.Fetcher, err erro
 	// Create a new http client and fetcher with the timeouts set via the flags,
 	// since we don't have a config with timeout values we can use
 	timeout := int(e.FetchTimeout.Seconds())
-	e.client = resource.NewHttpClient(e.Logger, types.Timeouts{HTTPTotal: &timeout})
+	e.client = resource.NewHttpClient(e.Logger, types.Timeouts{HTTPTotal: &timeout}, 0)
 	f, err = e.OEMConfig.NewFetcherFunc()(e.Logger, &e.client)
 	if err != nil {
 		e.Logger.Crit("failed to generate fetcher: %s", err)
@@ -117,7 +117,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, f resource.Fetcher, err erro
 
 	// Regenerate the http client and fetcher to use the timeouts from the
 	// newly fetched config
-	e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts)
+	e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts, 0)
 	f, err = e.OEMConfig.NewFetcherFunc()(e.Logger, &e.client)
 	if err != nil {
 		e.Logger.Crit("failed to generate fetcher: %s", err)
@@ -166,7 +166,7 @@ func (e Engine) fetchProviderConfig(f resource.Fetcher) (types.Config, error) {
 // provided config will be returned unmodified.
 func (e *Engine) renderConfig(cfg types.Config, f resource.Fetcher) (types.Config, error) {
 	// Apply any new timeout info before fetching other configs.
-	e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts)
+	e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts, 0)
 	if cfgRef := cfg.Ignition.Config.Replace; cfgRef != nil {
 		return e.fetchReferencedConfig(*cfgRef, f)
 	}

--- a/internal/main.go
+++ b/internal/main.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/coreos/ignition/internal/exec/stages/files"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/oem"
+	"github.com/coreos/ignition/internal/util/oem/azure"
 	"github.com/coreos/ignition/internal/version"
 )
 
@@ -76,6 +77,15 @@ func main() {
 		}
 	}
 
+	azureProvisioner := azure.NewAzureProvisioner(&logger)
+
+	if flags.oem.String() == "azure" && flags.stage == "disks" {
+		err := azureProvisioner.ReportProvisioningStarting()
+		if err != nil {
+			logger.Err("unable to report start of provisioning: %v", err)
+		}
+	}
+
 	oemConfig := oem.MustGet(flags.oem.String())
 	engine := exec.Engine{
 		Root:         flags.root,
@@ -86,6 +96,18 @@ func main() {
 	}
 
 	if !engine.Run(flags.stage.String()) {
+		if flags.oem.String() == "azure" {
+			err := azureProvisioner.ReportProvisioningFailed("something went wrong")
+			if err != nil {
+				logger.Err("unable to report failure of provisioning: %v", err)
+			}
+		}
 		os.Exit(1)
+	}
+	if flags.oem.String() == "azure" && flags.stage == "files" {
+		err := azureProvisioner.ReportProvisioningSucceeded()
+		if err != nil {
+			logger.Err("unable to report success of provisioning: %v", err)
+		}
 	}
 }

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -86,13 +86,11 @@ func init() {
 		baseConfig: types.Config{
 			Systemd: types.Systemd{
 				Units: []types.Unit{
-					{Enabled: yes, Name: "waagent.service"},
 					{Name: "etcd2.service", Dropins: []types.Dropin{
 						{Name: "10-oem.conf", Contents: "[Service]\nEnvironment=ETCD_ELECTION_TIMEOUT=1200\n"},
 					}},
 				},
 			},
-			Storage: types.Storage{Files: []types.File{serviceFromOem("waagent.service")}},
 		},
 		defaultUserConfig: types.Config{Systemd: types.Systemd{Units: []types.Unit{userCloudInit("Azure", "azure")}}},
 	})

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -86,6 +86,7 @@ func init() {
 		baseConfig: types.Config{
 			Systemd: types.Systemd{
 				Units: []types.Unit{
+					{Enable: true, Name: "coreos-metadata-sshkeys@.service"},
 					{Name: "etcd2.service", Dropins: []types.Dropin{
 						{Name: "10-oem.conf", Contents: "[Service]\nEnvironment=ETCD_ELECTION_TIMEOUT=1200\n"},
 					}},

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -228,7 +228,7 @@ func (f *Fetcher) FetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) err
 func (f *Fetcher) FetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) error {
 	if f.Client == nil {
 		f.Logger.Warning("Fetcher http client not initialized, ignoring any possible timeouts")
-		c := NewHttpClient(f.Logger, types.Timeouts{})
+		c := NewHttpClient(f.Logger, types.Timeouts{}, 0)
 		f.Client = &c
 	}
 	dataReader, status, err := f.Client.Get(u.String(), opts.Headers)

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -231,7 +231,7 @@ func (f *Fetcher) FetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) err
 		c := NewHttpClient(f.Logger, types.Timeouts{})
 		f.Client = &c
 	}
-	dataReader, status, err := f.Client.getReaderWithHeader(u.String(), opts.Headers)
+	dataReader, status, err := f.Client.Get(u.String(), opts.Headers)
 	if err != nil {
 		return err
 	}

--- a/internal/util/oem/azure/report.go
+++ b/internal/util/oem/azure/report.go
@@ -1,0 +1,264 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/resource"
+)
+
+const (
+	healthReportUriFormat = "http://%s/machine?comp=health"
+	goalStateUri          = "http://%s/machine/?comp=goalstate"
+
+	agentName             = "com.coreos.metadata"
+	fabricProtocolVersion = "2012-11-30"
+
+	leaseRetryInterval = 500 * time.Millisecond
+)
+
+type HealthReport struct {
+	XMLName              xml.Name       `xml:"Health"`
+	Xsi                  string         `xml:"xmlns:xsi,attr"`
+	Xsd                  string         `xml:"xmlns:xsd,attr"`
+	GoalStateIncarnation string         `xml:"GoalStateIncarnation"`
+	ContainerId          string         `xml:"Container>ContainerId"`
+	InstanceId           string         `xml:"Container>RoleInstanceList>Role>InstanceId"`
+	State                string         `xml:"Container>RoleInstanceList>Role>Health>State"`
+	Details              *HealthDetails `xml:"Container>RoleInstanceList>Role>Health>Details"`
+}
+
+type HealthDetails struct {
+	SubStatus   string `xml:"SubStatus"`
+	Description string `xml:"Description"`
+}
+
+type GoalState struct {
+	XMLName               xml.Name                `xml:"GoalState"`
+	Version               string                  `xml:"Version"`
+	Incarnation           string                  `xml:"Incarnation"`
+	ExpectedState         string                  `xml:"Machine>ExpectedState"`
+	StopRolesDeadlineHint string                  `xml:"Machine>StopRolesDeadlineHint"`
+	LBProbePorts          []int                   `xml:"Machine>LBProbePorts>Port"`
+	ExpectHealthReport    string                  `xml:"Machine>ExpectHealthReport"`
+	ContainerId           string                  `xml:"Container>ContainerId"`
+	RoleInstanceList      []GoalStateRoleInstance `xml:"Container>RoleInstanceList>RoleInstance"`
+}
+
+type GoalStateRoleInstance struct {
+	XMLName                  xml.Name `xml:"RoleInstance"`
+	InstanceId               string   `xml:"InstanceId"`
+	State                    string   `xml:"State"`
+	HostingEnvironmentConfig string   `xml:"Configuration>HostingEnvironmentConfig"`
+	SharedConfig             string   `xml:"Configuration>SharedConfig"`
+	ExtensionsConfig         string   `xml:"Configuration>ExtensionsConfig"`
+	FullConfig               string   `xml:"Configuration>FullConfig"`
+	Certificates             string   `xml:"Configuration>Certificates"`
+	ConfigName               string   `xml:"Configuration>ConfigName"`
+}
+
+type AzureProvisioner struct {
+	client  resource.HttpClient
+	headers map[string][]string
+}
+
+func NewAzureProvisioner(l *log.Logger) *AzureProvisioner {
+	return &AzureProvisioner{
+		client: resource.NewHttpClient(l, types.Timeouts{}, 400),
+		headers: map[string][]string{
+			"x-ms-agent-name": {agentName},
+			"x-ms-version":    {fabricProtocolVersion},
+			"Content-Type":    {"text/xml; charset=utf-8"},
+		},
+	}
+}
+
+// buildHealthReport will convert the goal state and the desired message into an
+// XML-encoded health report message
+func buildHealthReport(incarnation, containerId, roleInstanceId, status, substatus, description string) ([]byte, error) {
+	var details *HealthDetails
+	if substatus != "" {
+		details = &HealthDetails{
+			SubStatus:   substatus,
+			Description: description,
+		}
+	}
+	data, err := xml.MarshalIndent(HealthReport{
+		Xsi:                  "http://www.w3.org/2001/XMLSchema-instance",
+		Xsd:                  "http://www.w3.org/2001/XMLSchema",
+		GoalStateIncarnation: incarnation,
+		ContainerId:          containerId,
+		InstanceId:           roleInstanceId,
+		State:                status,
+		Details:              details,
+	}, "  ", "    ")
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(xml.Header), data...), err
+}
+
+// getGoalState will send a request to the given IP address for the XML-encoded
+// goal state of this machine, and then decodes the message and returns it.
+func (a *AzureProvisioner) getGoalState(addr net.IP) (GoalState, error) {
+	xmlBlobReader, _, err := a.client.Get(fmt.Sprintf(goalStateUri, addr.String()), a.headers)
+	if err != nil {
+		return GoalState{}, fmt.Errorf("failed to fetch goal state: %v", err)
+	}
+	defer xmlBlobReader.Close()
+	xmlBlob, err := ioutil.ReadAll(xmlBlobReader)
+	if err != nil {
+		return GoalState{}, fmt.Errorf("failed to read goal state: %v", err)
+	}
+	var gs GoalState
+	err = xml.Unmarshal(xmlBlob, &gs)
+	if err != nil {
+		return GoalState{}, err
+	}
+	return gs, nil
+}
+
+// findLease will attempt to find a systemd lease file for one of the interfaces
+// enumerated by net.Interfaces()
+func findLease() (*os.File, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("could not list interfaces: %v", err)
+	}
+
+	// It will take an unknown amount of time for an interface to successfully
+	// go through the DHCP dance, so keep retrying (and sleeping between tries)
+	// indefinitely.
+	for {
+		for _, iface := range ifaces {
+			lease, err := os.Open(fmt.Sprintf("/run/systemd/netif/leases/%d", iface.Index))
+			if os.IsNotExist(err) {
+				continue
+			} else if err != nil {
+				return nil, err
+			} else {
+				return lease, nil
+			}
+		}
+
+		fmt.Printf("No leases found. Waiting...")
+		time.Sleep(leaseRetryInterval)
+	}
+}
+
+// getFabricAddress attempts to look up the address of the Azure fabric server
+// (which I guess shares an IP address with the wire server?) by searching
+// through information about the current DHCP lease for an OPTION_245 line.
+func getFabricAddress() (net.IP, error) {
+	lease, err := findLease()
+	if err != nil {
+		return nil, err
+	}
+	defer lease.Close()
+
+	var rawEndpoint string
+	line := bufio.NewScanner(lease)
+	for line.Scan() {
+		parts := strings.Split(line.Text(), "=")
+		if parts[0] == "OPTION_245" && len(parts) == 2 {
+			rawEndpoint = parts[1]
+			break
+		}
+	}
+
+	if len(rawEndpoint) == 0 || len(rawEndpoint) != 8 {
+		return nil, fmt.Errorf("fabric endpoint not found in leases")
+	}
+
+	octets := make([]byte, 4)
+	for i := 0; i < 4; i++ {
+		octet, err := strconv.ParseUint(rawEndpoint[2*i:2*i+2], 16, 8)
+		if err != nil {
+			return nil, err
+		}
+		octets[i] = byte(octet)
+	}
+
+	return net.IPv4(octets[0], octets[1], octets[2], octets[3]), nil
+}
+
+// reportHealth sends a message to the Azure wire server, with the provided
+// status, substatus, and description.
+func (a *AzureProvisioner) reportHealth(status, substatus, description string) error {
+	// Get the address of the server we need to talk to
+	fabricAddress, err := getFabricAddress()
+	if err != nil {
+		return err
+	}
+	// Get the goal state via get request to the server we just looked up
+	goalState, err := a.getGoalState(fabricAddress)
+	if err != nil {
+		return err
+	}
+	// There must be at least one item in the RoleInstanceList (otherwise this
+	// instance doesn't exist)
+	if len(goalState.RoleInstanceList) == 0 {
+		return fmt.Errorf("role instance list in goal state cannot be empty")
+	}
+	// Build a health report with the goal state we fetched and the desired
+	// message we wish to send
+	healthReport, err := buildHealthReport(goalState.Incarnation, goalState.ContainerId, goalState.RoleInstanceList[0].InstanceId, status, substatus, description)
+	if err != nil {
+		return err
+	}
+	// Send the message to the wire server
+	body, _, err := a.client.Post(fmt.Sprintf(healthReportUriFormat, fabricAddress.String()), a.headers, bytes.NewBuffer(healthReport))
+	if err != nil {
+		return err
+	}
+	body.Close()
+	return nil
+}
+
+// ReportProvisioningStarting will send a message to the Azure wire server
+// reporting that this machine is online but not ready, and provisioning has
+// begun. This should be called once when provisioning begins (so the start of
+// the disks stage)
+func (a *AzureProvisioner) ReportProvisioningStarting() error {
+	return a.reportHealth("NotReady", "Provisioning", "Starting")
+}
+
+// ReportProvisioningFailed will send a message to the Azure wire server
+// reporting that provisioning has failed on this machine. This should be called
+// if a failure occurs and the machine is not going to successfully finish
+// booting.
+func (a *AzureProvisioner) ReportProvisioningFailed(description string) error {
+	return a.reportHealth("NotReady", "ProvisioningFailed", description)
+}
+
+// ReportProvisioningSucceeded will send a message to the Azure wire server
+// reporting that provisioning has succeeded on this machine. This should be
+// called once when provisiong has finished (so at the end of the files stage).
+// If this is not called, Azure will never mark a machine as "ready".
+func (a *AzureProvisioner) ReportProvisioningSucceeded() error {
+	return a.reportHealth("Ready", "", "")
+}


### PR DESCRIPTION
Adds logic for sending provisioning reports when running on Azure, replacing the logic of the WAAgent. Ignition sends a report when provisioning begins (start disks stage), and another on failure or success (where success is the end of the files stage).

Also modifies `internal/oem/oem.go` to enable `coreos-metadata-sshkeys@.service` (which requires `coreos-metadata` changes to be made/merged).

Still a work in progress, but I'd like to begin review on this. Things left to do:
- [x] remove `internal/util/retry/retry.go` and use the already existing `internal/resource/http.go` for http retry logic (will require some refactoring/improving of the latter)
- [ ] build another image and test on azure again (some time has passed since I last tested this)

This is intentionally not including support for Azure Stack, that can be added in a followup PR.

Replaces https://github.com/coreos/ignition/pull/374