### PR TITLE
main: add validate flag

### DIFF
--- a/internal/exec/validate.go
+++ b/internal/exec/validate.go
@@ -1,0 +1,39 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/coreos/ignition/config"
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+func Validate(filename string) (report.Report, error) {
+	var err error
+	var b []byte
+	if filename == "-" {
+		b, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		b, err = ioutil.ReadFile(filename)
+	}
+	if err != nil {
+		return report.Report{}, err
+	}
+
+	_, r, err := config.Parse(b)
+	return r, err
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -38,6 +38,7 @@ func main() {
 		root         string
 		stage        stages.Name
 		version      bool
+		validate     string
 	}{}
 
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
@@ -47,11 +48,30 @@ func main() {
 	flag.StringVar(&flags.root, "root", "/", "root of the filesystem")
 	flag.Var(&flags.stage, "stage", fmt.Sprintf("execution stage. %v", stages.Names()))
 	flag.BoolVar(&flags.version, "version", false, "print the version and exit")
+	flag.StringVar(&flags.validate, "validate", "", "validate specified config then exit")
 
 	flag.Parse()
 
 	if flags.version {
 		fmt.Printf("%s\n", version.String)
+		return
+	}
+
+	if flags.validate != "" {
+		report, err := exec.Validate(flags.validate)
+		if len(report.Entries) != 0 {
+			fmt.Println(report)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		if len(report.Entries) == 0 {
+			// Just silently exit if everything passed without even warnings
+			return
+		}
+		// Print this to be clear that despite any warnings the config is valid
+		fmt.Println("Config is valid")
 		return
 	}
 


### PR DESCRIPTION
Add flag to just validate Ignition configs then exist. Developing
validation logic has either been time consuming (as new images need to
be built) or dangerous due to running ignition locally.

I'm not married to the location `internal/exec/validate.go` but it seemed like the best place considering its an execution path but not a stage.