### PR TITLE
url: increase S3 and TFTP retries

### DIFF
--- a/doc/operator-notes.md
+++ b/doc/operator-notes.md
@@ -10,10 +10,11 @@ Any HTTP response code less than 500 results in the request being completed, and
 
 Ignition will initially wait 100 milliseconds between failed attempts, and the amount of time to wait doubles for each failed attempt until it reaches 5 seconds.
 
+Other providers such as S3 and TFTP already have retry logic at library level. In those cases, failed downloads will be retried up to 10 times before aborting.
+
 ## EC2 and IAM roles
 
 Ignition has support for fetching files over the S3 protocol. When Ignition is running in EC2, it supports using the IAM role given to the EC2 instance to fetch protected assets from S3. If IAM credentials are not successfully fetched, Ignition will attempt to fetch the file with no credentials.
-
 
 ## Filesystem-Reuse Semantics
 

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -171,6 +171,7 @@ func (f *Fetcher) FetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) err
 	if err != nil {
 		return err
 	}
+	c.SetRetries(10)
 	wt, err := c.Receive(u.Path, "octet")
 	if err != nil {
 		return err

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -322,8 +322,10 @@ func (f *Fetcher) FetchFromS3(u url.URL, dest *os.File, opts FetchOptions) error
 
 	if f.AWSSession == nil {
 		var err error
+		maxRetries := int(10)
 		f.AWSSession, err = session.NewSession(&aws.Config{
 			Credentials: credentials.AnonymousCredentials,
+			MaxRetries:  &maxRetries,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
This increases the number of retries performed by the TFTP and S3 clients in case of transient network errors.

Fixes OST-73