### PR TITLE
tests: always use private TMPDIR subdirectory

### DIFF
--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -232,17 +232,13 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	}
 
 	// Ignition config
-	configDir := filepath.Join(tmpDirectory, "config")
-	if err := os.Mkdir(configDir, 0777); err != nil {
-		t.Fatal(err)
-	}
-	if err := ioutil.WriteFile(filepath.Join(configDir, "config.ign"), []byte(test.Config), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(tmpDirectory, "config.ign"), []byte(test.Config), 0666); err != nil {
 		t.Fatal(err)
 	}
 
 	// Ignition
-	disks := runIgnition(t, "disks", rootLocation, configDir, negativeTests)
-	files := runIgnition(t, "files", rootLocation, configDir, negativeTests)
+	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, negativeTests)
+	files := runIgnition(t, "files", rootLocation, tmpDirectory, negativeTests)
 	if negativeTests && disks && files {
 		t.Fatal("Expected failure and ignition succeeded")
 	}

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -127,25 +127,30 @@ func TestIgnitionBlackBoxNegative(t *testing.T) {
 func outer(t *testing.T, test types.Test, negativeTests bool) {
 	t.Log(test.Name)
 
-	if os.Getenv("TMPDIR") == "" {
-		originalTmpDir := os.Getenv("TMPDIR")
-		tmpDirectory, err := ioutil.TempDir("/var/tmp", "ignition-blackbox-")
+	originalTmpDir := os.Getenv("TMPDIR")
+	if originalTmpDir == "" {
+		err := os.Setenv("TMPDIR", "/var/tmp")
 		if err != nil {
-			t.Fatalf("failed to create a temp dir: %v", err)
+			t.Fatalf("couldn't initialize TMPDIR: %v", err)
 		}
-		// the tmpDirectory must be 0755 or the tests will fail as the tool will
-		// not have permissions to perform some actions in the mounted folders
-		err = os.Chmod(tmpDirectory, 0755)
-		if err != nil {
-			t.Fatalf("failed to change mode of temp dir: %v", err)
-		}
-		err = os.Setenv("TMPDIR", tmpDirectory)
-		if err != nil {
-			t.Fatalf("failed to set TMPDIR environment var: %v", err)
-		}
-		defer os.Setenv("TMPDIR", originalTmpDir)
-		defer os.RemoveAll(tmpDirectory)
 	}
+
+	tmpDirectory, err := ioutil.TempDir("", "ignition-blackbox-")
+	if err != nil {
+		t.Fatalf("failed to create a temp dir: %v", err)
+	}
+	// the tmpDirectory must be 0755 or the tests will fail as the tool will
+	// not have permissions to perform some actions in the mounted folders
+	err = os.Chmod(tmpDirectory, 0755)
+	if err != nil {
+		t.Fatalf("failed to change mode of temp dir: %v", err)
+	}
+	err = os.Setenv("TMPDIR", tmpDirectory)
+	if err != nil {
+		t.Fatalf("failed to set TMPDIR environment var: %v", err)
+	}
+	defer os.Setenv("TMPDIR", originalTmpDir)
+	defer os.RemoveAll(tmpDirectory)
 
 	var rootLocation string
 
@@ -153,8 +158,8 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	for i, disk := range test.In {
 		// Move the ImageFile inside the temp dir
 		imageFileName := disk.ImageFile // create a copy for doing device replaces later
-		disk.ImageFile = filepath.Join(os.Getenv("TMPDIR"), disk.ImageFile)
-		test.Out[i].ImageFile = filepath.Join(os.Getenv("TMPDIR"), test.Out[i].ImageFile)
+		disk.ImageFile = filepath.Join(os.TempDir(), disk.ImageFile)
+		test.Out[i].ImageFile = filepath.Join(os.TempDir(), test.Out[i].ImageFile)
 
 		// There may be more partitions created by Ignition, so look at the
 		// expected output instead of the input to determine image size
@@ -174,7 +179,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 		setOffsets(test.Out[i].Partitions)
 
 		// Creation
-		createVolume(t, disk.ImageFile, imageSize, 20, 16, 63, disk.Partitions)
+		createVolume(t, i, disk.ImageFile, imageSize, 20, 16, 63, disk.Partitions)
 		disk.Device = setDevices(t, disk.ImageFile, disk.Partitions)
 		test.Out[i].Device = disk.Device
 		rootMounted := mountRootPartition(t, disk.Partitions)
@@ -210,8 +215,6 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 		setExpectedPartitionsDrive(test.In[i].Partitions, disk.Partitions)
 
 		// Cleanup
-		defer removeFile(t, disk.ImageFile)
-		defer removeMountFolders(t, disk.Partitions)
 		defer destroyDevice(t, disk.Device)
 		defer unmountRootPartition(t, disk.Partitions)
 	}
@@ -228,9 +231,16 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 		}
 	}
 
+	// Ignition config
+	configDir := filepath.Join(tmpDirectory, "config")
+	if err := os.Mkdir(configDir, 0777); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(configDir, "config.ign"), []byte(test.Config), 0666); err != nil {
+		t.Fatal(err)
+	}
+
 	// Ignition
-	configDir := writeIgnitionConfig(t, test.Config)
-	defer removeFile(t, filepath.Join(configDir, "config.ign"))
 	disks := runIgnition(t, "disks", rootLocation, configDir, negativeTests)
 	files := runIgnition(t, "files", rootLocation, configDir, negativeTests)
 	if negativeTests && disks && files {

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -156,10 +156,9 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 
 	// Setup
 	for i, disk := range test.In {
-		// Move the ImageFile inside the temp dir
-		imageFileName := disk.ImageFile // create a copy for doing device replaces later
-		disk.ImageFile = filepath.Join(os.TempDir(), disk.ImageFile)
-		test.Out[i].ImageFile = filepath.Join(os.TempDir(), test.Out[i].ImageFile)
+		// Set image file path
+		disk.ImageFile = filepath.Join(os.TempDir(), fmt.Sprintf("hd%d", i))
+		test.Out[i].ImageFile = disk.ImageFile
 
 		// There may be more partitions created by Ignition, so look at the
 		// expected output instead of the input to determine image size
@@ -200,9 +199,9 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			}
 		}
 
-		// Replace any instance of $<image-file> with the actual loop device
+		// Replace any instance of $disk<num> with the actual loop device
 		// that got assigned to it
-		test.Config = strings.Replace(test.Config, "$"+imageFileName, disk.Device, -1)
+		test.Config = strings.Replace(test.Config, fmt.Sprintf("$disk%d", i), disk.Device, -1)
 
 		if rootLocation == "" {
 			rootLocation = getRootLocation(disk.Partitions)

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -17,7 +17,6 @@ package blackbox
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -86,21 +85,6 @@ func getRootLocation(partitions []*types.Partition) string {
 	return ""
 }
 
-func removeFile(t *testing.T, imageFile string) {
-	err := os.Remove(imageFile)
-	if err != nil {
-		t.Log(err)
-	}
-}
-
-func removeMountFolders(t *testing.T, partitions []*types.Partition) {
-	for _, p := range partitions {
-		if p.MountPath != "" {
-			removeFile(t, p.MountPath)
-		}
-	}
-}
-
 // returns true if no error, false if error
 func runIgnition(t *testing.T, stage, root, configDir string, expectFail bool) bool {
 	args := []string{"-clear-cache", "-oem", "file", "-stage", stage, "-root", root}
@@ -125,19 +109,6 @@ func pickPartition(t *testing.T, device string, partitions []*types.Partition, l
 	return ""
 }
 
-func writeIgnitionConfig(t *testing.T, config string) string {
-	tmpDir, err := ioutil.TempDir("", "config")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = ioutil.WriteFile(
-		filepath.Join(tmpDir, "config.ign"), []byte(config), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return tmpDir
-}
-
 func calculateImageSize(partitions []*types.Partition) int64 {
 	// 63 is the number of sectors cgpt uses when generating a hybrid MBR
 	size := int64(63 * 512)
@@ -150,7 +121,7 @@ func calculateImageSize(partitions []*types.Partition) int64 {
 
 // createVolume will create the image file of the specified size, create a
 // partition table in it, and generate mount paths for every partition
-func createVolume(t *testing.T, imageFile string, size int64, cylinders int, heads int, sectorsPerTrack int, partitions []*types.Partition) {
+func createVolume(t *testing.T, index int, imageFile string, size int64, cylinders int, heads int, sectorsPerTrack int, partitions []*types.Partition) {
 	// attempt to create the file, will leave already existing files alone.
 	// os.Truncate requires the file to already exist
 	out, err := os.Create(imageFile)
@@ -172,11 +143,10 @@ func createVolume(t *testing.T, imageFile string, size int64, cylinders int, hea
 			continue
 		}
 
-		mntPath, err := ioutil.TempDir("", fmt.Sprintf("hd1p%d", counter))
-		if err != nil {
+		partition.MountPath = filepath.Join(os.TempDir(), fmt.Sprintf("hd%dp%d", index, counter))
+		if err := os.Mkdir(partition.MountPath, 0777); err != nil {
 			t.Fatal(err)
 		}
-		partition.MountPath = mntPath
 	}
 }
 

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -86,11 +86,11 @@ func getRootLocation(partitions []*types.Partition) string {
 }
 
 // returns true if no error, false if error
-func runIgnition(t *testing.T, stage, root, configDir string, expectFail bool) bool {
+func runIgnition(t *testing.T, stage, root, cwd string, expectFail bool) bool {
 	args := []string{"-clear-cache", "-oem", "file", "-stage", stage, "-root", root}
 	cmd := exec.Command("ignition", args...)
 	t.Log("ignition", args)
-	cmd.Dir = configDir
+	cmd.Dir = cwd
 	out, err := cmd.CombinedOutput()
 	if err != nil && !expectFail {
 		t.Fatal(args, err, string(out))

--- a/tests/positive/storage/creation.go
+++ b/tests/positive/storage/creation.go
@@ -126,7 +126,7 @@ func CreateNewPartitions() types.Test {
 		"storage": {
 		    "disks": [
 			    {
-					"device": "$blackbox_ignition_secondary_disk.img",
+					"device": "$disk1",
 					"wipeTable": true,
 					"partitions": [
 						{
@@ -152,7 +152,6 @@ func CreateNewPartitions() types.Test {
 	// are intentionally different so if Ignition doesn't do the right thing the
 	// validation will fail.
 	in = append(in, types.Disk{
-		ImageFile: "blackbox_ignition_secondary_disk.img",
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",
@@ -171,7 +170,6 @@ func CreateNewPartitions() types.Test {
 		},
 	})
 	out = append(out, types.Disk{
-		ImageFile: "blackbox_ignition_secondary_disk.img",
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",
@@ -204,7 +202,7 @@ func AppendPartition() types.Test {
 		},
 		"storage": {
 			"disks": [{
-				"device": "$blackbox_ignition_secondary_disk.img",
+				"device": "$disk1",
 				"wipeTable": false,
 				"partitions": [{
 					"label": "additional-partition",
@@ -218,7 +216,6 @@ func AppendPartition() types.Test {
 	}`
 
 	in = append(in, types.Disk{
-		ImageFile: "blackbox_ignition_secondary_disk.img",
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",
@@ -237,7 +234,6 @@ func AppendPartition() types.Test {
 		},
 	})
 	out = append(out, types.Disk{
-		ImageFile: "blackbox_ignition_secondary_disk.img",
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",

--- a/tests/positive/storage/reuse_filesystem.go
+++ b/tests/positive/storage/reuse_filesystem.go
@@ -50,7 +50,6 @@ func ReuseExistingFilesystem() types.Test {
 		}
 	}`
 	in = append(in, types.Disk{
-		ImageFile: "blackbox_ignition_secondary_disk.img",
 		Partitions: types.Partitions{
 			{
 				Label:           "important-data",
@@ -72,7 +71,6 @@ func ReuseExistingFilesystem() types.Test {
 		},
 	})
 	out = append(out, types.Disk{
-		ImageFile: "blackbox_ignition_secondary_disk.img",
 		Partitions: types.Partitions{
 			{
 				Label:           "important-data",

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -18,10 +18,6 @@ import (
 	"fmt"
 )
 
-const (
-	RootDeviceImageFile = "blackbox_ignition_test.img"
-)
-
 type File struct {
 	Node
 	Contents string
@@ -119,7 +115,6 @@ func (ps Partitions) AddRemovedNodes(label string, ns []Node) {
 func GetBaseDisk() []Disk {
 	return []Disk{
 		{
-			ImageFile: RootDeviceImageFile,
 			Partitions: Partitions{
 				{
 					Number:         1,


### PR DESCRIPTION
Respect `TMPDIR` if supplied, but create a subdirectory under it. This allows the rest of the codebase to create files with fixed names and not have to clean them up.

cc @arithx