### PR TITLE
oem: don't bind-mount docker into Google Cloud SDK container

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -202,7 +202,6 @@ func init() {
 							Mode: 0444,
 							Contents: contentsFromString(`#!/bin/sh
 alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
-alias gcutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config google/cloud-sdk gcutil"
 alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config google/cloud-sdk gsutil"
 `),
 						},

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -201,7 +201,7 @@ func init() {
 						FileEmbedded1: types.FileEmbedded1{
 							Mode: 0444,
 							Contents: contentsFromString(`#!/bin/sh
-alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker google/cloud-sdk gcloud"
+alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config -v /var/run/docker.sock:/var/run/docker.sock google/cloud-sdk gcloud"
 alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -t -i --net="host" -v $HOME/.config:/root/.config google/cloud-sdk gsutil"
 `),
 						},


### PR DESCRIPTION
Bind-mounting the `docker` binary doesn't work with the torcx docker package, and `google/cloud-sdk` may ship its own docker binary in future.

For https://github.com/coreos/bugs/issues/2112.