### PR TITLE
doc: Drop deprecated "create" usage

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -60,9 +60,9 @@ Environment=SYSTEMD_LOG_LEVEL=debug
 
 ## Reformat the Root Filesystem
 
-This example Ignition configuration will locate the device with the "ROOT" filesystem label (the root filesystem) and reformat it to btrfs, recreating the filesystem label. The `force` option is set to ensure that `mkfs.btrfs` ignores any existing filesystem.
-
 ### Btrfs
+
+This example Ignition configuration will locate the device with the "ROOT" filesystem label (the root filesystem) and reformat it to btrfs, recreating the filesystem label. The `wipeFilesystem` option is set to ensure that Ignition ignores any existing filesystem.
 
 ```json ignition
 {
@@ -81,6 +81,8 @@ This example Ignition configuration will locate the device with the "ROOT" files
 ```
 
 ### XFS
+
+This example Ignition configuration will locate the device with the "ROOT" filesystem label (the root filesystem) and reformat it to XFS, recreating the filesystem label. The `wipeFilesystem` option is set to ensure that Ignition ignores any existing filesystem.
 
 ```json ignition
 {

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -73,7 +73,7 @@ This example Ignition configuration will locate the device with the "ROOT" files
         "device": "/dev/disk/by-label/ROOT",
         "format": "btrfs",
         "wipeFilesystem": true,
-        "options": [ "--label=ROOT" ]
+        "label": "ROOT"
       }
     }]
   }
@@ -91,14 +91,12 @@ This example Ignition configuration will locate the device with the "ROOT" files
         "device": "/dev/disk/by-label/ROOT",
         "format": "xfs",
         "wipeFilesystem": true,
-        "options": [ "-L", "ROOT" ]
+        "label": "ROOT"
       }
     }]
   }
 }
 ```
-
-The create options are forwarded to the underlying `mkfs.$format` utility. The respective `mkfs.$format` manual pages document the available options.
 
 ## Create Files on the Root Filesystem
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -195,7 +195,7 @@ In many scenarios, it may be useful to have an external data volume. This config
       "mount": {
         "device": "/dev/md/data",
         "format": "ext4",
-        "create": { "options": [ "-L", "DATA" ] }
+        "label": "DATA"
       }
     }]
   },

--- a/doc/migrating-configs.md
+++ b/doc/migrating-configs.md
@@ -106,7 +106,7 @@ Version 2.0.0 of the configuration specification included an object named `creat
 ```json ignition
 {
   "ignition": {
-    "version": "2.1.0"
+    "version": "2.0.0"
   },
   "storage": {
     "filesystems": [
@@ -161,7 +161,7 @@ Similar to the `create` object in the `filesystems` section, version 2.0.0 of th
 ```json ignition
 {
   "ignition": {
-    "version": "2.1.0"
+    "version": "2.0.0"
   },
   "passwd": {
     "users": [
@@ -172,7 +172,7 @@ Similar to the `create` object in the `filesystems` section, version 2.0.0 of th
           "gecos": "user creation test",
           "noCreateHome": true,
           "noUserGroup": true
-        },
+        }
       }
     ]
   }


### PR DESCRIPTION
These examples would result in warnings (and an error in the last one) when they were validated.