### PR TITLE
*: add validate only flag

### DIFF
--- a/internal/exec/stages/noop/noop.go
+++ b/internal/exec/stages/noop/noop.go
@@ -1,0 +1,50 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noop
+
+import (
+	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/internal/exec/stages"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/resource"
+)
+
+const (
+	name = "noop"
+)
+
+func init() {
+	stages.Register(creator{})
+}
+
+type creator struct{}
+
+func (creator) Create(_ *log.Logger, _ string, _ resource.Fetcher) stages.Stage {
+	return &stage{}
+}
+
+func (creator) Name() string {
+	return name
+}
+
+type stage struct{}
+
+func (stage) Name() string {
+	return name
+}
+
+func (s stage) Run(_ types.Config) bool {
+	return true
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/ignition/internal/exec/stages"
 	_ "github.com/coreos/ignition/internal/exec/stages/disks"
 	_ "github.com/coreos/ignition/internal/exec/stages/files"
+	_ "github.com/coreos/ignition/internal/exec/stages/noop"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/oem"
 	"github.com/coreos/ignition/internal/version"
@@ -38,6 +39,7 @@ func main() {
 		root         string
 		stage        stages.Name
 		version      bool
+		validate     string
 	}{}
 
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
@@ -47,12 +49,19 @@ func main() {
 	flag.StringVar(&flags.root, "root", "/", "root of the filesystem")
 	flag.Var(&flags.stage, "stage", fmt.Sprintf("execution stage. %v", stages.Names()))
 	flag.BoolVar(&flags.version, "version", false, "print the version and exit")
+	flag.StringVar(&flags.validate, "validate", "", "path to ignition config to validate")
 
 	flag.Parse()
 
 	if flags.version {
 		fmt.Printf("%s\n", version.String)
 		return
+	}
+
+	if flags.validate != "" {
+		flags.oem = "file"
+		flags.configCache = ""
+		flags.stage = "noop"
 	}
 
 	if flags.oem == "" {

--- a/internal/providers/file/file.go
+++ b/internal/providers/file/file.go
@@ -15,6 +15,7 @@
 package file
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
 
@@ -31,6 +32,9 @@ const (
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	filename := os.Getenv(cfgFilenameEnvVar)
+	if f := flag.Lookup("validate"); f != nil && f.Value.String() != "" {
+		filename = f.Value.String()
+	}
 	if filename == "" {
 		filename = defaultFilename
 		f.Logger.Info("using default filename")


### PR DESCRIPTION
Developing validation logic either has a long test time due to needing
to build new images, or is dangerous due to needing to run Ignition
locally. This adds a --validate <ignfile> flag that allows Ignition to
just validate a config then exit.

It is implemented as a no-op stage and uses the file provider.