### PR TITLE
internal/exec/util/passwd: Drop GECOS quotes

### DIFF
--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -99,7 +99,7 @@ func (u Util) EnsureUser(c types.PasswdUser) error {
 	}
 
 	if c.Gecos != "" {
-		args = append(args, "--comment", fmt.Sprintf("%q", c.Gecos))
+		args = append(args, "--comment", c.Gecos)
 	}
 
 	if c.PrimaryGroup != "" {


### PR DESCRIPTION
I haven't tested this yet, but it looks obvious.  Was there a reason for this behavior?