### PR TITLE
config/types: rename PasswdUserGroups to Groups

### DIFF
--- a/config/translate.go
+++ b/config/translate.go
@@ -483,10 +483,10 @@ func TranslateFromV2_1(old v2_1.Config) types.Config {
 			UID:          old.UID,
 		}
 	}
-	translatePasswdUserGroupSlice := func(old []v2_1.PasswdUserGroup) []types.PasswdUserGroup {
-		var res []types.PasswdUserGroup
+	translatePasswdUserGroupSlice := func(old []v2_1.PasswdUserGroup) []types.Group {
+		var res []types.Group
 		for _, g := range old {
-			res = append(res, types.PasswdUserGroup(g))
+			res = append(res, types.Group(g))
 		}
 		return res
 	}

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -1745,7 +1745,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 							HomeDir:           "/home/user 2",
 							NoCreateHome:      true,
 							PrimaryGroup:      "wheel",
-							Groups:            []types.PasswdUserGroup{"wheel", "plugdev"},
+							Groups:            []types.Group{"wheel", "plugdev"},
 							NoUserGroup:       true,
 							System:            true,
 							NoLogInit:         true,

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -66,6 +66,8 @@ type Filesystem struct {
 	Path  *string `json:"path,omitempty"`
 }
 
+type Group string
+
 type Ignition struct {
 	Config   IgnitionConfig `json:"config,omitempty"`
 	Timeouts Timeouts       `json:"timeouts,omitempty"`
@@ -149,7 +151,7 @@ type PasswdGroup struct {
 type PasswdUser struct {
 	Create            *Usercreate        `json:"create,omitempty"`
 	Gecos             string             `json:"gecos,omitempty"`
-	Groups            []PasswdUserGroup  `json:"groups,omitempty"`
+	Groups            []Group            `json:"groups,omitempty"`
 	HomeDir           string             `json:"homeDir,omitempty"`
 	Name              string             `json:"name,omitempty"`
 	NoCreateHome      bool               `json:"noCreateHome,omitempty"`
@@ -162,8 +164,6 @@ type PasswdUser struct {
 	System            bool               `json:"system,omitempty"`
 	UID               *int               `json:"uid,omitempty"`
 }
-
-type PasswdUserGroup string
 
 type Raid struct {
 	Devices []Device `json:"devices,omitempty"`

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -121,10 +121,10 @@ func (u Util) EnsureUser(c types.PasswdUser) error {
 }
 
 // golang--
-func translateV2_1UsercreateGroupSliceToPasswdUserGroupSlice(groups []types.UsercreateGroup) []types.PasswdUserGroup {
-	newGroups := make([]types.PasswdUserGroup, len(groups))
+func translateV2_1UsercreateGroupSliceToPasswdUserGroupSlice(groups []types.UsercreateGroup) []types.Group {
+	newGroups := make([]types.Group, len(groups))
 	for i, g := range groups {
-		newGroups[i] = types.PasswdUserGroup(g)
+		newGroups[i] = types.Group(g)
 	}
 	return newGroups
 }
@@ -143,7 +143,7 @@ func (u Util) CheckIfUserExists(c types.PasswdUser) (bool, error) {
 }
 
 // golang--
-func translateV2_1PasswdUserGroupSliceToStringSlice(groups []types.PasswdUserGroup) []string {
+func translateV2_1PasswdUserGroupSliceToStringSlice(groups []types.Group) []string {
 	newGroups := make([]string, len(groups))
 	for i, g := range groups {
 		newGroups[i] = string(g)


### PR DESCRIPTION
schemaTyper had a bug where it would non-deterministically pick names
for types. This is fixed as of schemaTyper commit
`4ea028d9a4060b67eda07b64cf865d567b73df88`. Use the deteministic type
names.

Unfortunately the new names are not as descriptive. Keep the old
function names for the conversion functions because they are more
descriptive.