### PR TITLE
Disallow size 0 when start is not 0

### DIFF
--- a/config/types/partition.go
+++ b/config/types/partition.go
@@ -29,6 +29,7 @@ const (
 var (
 	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
 	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrSizeZero             = errors.New("size can only be zero if start is zero")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -45,6 +46,13 @@ func (p Partition) ValidateLabel() report.Report {
 		})
 	}
 	return r
+}
+
+func (p Partition) ValidateSize() report.Report {
+	if p.Size == 0 && p.Start != 0 {
+		return report.ReportFromError(ErrSizeZero, report.EntryError)
+	}
+	return report.Report{}
 }
 
 func (p Partition) ValidateTypeGUID() report.Report {

--- a/config/types/partition_test.go
+++ b/config/types/partition_test.go
@@ -21,6 +21,36 @@ import (
 	"github.com/coreos/ignition/config/validate/report"
 )
 
+func TestValidateSize(t *testing.T) {
+	type in Partition
+	type out struct {
+		report report.Report
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{Size: 0, Start: 0},
+			out{report.Report{}},
+		},
+		{
+			in{Size: 1, Start: 1},
+			out{report.Report{}},
+		},
+		{
+			in{Size: 0, Start: 1},
+			out{report.ReportFromError(ErrSizeZero, report.EntryError)},
+		},
+	}
+	for i, test := range tests {
+		r := Partition(test.in).ValidateSize()
+		if !reflect.DeepEqual(r, test.out.report) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out.report, r)
+		}
+	}
+}
+
 func TestValidateLabel(t *testing.T) {
 	type in struct {
 		label string

--- a/config/v2_0/types/partition.go
+++ b/config/v2_0/types/partition.go
@@ -43,6 +43,13 @@ func (n PartitionLabel) Validate() report.Report {
 	return report.Report{}
 }
 
+func (p Partition) ValidateSize() report.Report {
+	if p.Size == 0 && p.Start != 0 {
+		return report.ReportFromError(fmt.Errorf("size can only be zero if start is zero"), report.EntryError)
+	}
+	return report.Report{}
+}
+
 type PartitionDimension uint64
 
 type PartitionTypeGUID string

--- a/config/v2_1/types/partition.go
+++ b/config/v2_1/types/partition.go
@@ -29,6 +29,7 @@ const (
 var (
 	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
 	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrSizeZero             = errors.New("size can only be zero if start is zero")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -45,6 +46,13 @@ func (p Partition) ValidateLabel() report.Report {
 		})
 	}
 	return r
+}
+
+func (p Partition) ValidateSize() report.Report {
+	if p.Size == 0 && p.Start != 0 {
+		return report.ReportFromError(ErrSizeZero, report.EntryError)
+	}
+	return report.Report{}
 }
 
 func (p Partition) ValidateTypeGUID() report.Report {

--- a/config/v2_1/types/partition_test.go
+++ b/config/v2_1/types/partition_test.go
@@ -21,6 +21,36 @@ import (
 	"github.com/coreos/ignition/config/validate/report"
 )
 
+func TestValidateSize(t *testing.T) {
+	type in Partition
+	type out struct {
+		report report.Report
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in{Size: 0, Start: 0},
+			out{report.Report{}},
+		},
+		{
+			in{Size: 1, Start: 1},
+			out{report.Report{}},
+		},
+		{
+			in{Size: 0, Start: 1},
+			out{report.ReportFromError(ErrSizeZero, report.EntryError)},
+		},
+	}
+	for i, test := range tests {
+		r := Partition(test.in).ValidateSize()
+		if !reflect.DeepEqual(r, test.out.report) {
+			t.Errorf("#%d: wanted %v, got %v", i, test.out.report, r)
+		}
+	}
+}
+
 func TestValidateLabel(t *testing.T) {
 	type in struct {
 		label string

--- a/doc/configuration-v2_0.md
+++ b/doc/configuration-v2_0.md
@@ -22,8 +22,8 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
       * **_label_** (string): the PARTLABEL for the partition.
       * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the remainder of the disk.
-      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the the largest block available. Specifying zero is only valid if `start` is also zero.
+      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the start of the largest block available.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
   * **_raid_** (list of objects): the list of RAID arrays to be configured.
     * **name** (string): the name to use for the resulting md device.

--- a/doc/configuration-v2_1.md
+++ b/doc/configuration-v2_1.md
@@ -23,8 +23,8 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
       * **_label_** (string): the PARTLABEL for the partition.
       * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the remainder of the disk.
-      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the the largest block available. Specifying zero is only valid if `start` is also zero.
+      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the start of the largest block available.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
       * **_guid_** (string): the GPT unique partition GUID.
   * **_raid_** (list of objects): the list of RAID arrays to be configured.

--- a/doc/configuration-v2_2-experimental.md
+++ b/doc/configuration-v2_2-experimental.md
@@ -25,8 +25,8 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
       * **_label_** (string): the PARTLABEL for the partition.
       * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the remainder of the disk.
-      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the the largest block available. Specifying zero is only valid if `start` is also zero.
+      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the start of the largest block available.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
       * **_guid_** (string): the GPT unique partition GUID.
   * **_raid_** (list of objects): the list of RAID arrays to be configured.

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -162,7 +162,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 
 		// There may be more partitions created by Ignition, so look at the
 		// expected output instead of the input to determine image size
-		imageSize := calculateImageSize(test.Out[i].Partitions)
+		imageSize := test.Out[i].CalculateImageSize()
 
 		// Finish data setup
 		for _, part := range disk.Partitions {
@@ -171,11 +171,12 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			}
 			updateTypeGUID(t, part)
 		}
-		setOffsets(disk.Partitions)
+
+		disk.SetOffsets()
 		for _, part := range test.Out[i].Partitions {
 			updateTypeGUID(t, part)
 		}
-		setOffsets(test.Out[i].Partitions)
+		test.Out[i].SetOffsets()
 
 		// Creation
 		createVolume(t, i, disk.ImageFile, imageSize, 20, 16, 63, disk.Partitions)
@@ -247,7 +248,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			// Validation
 			mountPartitions(t, disk.Partitions)
 			t.Log(disk.ImageFile)
-			validatePartitions(t, disk.Partitions, disk.ImageFile)
+			validateDisk(t, disk, disk.ImageFile)
 			validateFilesystems(t, disk.Partitions, disk.ImageFile)
 			validateFilesDirectoriesAndLinks(t, disk.Partitions)
 			unmountPartitions(t, disk.Partitions)

--- a/tests/negative/storage/invalid_size.go
+++ b/tests/negative/storage/invalid_size.go
@@ -1,0 +1,43 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, InvalidSize())
+}
+
+func InvalidSize() types.Test {
+	name := "Invalid Filesystem"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+		"ignition": {"version": "2.0.0"},
+		"storage": {
+			"disks": [{
+				"paritions": [
+					"size": 0,
+					"start": 1
+				]
+			}]}
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}

--- a/tests/positive/storage/creation.go
+++ b/tests/positive/storage/creation.go
@@ -24,6 +24,7 @@ func init() {
 	register.Register(register.PositiveTest, WipeFilesystemWithSameType())
 	register.Register(register.PositiveTest, CreateNewPartitions())
 	register.Register(register.PositiveTest, AppendPartition())
+	register.Register(register.PositiveTest, PartitionSizeStart0())
 }
 
 func ForceNewFilesystemOfSameType() types.Test {
@@ -252,6 +253,48 @@ func AppendPartition() types.Test {
 			{
 				Label:    "additional-partition",
 				Number:   3,
+				Length:   65536,
+				TypeGUID: "F39C522B-9966-4429-A8F8-417CD5D83E5E",
+				GUID:     "3ED3993F-0016-422B-B134-09FCBA6F66EF",
+			},
+		},
+	})
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func PartitionSizeStart0() types.Test {
+	name := "Create a partition with size and start 0"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	var mntDevices []types.MntDevice
+	config := `{
+		"ignition": {
+			"version": "2.1.0"
+		},
+		"storage": {
+			"disks": [{
+				"device": "$disk1",
+				"wipeTable": false,
+				"partitions": [{
+					"label": "fills-disk",
+					"number": 1,
+					"start": 0,
+					"size": 0,
+					"typeGuid": "F39C522B-9966-4429-A8F8-417CD5D83E5E",
+					"guid": "3ED3993F-0016-422B-B134-09FCBA6F66EF"
+				}]
+			}]
+		}
+	}`
+
+	in = append(in, types.Disk{Align1M: true})
+	out = append(out, types.Disk{
+		Align1M: true,
+		Partitions: types.Partitions{
+			{
+				Label:    "fills-disk",
+				Number:   1,
 				Length:   65536,
 				TypeGUID: "F39C522B-9966-4429-A8F8-417CD5D83E5E",
 				GUID:     "3ED3993F-0016-422B-B134-09FCBA6F66EF",

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -40,8 +40,8 @@ func regexpSearch(t *testing.T, itemName, pattern string, data []byte) string {
 	return string(match[1])
 }
 
-func validatePartitions(t *testing.T, expected []*types.Partition, imageFile string) {
-	for _, e := range expected {
+func validateDisk(t *testing.T, d types.Disk, imageFile string) {
+	for _, e := range d.Partitions {
 		if e.TypeCode == "blank" || e.FilesystemType == "swap" {
 			continue
 		}
@@ -60,8 +60,8 @@ func validatePartitions(t *testing.T, expected []*types.Partition, imageFile str
 		actualSectors := regexpSearch(t, "partition size", "Partition size: (?P<sectors>\\d+) sectors", sgdiskInfo)
 		actualLabel := regexpSearch(t, "partition name", "Partition name: '(?P<name>[\\d\\w-_]+)'", sgdiskInfo)
 
-		// have to align the size to the nearest sector first
-		expectedSectors := align(e.Length, 512)
+		// have to align the size to the nearest sector alignment boundary first
+		expectedSectors := types.Align(e.Length, d.GetAlignment())
 
 		if e.TypeGUID != "" && e.TypeGUID != actualTypeGUID {
 			t.Error("TypeGUID does not match!", e.TypeGUID, actualTypeGUID)


### PR DESCRIPTION
When `sgdisk --new <num>:<start>:<end>` is handed 0 for end (as happens when size 0 is passed to Ignition) it will use the end of largest block regardless of what start is. We should specifying size 0 unless start is also 0.

Start/Size 0 use the largest block, not the first block. Update the docs to reflect that.