### PR TITLE
config/types: fix partition number validation

### DIFF
--- a/config/types/disk.go
+++ b/config/types/disk.go
@@ -62,7 +62,10 @@ func (n Disk) ValidatePartitions() report.Report {
 func (n Disk) partitionNumbersCollide() bool {
 	m := map[int][]Partition{}
 	for _, p := range n.Partitions {
-		m[p.Number] = append(m[p.Number], p)
+		if p.Number != 0 {
+			// a number of 0 means next available number, multiple devices can specify this
+			m[p.Number] = append(m[p.Number], p)
+		}
 	}
 	for _, n := range m {
 		if len(n) > 1 {

--- a/config/v2_0/types/disk.go
+++ b/config/v2_0/types/disk.go
@@ -60,7 +60,10 @@ func (n Disk) Validate() report.Report {
 func (n Disk) partitionNumbersCollide() bool {
 	m := map[int][]Partition{}
 	for _, p := range n.Partitions {
-		m[p.Number] = append(m[p.Number], p)
+		if p.Number != 0 {
+			// a number of 0 means next available number, multiple devices can specify this
+			m[p.Number] = append(m[p.Number], p)
+		}
 	}
 	for _, n := range m {
 		if len(n) > 1 {

--- a/config/v2_1/types/disk.go
+++ b/config/v2_1/types/disk.go
@@ -62,7 +62,10 @@ func (n Disk) ValidatePartitions() report.Report {
 func (n Disk) partitionNumbersCollide() bool {
 	m := map[int][]Partition{}
 	for _, p := range n.Partitions {
-		m[p.Number] = append(m[p.Number], p)
+		if p.Number != 0 {
+			// a number of 0 means next available number, multiple devices can specify this
+			m[p.Number] = append(m[p.Number], p)
+		}
 	}
 	for _, n := range m {
 		if len(n) > 1 {


### PR DESCRIPTION
The spec allows specifying number 0 for "next available partition
number", so it should be valid for multiple partitions on the same disk
to specify it. Fix validation to not consider number 0 when checking for
collisions.