### PR TITLE
internal/exec/stages/disks: remove old comment

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -200,8 +200,6 @@ func (s stage) createRaids(config types.Config) error {
 	}
 
 	for _, md := range config.Storage.Raid {
-		// FIXME(vc): this is utterly flummoxed by a preexisting md.Name, the magic of device-resident md metadata really interferes with us.
-		// It's as if what ignition really needs is to turn off automagic md probing/running before getting started.
 		args := []string{
 			"--create", md.Name,
 			"--force",


### PR DESCRIPTION
RAID devices are no longer autostarted when ignition is running. This
comment no longer applies.