### PR TITLE
config/types: check for colons in partition labels when validating

### DIFF
--- a/config/types/partition.go
+++ b/config/types/partition.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -29,6 +30,7 @@ const (
 var (
 	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
 	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrLabelContainsColon   = errors.New("partition labels may not contain colon characters")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -41,6 +43,14 @@ func (p Partition) ValidateLabel() report.Report {
 	if len(p.Label) > 36 {
 		r.Add(report.Entry{
 			Message: ErrLabelTooLong.Error(),
+			Kind:    report.EntryError,
+		})
+	}
+
+	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
+	if strings.Contains(p.Label, ":") {
+		r.Add(report.Entry{
+			Message: ErrLabelContainsColon.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/types/partition_test.go
+++ b/config/types/partition_test.go
@@ -48,6 +48,10 @@ func TestValidateLabel(t *testing.T) {
 			in{"1111111111111111111111111111111111111"},
 			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
 		},
+		{
+			in{"test:"},
+			out{report.ReportFromError(ErrLabelContainsColon, report.EntryError)},
+		},
 	}
 	for i, test := range tests {
 		r := Partition{Label: test.in.label}.ValidateLabel()

--- a/config/v2_0/types/partition.go
+++ b/config/v2_0/types/partition.go
@@ -17,6 +17,7 @@ package types
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -39,6 +40,9 @@ func (n PartitionLabel) Validate() report.Report {
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(string(n)) > 36 {
 		return report.ReportFromError(fmt.Errorf("partition labels may not exceed 36 characters"), report.EntryError)
+	}
+	if strings.Contains(string(n), ":") {
+		return report.ReportFromError(fmt.Errorf("partition labels may not contain colon characters"), report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_1/types/partition.go
+++ b/config/v2_1/types/partition.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -29,6 +30,7 @@ const (
 var (
 	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
 	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrLabelContainsColon   = errors.New("partition labels may not contain colon characters")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -41,6 +43,14 @@ func (p Partition) ValidateLabel() report.Report {
 	if len(p.Label) > 36 {
 		r.Add(report.Entry{
 			Message: ErrLabelTooLong.Error(),
+			Kind:    report.EntryError,
+		})
+	}
+
+	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
+	if strings.Contains(p.Label, ":") {
+		r.Add(report.Entry{
+			Message: ErrLabelContainsColon.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/partition_test.go
+++ b/config/v2_1/types/partition_test.go
@@ -48,6 +48,10 @@ func TestValidateLabel(t *testing.T) {
 			in{"1111111111111111111111111111111111111"},
 			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
 		},
+		{
+			in{"test:"},
+			out{report.ReportFromError(ErrLabelContainsColon, report.EntryError)},
+		},
 	}
 	for i, test := range tests {
 		r := Partition{Label: test.in.label}.ValidateLabel()


### PR DESCRIPTION
`sgdisk` will truncate labels after a colon. We should validate labels do not have a colon to avoid unexpected truncation. 

One concern is this is *technically* a change in behavior, since Ignition currently silently truncates successfully, so there's an argument that this should generate a nonfatal error (warning or deprecation). I don't know how I feel about that, since its success violates the whole "an Ignition config is a description of your machine" idea and should be a failure.