### PR TITLE
config/validate: report better line/col info

### DIFF
--- a/config/validate/astjson/node.go
+++ b/config/validate/astjson/node.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node
+package astjson
 
 import (
 	"io"
 
 	json "github.com/ajeddeloh/go-json"
-	"github.com/coreos/ignition/config/validate"
+	"github.com/coreos/ignition/config/validate/astnode"
 	"go4.org/errorutil"
 )
 
@@ -40,16 +40,16 @@ func (n JsonNode) LiteralValue() interface{} {
 	return n.Value
 }
 
-func (n JsonNode) SliceChild(index int) (validate.AstNode, bool) {
+func (n JsonNode) SliceChild(index int) (astnode.AstNode, bool) {
 	if slice, ok := n.Value.([]json.Node); ok {
 		return JsonNode(slice[index]), true
 	}
 	return JsonNode{}, false
 }
 
-func (n JsonNode) KeyValueMap() (map[string]validate.AstNode, bool) {
+func (n JsonNode) KeyValueMap() (map[string]astnode.AstNode, bool) {
 	if kvmap, ok := n.Value.(map[string]json.Node); ok {
-		newKvmap := map[string]validate.AstNode{}
+		newKvmap := map[string]astnode.AstNode{}
 		for k, v := range kvmap {
 			newKvmap[k] = JsonNode(v)
 		}

--- a/config/validate/astnode/astnode.go
+++ b/config/validate/astnode/astnode.go
@@ -1,0 +1,45 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package astnode
+
+import (
+	"io"
+)
+
+// AstNode abstracts the differences between yaml and json nodes, providing a
+// common interface
+type AstNode interface {
+	// ValueLineCol returns the line, column, and highlight string of the value of
+	// this node in the source.
+	ValueLineCol(source io.ReadSeeker) (int, int, string)
+
+	// KeyLineCol returns the line, column, and highlight string of the key for the
+	// value of this node in the source.
+	KeyLineCol(source io.ReadSeeker) (int, int, string)
+
+	// LiteralValue returns the value of this node.
+	LiteralValue() interface{}
+
+	// SliceChild returns the child node at the index specified. If this node is not
+	// a slice node, an empty AstNode and false is returned.
+	SliceChild(index int) (AstNode, bool)
+
+	// KeyValueMap returns a map of keys and values. If this node is not a mapping
+	// node, nil and false are returned.
+	KeyValueMap() (map[string]AstNode, bool)
+
+	// Tag returns the struct tag used in the config structure used to unmarshal.
+	Tag() string
+}

--- a/config/validate/validate.go
+++ b/config/validate/validate.go
@@ -185,6 +185,10 @@ func validateStruct(vObj reflect.Value, ast AstNode, source io.ReadSeeker, check
 		// If there's a Validate<Name> func for the given field, call it
 		funct := vObj.MethodByName("Validate" + f.Type.Name)
 		if funct.IsValid() {
+			if sub_node != nil {
+				// if sub_node is non-nil, we can get better line/col info
+				line, col, _ = sub_node.ValueLineCol(src)
+			}
 			res := funct.Call(nil)
 			sub_report := res[0].Interface().(report.Report)
 			sub_report.AddPosition(line, col, "")

--- a/config/validate/validate.go
+++ b/config/validate/validate.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/coreos/ignition/config/validate/astnode"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -27,36 +28,10 @@ type validator interface {
 	Validate() report.Report
 }
 
-// AstNode abstracts the differences between yaml and json nodes, providing a
-// common interface
-type AstNode interface {
-	// ValueLineCol returns the line, column, and highlight string of the value of
-	// this node in the source.
-	ValueLineCol(source io.ReadSeeker) (int, int, string)
-
-	// KeyLineCol returns the line, column, and highlight string of the key for the
-	// value of this node in the source.
-	KeyLineCol(source io.ReadSeeker) (int, int, string)
-
-	// LiteralValue returns the value of this node.
-	LiteralValue() interface{}
-
-	// SliceChild returns the child node at the index specified. If this node is not
-	// a slice node, an empty AstNode and false is returned.
-	SliceChild(index int) (AstNode, bool)
-
-	// KeyValueMap returns a map of keys and values. If this node is not a mapping
-	// node, nil and false are returned.
-	KeyValueMap() (map[string]AstNode, bool)
-
-	// Tag returns the struct tag used in the config structure used to unmarshal.
-	Tag() string
-}
-
 // Validate walks down a struct tree calling Validate on every node that implements it, building
 // A report of all the errors, warnings, info, and deprecations it encounters. If checkUnusedKeys
 // is true, Validate will generate warnings for unused keys in the ast, otherwise it will not.
-func Validate(vObj reflect.Value, ast AstNode, source io.ReadSeeker, checkUnusedKeys bool) (r report.Report) {
+func Validate(vObj reflect.Value, ast astnode.AstNode, source io.ReadSeeker, checkUnusedKeys bool) (r report.Report) {
 	if !vObj.IsValid() {
 		return
 	}
@@ -138,11 +113,11 @@ func getFields(vObj reflect.Value) []field {
 	return ret
 }
 
-func validateStruct(vObj reflect.Value, ast AstNode, source io.ReadSeeker, checkUnusedKeys bool) report.Report {
+func validateStruct(vObj reflect.Value, ast astnode.AstNode, source io.ReadSeeker, checkUnusedKeys bool) report.Report {
 	r := report.Report{}
 
 	// isFromObject will be true if this struct was unmarshalled from a JSON object.
-	keys, isFromObject := map[string]AstNode{}, false
+	keys, isFromObject := map[string]astnode.AstNode{}, false
 	if ast != nil {
 		keys, isFromObject = ast.KeyValueMap()
 	}
@@ -154,8 +129,8 @@ func validateStruct(vObj reflect.Value, ast AstNode, source io.ReadSeeker, check
 	tags := []string{}
 
 	for _, f := range getFields(vObj) {
-		// Default to nil AstNode if the field's corrosponding node cannot be found.
-		var sub_node AstNode
+		// Default to nil astnode.AstNode if the field's corrosponding node cannot be found.
+		var sub_node astnode.AstNode
 		// Default to passing a nil source if the field's corrosponding node cannot be found.
 		// This ensures the line numbers reported from all sub-structs are 0 and will be changed by AddPosition
 		var src io.ReadSeeker

--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -15,15 +15,19 @@
 package validate
 
 import (
+	"bytes"
 	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
 
+	json "github.com/ajeddeloh/go-json"
+	"github.com/coreos/ignition/config/validate/astjson"
+	"github.com/coreos/ignition/config/validate/report"
 	// Import into the same namespace to keep config definitions clean
 	. "github.com/coreos/ignition/config/types"
-	"github.com/coreos/ignition/config/validate/report"
 )
 
 func TestValidate(t *testing.T) {
@@ -123,6 +127,132 @@ func TestValidate(t *testing.T) {
 		if !reflect.DeepEqual(expectedReport, r) {
 			t.Errorf("#%d: bad error: want %v, got %v", i, expectedReport, r)
 		}
+	}
+}
+
+var dummyErr = errors.New("dummy error")
+
+// These types need to be declared here to allow us to define Validate() methods on them
+// simple case, no embedding, no Validate<NAME> functions, just Validate() defined on a struct
+type Simple struct{}
+
+func (s Simple) Validate() report.Report {
+	return report.ReportFromError(dummyErr, report.EntryError)
+}
+
+type NamedValidate struct {
+	A string `json:"a"`
+}
+
+func (n NamedValidate) ValidateA() report.Report {
+	return report.ReportFromError(dummyErr, report.EntryError)
+}
+
+type simpleEmbedded struct {
+	Simple
+}
+
+type NamedEmbedded struct {
+	NamedValidate
+}
+
+type twiceNestedAndNamed struct {
+	NamedEmbedded
+}
+
+func TestValidateLineCol(t *testing.T) {
+	type in struct {
+		cfg string
+		// use reflect.Type to allow not needing an entire ignition config. Using interface{}
+		// would require the unbox and rebox trick, and Validate() needs a reflect.Value anyway.
+		// Unforunately, this means we can't (easily) factor out the reflect.TypeOf() call, but
+		// it makes the test code easier to read.
+		unmarshalInto reflect.Type
+	}
+	type out struct {
+		r report.Report
+	}
+
+	reportFromDummyWithLineCol := func(line, col int) report.Report {
+		r := report.ReportFromError(dummyErr, report.EntryError)
+		r.AddPosition(line, col, "")
+		return r
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			// no Validate()
+			in:  in{cfg: "{}", unmarshalInto: reflect.TypeOf(struct{}{})},
+			out: out{},
+		},
+		{
+			in: in{
+				cfg: `{
+}`,
+				unmarshalInto: reflect.TypeOf(Simple{}),
+			},
+			out: out{r: reportFromDummyWithLineCol(2, 2)},
+		},
+		{
+			in: in{
+				cfg: `{
+}`,
+				unmarshalInto: reflect.TypeOf(simpleEmbedded{}),
+			},
+			out: out{r: reportFromDummyWithLineCol(2, 2)},
+		},
+		{
+			in: in{
+				cfg: `{
+	"a": "foobar"
+}`,
+				unmarshalInto: reflect.TypeOf(NamedValidate{}),
+			},
+			out: out{r: reportFromDummyWithLineCol(2, 15)},
+		},
+		{
+			in: in{
+				cfg: `{
+	"a": "foobar"
+}`,
+				unmarshalInto: reflect.TypeOf(NamedEmbedded{}),
+			},
+			out: out{r: reportFromDummyWithLineCol(2, 15)},
+		},
+		{
+			in: in{
+				cfg: `{
+	"a": "foobar"
+}`,
+				unmarshalInto: reflect.TypeOf(twiceNestedAndNamed{}),
+			},
+			out: out{r: reportFromDummyWithLineCol(2, 15)},
+		},
+	}
+
+	for i, test := range tests {
+		v := reflect.New(test.in.unmarshalInto)
+		if err := json.Unmarshal([]byte(test.in.cfg), v.Interface()); err != nil {
+			t.Errorf("#%d: Failed to unmarshal into struct. This is most likely an error with the test: %v", i, err)
+		}
+
+		var ast json.Node
+		if err := json.Unmarshal([]byte(test.in.cfg), &ast); err != nil {
+			t.Errorf("#%d: Failed to unmarshal into ast. This is most likely an error with the test: %v", i, err)
+		}
+
+		reader := bytes.NewReader([]byte(test.in.cfg))
+
+		r := Validate(v, astjson.FromJsonRoot(ast), reader, false)
+		// highlight strings are hard to generate by hand, so ignore them for now
+		// TODO(ajeddeloh) test highlight strings
+		for i := range r.Entries {
+			r.Entries[i].Highlight = ""
+		}
+		assert.Equal(t, test.out.r, r, "#%d bad report", i)
 	}
 }
 


### PR DESCRIPTION
When Ignition switched to using a json schema the validation logic
changed slightly to allow Validate<FieldName>() functions to be called
as well. Ignition did not try to get the corrosponding ast node for that
field. This lets Ignition try to get the corrosponding ast node.