### PR TITLE
doc/development: update dependencies

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -62,6 +62,7 @@ The following packages are required by the Blackbox Test:
 * `uuid-runtime`
 * `gdisk`
 * `coreutils`
+* `shadow-utils`
 
 ## Writing Blackbox Tests
 


### PR DESCRIPTION
This was missed initially. shadow-utils is needed for commands like useradd.