### PR TITLE
*: add profile for OS-specific configuration

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coreos/ignition/internal/exec/util"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/oem"
+	"github.com/coreos/ignition/internal/profile"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/cmdline"
 	"github.com/coreos/ignition/internal/resource"
@@ -42,6 +43,7 @@ type Engine struct {
 	ConfigCache  string
 	FetchTimeout time.Duration
 	Logger       *log.Logger
+	Profile      profile.Profile
 	Root         string
 	OEMConfig    oem.Config
 
@@ -90,7 +92,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, f resource.Fetcher, err erro
 		// Create an http client and fetcher with the timeouts from the cached
 		// config
 		e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts)
-		f, err = e.OEMConfig.NewFetcherFunc()(e.Logger, &e.client)
+		f, err = e.OEMConfig.NewFetcherFunc()(e.Profile, e.Logger, &e.client)
 		if err != nil {
 			e.Logger.Crit("failed to generate fetcher: %s", err)
 			return
@@ -102,7 +104,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, f resource.Fetcher, err erro
 	// since we don't have a config with timeout values we can use
 	timeout := int(e.FetchTimeout.Seconds())
 	e.client = resource.NewHttpClient(e.Logger, types.Timeouts{HTTPTotal: &timeout})
-	f, err = e.OEMConfig.NewFetcherFunc()(e.Logger, &e.client)
+	f, err = e.OEMConfig.NewFetcherFunc()(e.Profile, e.Logger, &e.client)
 	if err != nil {
 		e.Logger.Crit("failed to generate fetcher: %s", err)
 		return
@@ -118,7 +120,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, f resource.Fetcher, err erro
 	// Regenerate the http client and fetcher to use the timeouts from the
 	// newly fetched config
 	e.client = resource.NewHttpClient(e.Logger, cfg.Ignition.Timeouts)
-	f, err = e.OEMConfig.NewFetcherFunc()(e.Logger, &e.client)
+	f, err = e.OEMConfig.NewFetcherFunc()(e.Profile, e.Logger, &e.client)
 	if err != nil {
 		e.Logger.Crit("failed to generate fetcher: %s", err)
 		return

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/profile"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/azure"
 	"github.com/coreos/ignition/internal/providers/cloudstack"
@@ -62,10 +63,11 @@ func (c Config) NewFetcherFunc() providers.FuncNewFetcher {
 	if c.newFetcher != nil {
 		return c.newFetcher
 	}
-	return func(l *log.Logger, c *resource.HttpClient) (resource.Fetcher, error) {
+	return func(p profile.Profile, l *log.Logger, c *resource.HttpClient) (resource.Fetcher, error) {
 		return resource.Fetcher{
-			Logger: l,
-			Client: c,
+			Profile: p,
+			Logger:  l,
+			Client:  c,
 		}, nil
 	}
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,59 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type Profile struct {
+	OEM OEM `json:"oem"`
+}
+
+type OEM struct {
+	// Device link where oem partition is found.
+	Device string `json:"device,omitempty"`
+	// OEM directories within root fs to consider before mounting.
+	SearchDirectories []string `json:"search-dirs,omitempty"`
+}
+
+var defaultProfile = Profile{
+	OEM: OEM{
+		Device:            "/dev/disk/by-label/OEM",
+		SearchDirectories: []string{"/usr/share/oem"},
+	},
+}
+
+func New(filename string) (Profile, error) {
+	profile := defaultProfile
+
+	if filename == "" {
+		return profile, nil
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return Profile{}, err
+	}
+	defer f.Close()
+
+	if err := json.NewDecoder(f).Decode(&profile); err != nil {
+		return Profile{}, fmt.Errorf("decoding %s: %v", filename, err)
+	}
+
+	return profile, nil
+}

--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/profile"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -50,13 +51,14 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	return util.ParseConfig(f.Logger, data)
 }
 
-func NewFetcher(l *log.Logger, c *resource.HttpClient) (resource.Fetcher, error) {
+func NewFetcher(p profile.Profile, l *log.Logger, c *resource.HttpClient) (resource.Fetcher, error) {
 	sess, err := session.NewSession(&aws.Config{})
 	if err != nil {
 		return resource.Fetcher{}, err
 	}
 	sess.Config.Credentials = ec2rolecreds.NewCredentials(sess)
 	return resource.Fetcher{
+		Profile:    p,
 		Logger:     l,
 		Client:     c,
 		AWSSession: sess,

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/profile"
 	"github.com/coreos/ignition/internal/resource"
 )
 
@@ -28,4 +29,4 @@ var (
 )
 
 type FuncFetchConfig func(f resource.Fetcher) (types.Config, report.Report, error)
-type FuncNewFetcher func(logger *log.Logger, client *resource.HttpClient) (resource.Fetcher, error)
+type FuncNewFetcher func(profile profile.Profile, logger *log.Logger, client *resource.HttpClient) (resource.Fetcher, error)

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -157,6 +157,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	var rootLocation string
 
 	// Setup
+	oemDirs := createOEMDirs(t, test.OEMDirs)
 	for i, disk := range test.In {
 		// Set image file path
 		disk.ImageFile = filepath.Join(os.TempDir(), fmt.Sprintf("hd%d", i))
@@ -188,7 +189,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			prepareRootPartitionForPasswd(t, disk.Partitions)
 		}
 		mountPartitions(t, disk.Partitions)
-		createFiles(t, disk.Partitions)
+		createFilesForPartitions(t, disk.Partitions)
 		unmountPartitions(t, disk.Partitions)
 
 		// Mount device name substitution
@@ -237,7 +238,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 		t.Fatal(err)
 	}
 	profilePath := filepath.Join(tmpDirectory, "profile")
-	writeIgnitionProfile(t, profilePath, test.In[0].Partitions)
+	writeIgnitionProfile(t, profilePath, test.In[0].Partitions, oemDirs)
 
 	// Ignition
 	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, profilePath, negativeTests)

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -81,6 +81,8 @@ fdsa`))
                 }]
         }
 }`))
+	} else {
+		return fmt.Errorf("no such file %q", filename)
 	}
 
 	_, err := rf.ReadFrom(buf)

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -230,14 +230,16 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 		}
 	}
 
-	// Ignition config
+	// Ignition configs
 	if err := ioutil.WriteFile(filepath.Join(tmpDirectory, "config.ign"), []byte(test.Config), 0666); err != nil {
 		t.Fatal(err)
 	}
+	profilePath := filepath.Join(tmpDirectory, "profile")
+	writeIgnitionProfile(t, profilePath, test.In[0].Partitions)
 
 	// Ignition
-	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, negativeTests)
-	files := runIgnition(t, "files", rootLocation, tmpDirectory, negativeTests)
+	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, profilePath, negativeTests)
+	files := runIgnition(t, "files", rootLocation, tmpDirectory, profilePath, negativeTests)
 	if negativeTests && disks && files {
 		t.Fatal("Expected failure and ignition succeeded")
 	}

--- a/tests/negative/files/invalid_hash.go
+++ b/tests/negative/files/invalid_hash.go
@@ -54,14 +54,19 @@ func InvalidHash() types.Test {
 			}]}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func InvalidHashFromHTTPURL() types.Test {
 	name := "Invalid File Hash from HTTP URL"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -85,5 +90,10 @@ func InvalidHashFromHTTPURL() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -1,0 +1,86 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, MissingRemoteContentsHTTP())
+	register.Register(register.NegativeTest, MissingRemoteContentsTFTP())
+	register.Register(register.NegativeTest, MissingRemoteContentsOEM())
+}
+
+func MissingRemoteContentsHTTP() types.Test {
+	name := "Missing File from Remote Contents - HTTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": { "version": "2.0.0" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "http://127.0.0.1:8080/asdf"
+	      }
+	    }]
+	  }
+	}`
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func MissingRemoteContentsTFTP() types.Test {
+	name := "Missing File from Remote Contents - TFTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+          "ignition": { "version": "2.1.0" },
+          "storage": {
+            "files": [{
+              "filesystem": "root",
+              "path": "/foo/bar",
+              "contents": {
+                "source": "tftp://127.0.0.1:69/asdf"
+              }
+            }]
+          }
+        }`
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func MissingRemoteContentsOEM() types.Test {
+	name := "Create Files from Remote Contents - OEM"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": { "version": "2.0.0" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "oem:///source"
+	      }
+	    }]
+	  }
+	}`
+	return types.Test{name, in, out, mntDevices, config}
+}

--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -29,7 +29,6 @@ func MissingRemoteContentsHTTP() types.Test {
 	name := "Missing File from Remote Contents - HTTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -42,14 +41,18 @@ func MissingRemoteContentsHTTP() types.Test {
 	    }]
 	  }
 	}`
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func MissingRemoteContentsTFTP() types.Test {
 	name := "Missing File from Remote Contents - TFTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": { "version": "2.1.0" },
           "storage": {
@@ -62,14 +65,18 @@ func MissingRemoteContentsTFTP() types.Test {
             }]
           }
         }`
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func MissingRemoteContentsOEM() types.Test {
 	name := "Create Files from Remote Contents - OEM"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -82,5 +89,10 @@ func MissingRemoteContentsOEM() types.Test {
 	    }]
 	  }
 	}`
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -22,6 +22,13 @@ import (
 func init() {
 	register.Register(register.NegativeTest, ReplaceConfigWithInvalidHash())
 	register.Register(register.NegativeTest, AppendConfigWithInvalidHash())
+
+	register.Register(register.NegativeTest, ReplaceConfigWithMissingFileHTTP())
+	register.Register(register.NegativeTest, ReplaceConfigWithMissingFileTFTP())
+	register.Register(register.NegativeTest, ReplaceConfigWithMissingFileOEM())
+	register.Register(register.NegativeTest, AppendConfigWithMissingFileHTTP())
+	register.Register(register.NegativeTest, AppendConfigWithMissingFileTFTP())
+	register.Register(register.NegativeTest, AppendConfigWithMissingFileOEM())
 }
 
 func ReplaceConfigWithInvalidHash() types.Test {
@@ -76,6 +83,120 @@ func AppendConfigWithInvalidHash() types.Test {
           "contents": { "source": "data:,another%20example%20file%0A" }
         }]
       }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func ReplaceConfigWithMissingFileHTTP() types.Test {
+	name := "Replace Config with Missing File - HTTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.0.0",
+	    "config": {
+	      "replace": {
+	        "source": "http://127.0.0.1:8080/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func ReplaceConfigWithMissingFileTFTP() types.Test {
+	name := "Replace Config with Missing File - TFTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.0.0",
+	    "config": {
+	      "replace": {
+	        "source": "tftp://127.0.0.1:69/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func ReplaceConfigWithMissingFileOEM() types.Test {
+	name := "Replace Config with Missing File - OEM"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.0.0",
+	    "config": {
+	      "replace": {
+	        "source": "oem:///asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithMissingFileHTTP() types.Test {
+	name := "Append Config with Missing File - HTTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.0.0",
+	    "config": {
+	      "append": {
+	        "source": "http://127.0.0.1:8080/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithMissingFileTFTP() types.Test {
+	name := "Append Config with Missing File - TFTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.0.0",
+	    "config": {
+	      "append": {
+	        "source": "tftp://127.0.0.1:69/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithMissingFileOEM() types.Test {
+	name := "Append Config with Missing File - OEM"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.0.0",
+	    "config": {
+	      "append": {
+	        "source": "oem:///asdf"
+	      }
+	    }
+	  }
 	}`
 
 	return types.Test{name, in, out, mntDevices, config}

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -53,7 +53,13 @@ func ReplaceConfigWithInvalidHash() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func AppendConfigWithInvalidHash() types.Test {
@@ -85,14 +91,19 @@ func AppendConfigWithInvalidHash() types.Test {
       }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReplaceConfigWithMissingFileHTTP() types.Test {
 	name := "Replace Config with Missing File - HTTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -104,14 +115,18 @@ func ReplaceConfigWithMissingFileHTTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithMissingFileTFTP() types.Test {
 	name := "Replace Config with Missing File - TFTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -123,14 +138,18 @@ func ReplaceConfigWithMissingFileTFTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithMissingFileOEM() types.Test {
 	name := "Replace Config with Missing File - OEM"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -142,14 +161,18 @@ func ReplaceConfigWithMissingFileOEM() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithMissingFileHTTP() types.Test {
 	name := "Append Config with Missing File - HTTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -161,14 +184,18 @@ func AppendConfigWithMissingFileHTTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithMissingFileTFTP() types.Test {
 	name := "Append Config with Missing File - TFTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -180,14 +207,18 @@ func AppendConfigWithMissingFileTFTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithMissingFileOEM() types.Test {
 	name := "Append Config with Missing File - OEM"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -199,5 +230,10 @@ func AppendConfigWithMissingFileOEM() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/general/invalid_version.go
+++ b/tests/negative/general/invalid_version.go
@@ -27,7 +27,6 @@ func InvalidVersion() types.Test {
 	name := "Invalid Version"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "4.0.0"},
 		"storage": {
@@ -38,5 +37,10 @@ func InvalidVersion() types.Test {
 			}]}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/regression/filesystem.go
+++ b/tests/negative/regression/filesystem.go
@@ -47,5 +47,11 @@ func VFATIgnoresWipeFilesystem() types.Test {
                         }
         }`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/negative/storage/invalid_filesystem.go
+++ b/tests/negative/storage/invalid_filesystem.go
@@ -27,7 +27,6 @@ func InvalidFilesystem() types.Test {
 	name := "Invalid Filesystem"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.0.0"},
 		"storage": {
@@ -38,5 +37,10 @@ func InvalidFilesystem() types.Test {
 			}]}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/storage/no_device.go
+++ b/tests/negative/storage/no_device.go
@@ -30,7 +30,6 @@ func NoDevice() types.Test {
 	name := "No Device"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -43,14 +42,18 @@ func NoDevice() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func NoDeviceWithForce() types.Test {
 	name := "No Device w/ Force"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.0.0"},
 		"storage": {
@@ -66,14 +69,18 @@ func NoDeviceWithForce() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func NoDeviceWithWipeFilesystemTrue() types.Test {
 	name := "No Device w/ wipeFilesystem true"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -87,14 +94,18 @@ func NoDeviceWithWipeFilesystemTrue() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func NoDeviceWithWipeFilesystemFalse() types.Test {
 	name := "No Device w/ wipeFilesystem false"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -108,5 +119,10 @@ func NoDeviceWithWipeFilesystemFalse() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/storage/no_filesystem_type.go
+++ b/tests/negative/storage/no_filesystem_type.go
@@ -47,7 +47,13 @@ func NoFilesystemType() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func NoFilesystemTypeWithForce() types.Test {
@@ -75,7 +81,13 @@ func NoFilesystemTypeWithForce() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func NoFilesystemTypeWithWipeFilesystem() types.Test {
@@ -101,5 +113,11 @@ func NoFilesystemTypeWithWipeFilesystem() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/negative/timeouts/timeouts.go
+++ b/tests/negative/timeouts/timeouts.go
@@ -40,7 +40,6 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 	name := "Decrease HTTP Response Headers Timeout"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := fmt.Sprintf(`{
 		"ignition": {
 			"version": "2.1.0",
@@ -62,5 +61,10 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 		}
 	}`, respondDelayServer.URL)
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/directory.go
+++ b/tests/positive/files/directory.go
@@ -27,7 +27,6 @@ func CreateDirectoryOnRoot() types.Test {
 	name := "Create a Directory on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -46,5 +45,10 @@ func CreateDirectoryOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -31,7 +31,6 @@ func CreateFileOnRoot() types.Test {
 	name := "Create Files on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -52,14 +51,18 @@ func CreateFileOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func UserGroupByID_2_0_0() types.Test {
 	name := "2.0.0 User/Group by id"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -84,14 +87,18 @@ func UserGroupByID_2_0_0() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func UserGroupByID_2_1_0() types.Test {
 	name := "2.1.0 User/Group by id"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -116,14 +123,18 @@ func UserGroupByID_2_1_0() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func UserGroupByName_2_1_0() types.Test {
 	name := "2.1.0 User/Group by name"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -148,5 +159,10 @@ func UserGroupByName_2_1_0() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/hash.go
+++ b/tests/positive/files/hash.go
@@ -28,7 +28,6 @@ func ValidateFileHashFromDataURL() types.Test {
 	name := "Validate File Hash from Data URL"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -52,14 +51,18 @@ func ValidateFileHashFromDataURL() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ValidateFileHashFromHTTPURL() types.Test {
 	name := "Validate File Hash from HTTP URL"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -83,5 +86,10 @@ func ValidateFileHashFromHTTPURL() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/link.go
+++ b/tests/positive/files/link.go
@@ -28,7 +28,6 @@ func CreateHardLinkOnRoot() types.Test {
 	name := "Create a Hard Link on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -67,14 +66,18 @@ func CreateHardLinkOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func CreateSymlinkOnRoot() types.Test {
 	name := "Create a Symlink on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -105,5 +108,10 @@ func CreateSymlinkOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -22,6 +22,7 @@ import (
 func init() {
 	register.Register(register.PositiveTest, CreateFileFromRemoteContentsHTTP())
 	register.Register(register.PositiveTest, CreateFileFromRemoteContentsTFTP())
+	register.Register(register.PositiveTest, CreateFileFromRemoteContentsOEM())
 }
 
 func CreateFileFromRemoteContentsHTTP() types.Test {
@@ -71,6 +72,44 @@ func CreateFileFromRemoteContentsTFTP() types.Test {
             }]
           }
         }`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+			},
+			Contents: "asdf\nfdsa",
+		},
+	})
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func CreateFileFromRemoteContentsOEM() types.Test {
+	name := "Create Files from Remote Contents - OEM"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": { "version": "2.0.0" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "oem:///source"
+	      }
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddFiles("OEM", []types.File{
+		{
+			Node: types.Node{
+				Name: "source",
+			},
+			Contents: "asdf\nfdsa",
+		},
+	})
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -29,7 +29,6 @@ func CreateFileFromRemoteContentsHTTP() types.Test {
 	name := "Create Files from Remote Contents - HTTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -52,14 +51,18 @@ func CreateFileFromRemoteContentsHTTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func CreateFileFromRemoteContentsTFTP() types.Test {
 	name := "Create Files from Remote Contents - TFTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": { "version": "2.1.0" },
           "storage": {
@@ -82,14 +85,18 @@ func CreateFileFromRemoteContentsTFTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func CreateFileFromRemoteContentsOEM() types.Test {
 	name := "Create Files from Remote Contents - OEM"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -120,5 +127,10 @@ func CreateFileFromRemoteContentsOEM() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -25,6 +25,8 @@ func init() {
 	register.Register(register.PositiveTest, AppendConfigWithRemoteConfigHTTP())
 	register.Register(register.PositiveTest, ReplaceConfigWithRemoteConfigTFTP())
 	register.Register(register.PositiveTest, AppendConfigWithRemoteConfigTFTP())
+	register.Register(register.PositiveTest, ReplaceConfigWithRemoteConfigOEM())
+	register.Register(register.PositiveTest, AppendConfigWithRemoteConfigOEM())
 	register.Register(register.PositiveTest, VersionOnlyConfig())
 	register.Register(register.PositiveTest, EmptyUserdata())
 }
@@ -129,6 +131,52 @@ func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 	return types.Test{name, in, out, mntDevices, config}
 }
 
+func ReplaceConfigWithRemoteConfigOEM() types.Test {
+	name := "Replacing the Config with a Remote Config from OEM"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	var mntDevices []types.MntDevice
+	config := `{
+          "ignition": {
+            "version": "2.0.0",
+            "config": {
+              "replace": {
+                "source": "oem:///config",
+                        "verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
+              }
+            }
+          }
+        }`
+	in[0].Partitions.AddFiles("OEM", []types.File{
+		{
+			Node: types.Node{
+				Name: "config",
+			},
+			Contents: `{
+	"ignition": { "version": "2.0.0" },
+	"storage": {
+		"files": [{
+		  "filesystem": "root",
+		  "path": "/foo/bar",
+		  "contents": { "source": "data:,example%20file%0A" }
+		}]
+	}
+}`,
+		},
+	})
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+			},
+			Contents: "example file\n",
+		},
+	})
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
 func AppendConfigWithRemoteConfigHTTP() types.Test {
 	name := "Appending to the Config with a Remote Config from HTTP"
 	in := types.GetBaseDisk()
@@ -195,6 +243,66 @@ func AppendConfigWithRemoteConfigTFTP() types.Test {
         }]
       }
         }`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+			},
+			Contents: "example file\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "bar2",
+				Directory: "foo",
+			},
+			Contents: "another example file\n",
+		},
+	})
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithRemoteConfigOEM() types.Test {
+	name := "Appending to the Config with a Remote Config from OEM"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	var mntDevices []types.MntDevice
+	config := `{
+          "ignition": {
+            "version": "2.0.0",
+            "config": {
+              "append": [{
+                "source": "oem:///config",
+                        "verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
+              }]
+            }
+          },
+      "storage": {
+        "files": [{
+          "filesystem": "root",
+          "path": "/foo/bar2",
+          "contents": { "source": "data:,another%20example%20file%0A" }
+        }]
+      }
+        }`
+	in[0].Partitions.AddFiles("OEM", []types.File{
+		{
+			Node: types.Node{
+				Name: "config",
+			},
+			Contents: `{
+	"ignition": { "version": "2.0.0" },
+	"storage": {
+		"files": [{
+		  "filesystem": "root",
+		  "path": "/foo/bar",
+		  "contents": { "source": "data:,example%20file%0A" }
+		}]
+	}
+}`,
+		},
+	})
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -70,14 +70,19 @@ func ReformatFilesystemAndWriteFile() types.Test {
 		},
 	}
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 	name := "Replacing the Config with a Remote Config from HTTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -99,14 +104,18 @@ func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 	name := "Replacing the Config with a Remote Config from TFTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.1.0",
@@ -128,14 +137,18 @@ func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithRemoteConfigOEM() types.Test {
 	name := "Replacing the Config with a Remote Config from OEM"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.0.0",
@@ -174,14 +187,18 @@ func ReplaceConfigWithRemoteConfigOEM() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithRemoteConfigHTTP() types.Test {
 	name := "Appending to the Config with a Remote Config from HTTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -217,14 +234,18 @@ func AppendConfigWithRemoteConfigHTTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithRemoteConfigTFTP() types.Test {
 	name := "Appending to the Config with a Remote Config from TFTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.1.0",
@@ -260,14 +281,18 @@ func AppendConfigWithRemoteConfigTFTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithRemoteConfigOEM() types.Test {
 	name := "Appending to the Config with a Remote Config from OEM"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.0.0",
@@ -320,27 +345,40 @@ func AppendConfigWithRemoteConfigOEM() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func VersionOnlyConfig() types.Test {
 	name := "Version Only Config"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func EmptyUserdata() types.Test {
 	name := "Empty Userdata"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := ``
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/networkd/create_unit.go
+++ b/tests/positive/networkd/create_unit.go
@@ -27,7 +27,6 @@ func CreateNetworkdUnit() types.Test {
 	name := "Create a networkd unit"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": { "version": "2.1.0" },
 		"networkd": {
@@ -47,5 +46,10 @@ func CreateNetworkdUnit() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/oem/oem.go
+++ b/tests/positive/oem/oem.go
@@ -1,0 +1,108 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package general
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.PositiveTest, OEMSearchPath())
+}
+
+func OEMSearchPath() types.Test {
+	name := "Read files from multiple locations in OEM search path"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+		"ignition": {"version": "2.0.0"},
+		"storage": {
+			"files": [
+				{
+					"filesystem": "root",
+					"path": "/ignition/out-1",
+					"contents": {"source": "oem:///source-1"}
+				},
+				{
+					"filesystem": "root",
+					"path": "/ignition/out-2",
+					"contents": {"source": "oem:///source-2"}
+				},
+				{
+					"filesystem": "root",
+					"path": "/ignition/out-3",
+					"contents": {"source": "oem:///source-3"}
+				}
+			]}
+	}`
+	oemDirs := [][]types.File{
+		{
+			{
+				Node: types.Node{
+					Name: "source-1",
+				},
+				Contents: "source-a",
+			},
+		},
+		{
+			{
+				Node: types.Node{
+					Name: "source-2",
+				},
+				Contents: "source-b",
+			},
+		},
+	}
+	in[0].Partitions.AddFiles("OEM", []types.File{
+		{
+			Node: types.Node{
+				Name: "source-3",
+			},
+			Contents: "source-c",
+		},
+	})
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "out-1",
+				Directory: "ignition",
+			},
+			Contents: "source-a",
+		},
+		{
+			Node: types.Node{
+				Name:      "out-2",
+				Directory: "ignition",
+			},
+			Contents: "source-b",
+		},
+		{
+			Node: types.Node{
+				Name:      "out-3",
+				Directory: "ignition",
+			},
+			Contents: "source-c",
+		},
+	})
+
+	return types.Test{
+		Name:    name,
+		In:      in,
+		Out:     out,
+		OEMDirs: oemDirs,
+		Config:  config,
+	}
+}

--- a/tests/positive/passwd/users.go
+++ b/tests/positive/passwd/users.go
@@ -27,7 +27,6 @@ func AddPasswdUsers() types.Test {
 	name := "Adding users"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {
 			"version": "2.0.0"
@@ -151,5 +150,10 @@ ENCRYPT_METHOD SHA512
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/regression/filesystem.go
+++ b/tests/positive/regression/filesystem.go
@@ -54,7 +54,13 @@ func EquivalentFilesystemUUIDsTreatedDistinctEXT4() types.Test {
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "6ABE925E-6DAF-4FAD-BC09-8D56BE8822DE"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "6ABE925E-6DAF-4FAD-BC09-8D56BE8822DE"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func EquivalentFilesystemUUIDsTreatedDistinctVFAT() types.Test {
@@ -86,5 +92,11 @@ func EquivalentFilesystemUUIDsTreatedDistinctVFAT() types.Test {
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "2e24ec82"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "vfat"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/positive/storage/creation.go
+++ b/tests/positive/storage/creation.go
@@ -69,7 +69,13 @@ func ForceNewFilesystemOfSameType() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func WipeFilesystemWithSameType() types.Test {
@@ -113,14 +119,19 @@ func WipeFilesystemWithSameType() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func CreateNewPartitions() types.Test {
 	name := "Create new partitions"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -188,14 +199,18 @@ func CreateNewPartitions() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendPartition() types.Test {
 	name := "Append partition to an existing partition table"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {
 			"version": "2.1.0"
@@ -259,5 +274,10 @@ func AppendPartition() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/storage/reformat_filesystem.go
+++ b/tests/positive/storage/reformat_filesystem.go
@@ -57,7 +57,13 @@ func ReformatToBTRFS_2_0_0() types.Test {
 	}`
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToXFS_2_0_0() types.Test {
@@ -87,7 +93,13 @@ func ReformatToXFS_2_0_0() types.Test {
 	}`
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "xfs"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToVFAT_2_0_0() types.Test {
@@ -118,7 +130,13 @@ func ReformatToVFAT_2_0_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "vfat"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToEXT4_2_0_0() types.Test {
@@ -150,7 +168,13 @@ func ReformatToEXT4_2_0_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToBTRFS_2_1_0() types.Test {
@@ -180,7 +204,13 @@ func ReformatToBTRFS_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToXFS_2_1_0() types.Test {
@@ -210,7 +240,13 @@ func ReformatToXFS_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "xfs"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToVFAT_2_1_0() types.Test {
@@ -240,7 +276,13 @@ func ReformatToVFAT_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "vfat"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "2e24ec82"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToEXT4_2_1_0() types.Test {
@@ -271,7 +313,13 @@ func ReformatToEXT4_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToSWAP_2_1_0() types.Test {
@@ -302,5 +350,11 @@ func ReformatToSWAP_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "swap"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/positive/storage/reuse_filesystem.go
+++ b/tests/positive/storage/reuse_filesystem.go
@@ -92,5 +92,11 @@ func ReuseExistingFilesystem() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/positive/systemd/create_unit.go
+++ b/tests/positive/systemd/create_unit.go
@@ -27,7 +27,6 @@ func CreateSystemdService() types.Test {
 	name := "Create a systemd service"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": { "version": "2.0.0" },
 		"systemd": {
@@ -55,5 +54,10 @@ func CreateSystemdService() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/systemd/modify_service.go
+++ b/tests/positive/systemd/modify_service.go
@@ -28,7 +28,6 @@ func ModifySystemdService() types.Test {
 	name := "Modify Services"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "systemd": {
@@ -51,14 +50,18 @@ func ModifySystemdService() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func MaskSystemdServices() types.Test {
 	name := "Mask Services"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "systemd": {
@@ -79,5 +82,10 @@ func MaskSystemdServices() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/timeouts/timeouts.go
+++ b/tests/positive/timeouts/timeouts.go
@@ -53,7 +53,6 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 	name := "Increase HTTP Response Headers Timeout"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := fmt.Sprintf(`{
 		"ignition": {
 			"version": "2.1.0",
@@ -83,14 +82,18 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ConfirmHTTPBackoffWorks() types.Test {
 	name := "Confirm HTTP Backoff Works"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := fmt.Sprintf(`{
 		"ignition": {
 			"version": "2.1.0"
@@ -117,5 +120,10 @@ func ConfirmHTTPBackoffWorks() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/registry/registry.go
+++ b/tests/registry/registry.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/coreos/ignition/tests/positive/files"
 	_ "github.com/coreos/ignition/tests/positive/general"
 	_ "github.com/coreos/ignition/tests/positive/networkd"
+	_ "github.com/coreos/ignition/tests/positive/oem"
 	_ "github.com/coreos/ignition/tests/positive/passwd"
 	_ "github.com/coreos/ignition/tests/positive/regression"
 	_ "github.com/coreos/ignition/tests/positive/storage"

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -80,6 +80,7 @@ type Test struct {
 	In         []Disk
 	Out        []Disk
 	MntDevices []MntDevice
+	OEMDirs    [][]File
 	Config     string
 }
 


### PR DESCRIPTION
Allow caller to pass a JSON file containing OS-specific settings such as the path to the OEM device node. For now, include the `oemDevicePath` and the `oemDirPath`. Generalize the latter to a set of search directories, since there's no inherent reason the OS should have only one lookaside directory.

cc @crawford for concept, @dgonyeo for concept and implementation, @arithx for tests