### PR TITLE
providers/cloudstack: support for network metadata

### DIFF
--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -19,11 +19,15 @@
 package cloudstack
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -39,6 +43,7 @@ import (
 const (
 	diskByLabelPath         = "/dev/disk/by-label/"
 	configDriveUserdataPath = "/cloudstack/userdata/user_data.txt"
+	LeaseRetryInterval      = 500 * time.Millisecond
 )
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
@@ -70,9 +75,13 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 		return fetchConfigFromDevice(f.Logger, ctx, "CONFIG-2")
 	})
 
+	go dispatch("metadata service", func() ([]byte, error) {
+		return fetchConfigFromMetadataService(f)
+	})
+
 	<-ctx.Done()
 	if ctx.Err() == context.DeadlineExceeded {
-		f.Logger.Info("Config drive was not available in time. Continuing without a config...")
+		f.Logger.Info("neither config drive nor metadata service were available in time. Continuing without a config...")
 	}
 
 	return config.Parse(data)
@@ -96,6 +105,53 @@ func getPath(label string) (string, error) {
 	}
 
 	return "", fmt.Errorf("label not found: %s", label)
+}
+
+func findLease() (*os.File, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("could not list interfaces: %v", err)
+	}
+
+	for {
+		for _, iface := range ifaces {
+			lease, err := os.Open(fmt.Sprintf("/run/systemd/netif/leases/%d", iface.Index))
+			if os.IsNotExist(err) {
+				continue
+			} else if err != nil {
+				return nil, err
+			} else {
+				return lease, nil
+			}
+		}
+
+		fmt.Printf("No leases found. Waiting...")
+		time.Sleep(LeaseRetryInterval)
+	}
+}
+
+func getDHCPServerAddress() (string, error) {
+	lease, err := findLease()
+	if err != nil {
+		return "", err
+	}
+	defer lease.Close()
+
+	var address string
+	line := bufio.NewScanner(lease)
+	for line.Scan() {
+		parts := strings.Split(line.Text(), "=")
+		if parts[0] == "SERVER_ADDRESS" && len(parts) == 2 {
+			address = parts[1]
+			break
+		}
+	}
+
+	if len(address) == 0 {
+		return "", fmt.Errorf("dhcp server address not found in leases")
+	}
+
+	return address, nil
 }
 
 func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, label string) ([]byte, error) {
@@ -134,4 +190,22 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, label string
 	}
 
 	return ioutil.ReadFile(filepath.Join(mnt, configDriveUserdataPath))
+}
+
+func fetchConfigFromMetadataService(f resource.Fetcher) ([]byte, error) {
+	addr, err := getDHCPServerAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	metadataServiceUrl := url.URL{
+		Scheme: "http",
+		Host:   addr,
+		Path:   "/latest/user-data",
+	}
+
+	res, err := f.FetchToBuffer(metadataServiceUrl, resource.FetchOptions{
+		Headers: resource.ConfigHeaders,
+	})
+	return res, err
 }


### PR DESCRIPTION
The original implementation for CloudStack left out support for network
metadata. This adds it. Note that the DHCP server's IP address is being
read from the networkd leases file (which we aren't supposed to parse).
This is safe for now, but should eventually migrate to a public API.