### PR TITLE
Revert "doc/development: update dependencies"

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -62,7 +62,6 @@ The following packages are required by the Blackbox Test:
 * `uuid-runtime`
 * `gdisk`
 * `coreutils`
-* `shadow-utils`
 
 ## Writing Blackbox Tests
 


### PR DESCRIPTION
This reverts commit 6b3ba69e66ada8d2c504545287bad89bfa2a2c6c.
tests/stubs/ has stubbed out commands supplied by shadow-utils, it is
not in fact a requirement for testing.