### PR TITLE
Update start/size docs, add tests

### DIFF
--- a/doc/configuration-v2_0.md
+++ b/doc/configuration-v2_0.md
@@ -22,8 +22,8 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
       * **_label_** (string): the PARTLABEL for the partition.
       * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the remainder of the disk.
-      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will be made as large as possible.
+      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the start of the largest block available.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
   * **_raid_** (list of objects): the list of RAID arrays to be configured.
     * **name** (string): the name to use for the resulting md device.

--- a/doc/configuration-v2_1.md
+++ b/doc/configuration-v2_1.md
@@ -23,8 +23,8 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
       * **_label_** (string): the PARTLABEL for the partition.
       * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the remainder of the disk.
-      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will be made as large as possible.
+      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the start of the largest block available.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
       * **_guid_** (string): the GPT unique partition GUID.
   * **_raid_** (list of objects): the list of RAID arrays to be configured.

--- a/doc/configuration-v2_2-experimental.md
+++ b/doc/configuration-v2_2-experimental.md
@@ -25,8 +25,8 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk.
       * **_label_** (string): the PARTLABEL for the partition.
       * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
-      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will fill the remainder of the disk.
-      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the earliest available part of the disk.
+      * **_size_** (integer): the size of the partition (in device logical sectors, 512 or 4096 bytes). If zero, the partition will be made as large as possible.
+      * **_start_** (integer): the start of the partition (in device logical sectors). If zero, the partition will be positioned at the start of the largest block available.
       * **_typeGuid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
       * **_guid_** (string): the GPT unique partition GUID.
   * **_raid_** (list of objects): the list of RAID arrays to be configured.

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -168,7 +168,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 
 		// There may be more partitions created by Ignition, so look at the
 		// expected output instead of the input to determine image size
-		imageSize := calculateImageSize(test.Out[i].Partitions)
+		imageSize := test.Out[i].CalculateImageSize()
 
 		// Finish data setup
 		for _, part := range disk.Partitions {
@@ -177,11 +177,12 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			}
 			updateTypeGUID(t, part)
 		}
-		setOffsets(disk.Partitions)
+
+		disk.SetOffsets()
 		for _, part := range test.Out[i].Partitions {
 			updateTypeGUID(t, part)
 		}
-		setOffsets(test.Out[i].Partitions)
+		test.Out[i].SetOffsets()
 
 		// Creation
 		createVolume(t, i, disk.ImageFile, imageSize, 20, 16, 63, disk.Partitions)
@@ -258,7 +259,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			// Validation
 			mountPartitions(t, disk.Partitions)
 			t.Log(disk.ImageFile)
-			validatePartitions(t, disk.Partitions, disk.ImageFile)
+			validateDisk(t, disk, disk.ImageFile)
 			validateFilesystems(t, disk.Partitions, disk.ImageFile)
 			validateFilesDirectoriesAndLinks(t, disk.Partitions)
 			unmountPartitions(t, disk.Partitions)

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -110,16 +110,6 @@ func pickPartition(t *testing.T, device string, partitions []*types.Partition, l
 	return ""
 }
 
-func calculateImageSize(partitions []*types.Partition) int64 {
-	// 63 is the number of sectors cgpt uses when generating a hybrid MBR
-	size := int64(63 * 512)
-	for _, p := range partitions {
-		size += int64(align(p.Length, 512) * 512)
-	}
-	size = size + int64(4096*512) // extra room to allow for alignments
-	return size
-}
-
 // createVolume will create the image file of the specified size, create a
 // partition table in it, and generate mount paths for every partition
 func createVolume(t *testing.T, index int, imageFile string, size int64, cylinders int, heads int, sectorsPerTrack int, partitions []*types.Partition) {
@@ -226,27 +216,6 @@ func formatPartition(t *testing.T, partition *types.Partition) {
 			"-m", "0", "-r", "0", "-e", "remount-ro", partition.Device,
 		}
 		_ = mustRun(t, "tune2fs", opts...)
-	}
-}
-
-func align(count int, alignment int) int {
-	offset := count % alignment
-	if offset != 0 {
-		count += alignment - offset
-	}
-	return count
-}
-
-func setOffsets(partitions []*types.Partition) {
-	// 34 is the first non-reserved GPT sector
-	offset := 34
-	for _, p := range partitions {
-		if p.Length == 0 || p.TypeCode == "blank" {
-			continue
-		}
-		offset = align(offset, 4096)
-		p.Offset = offset
-		offset += p.Length
 	}
 }
 

--- a/tests/positive/storage/creation.go
+++ b/tests/positive/storage/creation.go
@@ -24,6 +24,7 @@ func init() {
 	register.Register(register.PositiveTest, WipeFilesystemWithSameType())
 	register.Register(register.PositiveTest, CreateNewPartitions())
 	register.Register(register.PositiveTest, AppendPartition())
+	register.Register(register.PositiveTest, PartitionSizeStart0())
 }
 
 func ForceNewFilesystemOfSameType() types.Test {
@@ -284,4 +285,48 @@ func AppendPartition() types.Test {
 		Out:    out,
 		Config: config,
 	}
+}
+
+func PartitionSizeStart0() types.Test {
+	name := "Create a partition with size and start 0"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	var mntDevices []types.MntDevice
+	config := `{
+		"ignition": {
+			"version": "2.1.0"
+		},
+		"storage": {
+			"disks": [{
+				"device": "$disk1",
+				"wipeTable": false,
+				"partitions": [{
+					"label": "fills-disk",
+					"number": 1,
+					"start": 0,
+					"size": 0,
+					"typeGuid": "F39C522B-9966-4429-A8F8-417CD5D83E5E",
+					"guid": "3ED3993F-0016-422B-B134-09FCBA6F66EF"
+				}]
+			}]
+		}
+	}`
+
+	in = append(in, types.Disk{
+		Alignment: types.IgnitionAlignment,
+	})
+	out = append(out, types.Disk{
+		Alignment: types.IgnitionAlignment,
+		Partitions: types.Partitions{
+			{
+				Label:    "fills-disk",
+				Number:   1,
+				Length:   65536,
+				TypeGUID: "F39C522B-9966-4429-A8F8-417CD5D83E5E",
+				GUID:     "3ED3993F-0016-422B-B134-09FCBA6F66EF",
+			},
+		},
+	})
+
+	return types.Test{name, in, out, mntDevices, config}
 }

--- a/tests/positive/storage/creation.go
+++ b/tests/positive/storage/creation.go
@@ -163,6 +163,7 @@ func CreateNewPartitions() types.Test {
 	// are intentionally different so if Ignition doesn't do the right thing the
 	// validation will fail.
 	in = append(in, types.Disk{
+		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",
@@ -181,6 +182,7 @@ func CreateNewPartitions() types.Test {
 		},
 	})
 	out = append(out, types.Disk{
+		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",
@@ -231,6 +233,7 @@ func AppendPartition() types.Test {
 	}`
 
 	in = append(in, types.Disk{
+		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",
@@ -249,6 +252,7 @@ func AppendPartition() types.Test {
 		},
 	})
 	out = append(out, types.Disk{
+		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
 			{
 				Label:    "important-data",

--- a/tests/positive/storage/reuse_filesystem.go
+++ b/tests/positive/storage/reuse_filesystem.go
@@ -50,6 +50,7 @@ func ReuseExistingFilesystem() types.Test {
 		}
 	}`
 	in = append(in, types.Disk{
+		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
 			{
 				Label:           "important-data",
@@ -71,6 +72,7 @@ func ReuseExistingFilesystem() types.Test {
 		},
 	})
 	out = append(out, types.Disk{
+		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
 			{
 				Label:           "important-data",

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -40,8 +40,8 @@ func regexpSearch(t *testing.T, itemName, pattern string, data []byte) string {
 	return string(match[1])
 }
 
-func validatePartitions(t *testing.T, expected []*types.Partition, imageFile string) {
-	for _, e := range expected {
+func validateDisk(t *testing.T, d types.Disk, imageFile string) {
+	for _, e := range d.Partitions {
 		if e.TypeCode == "blank" || e.FilesystemType == "swap" {
 			continue
 		}
@@ -60,8 +60,8 @@ func validatePartitions(t *testing.T, expected []*types.Partition, imageFile str
 		actualSectors := regexpSearch(t, "partition size", "Partition size: (?P<sectors>\\d+) sectors", sgdiskInfo)
 		actualLabel := regexpSearch(t, "partition name", "Partition name: '(?P<name>[\\d\\w-_]+)'", sgdiskInfo)
 
-		// have to align the size to the nearest sector first
-		expectedSectors := align(e.Length, 512)
+		// have to align the size to the nearest sector alignment boundary first
+		expectedSectors := types.Align(e.Length, d.Alignment)
 
 		if e.TypeGUID != "" && e.TypeGUID != actualTypeGUID {
 			t.Error("TypeGUID does not match!", e.TypeGUID, actualTypeGUID)


### PR DESCRIPTION
Update the docs on `storage.disks.partitions.size` and `storage.disks.partitions.start` to be accurate.
Add blackbox test for specifying start and size 0.
Update blackbox test logic to handle exact disk/partition sizes.