### PR TITLE
news: update v0.19.0 news to included missed fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,10 @@
       reported correctly
     - Add warning if a non-existent filesystem is specified when creating links
       and directories
+    - Fix udev race causing systemd units depending on the Ignition disks stage and 
+      a device unit to fail when no filesystems are created
+    - Fix udev race where symlinks are deleted before Ignition can create its own
+      copy
 
 08-Sep-2017 IGNITION v0.18.0
 


### PR DESCRIPTION
Two bug fixes were omitted from the v0.19.0 release notes by mistake. Add them to the v0.19.0 NEWS entry.