### PR TITLE
Allow overriding distro-specific constants at link time; test oem:// resource URLs

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -17,6 +17,17 @@ package distro
 // Distro-specific settings that can be overridden at link time with e.g.
 // -X github.com/coreos/ignition/internal/distro.mdadmCmd=/opt/bin/mdadm
 var (
+	// Device node directories and paths
+	diskByIDDir       = "/dev/disk/by-id"
+	diskByLabelDir    = "/dev/disk/by-label"
+	diskByPartUUIDDir = "/dev/disk/by-partuuid"
+	oemDevicePath     = "/dev/disk/by-label/OEM"
+
+	// File paths
+	kernelCmdlinePath = "/proc/cmdline"
+	// initramfs directory to check before retrieving file from OEM partition
+	oemLookasideDir = "/usr/share/oem"
+
 	// Helper programs
 	mdadmCmd   = "/usr/sbin/mdadm"
 	mountCmd   = "/usr/bin/mount"
@@ -30,6 +41,14 @@ var (
 	vfatMkfsCmd  = "/usr/sbin/mkfs.vfat"
 	xfsMkfsCmd   = "/usr/sbin/mkfs.xfs"
 )
+
+func DiskByIDDir() string       { return diskByIDDir }
+func DiskByLabelDir() string    { return diskByLabelDir }
+func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
+func OEMDevicePath() string     { return oemDevicePath }
+
+func KernelCmdlinePath() string { return kernelCmdlinePath }
+func OEMLookasideDir() string   { return oemLookasideDir }
 
 func MdadmCmd() string   { return mdadmCmd }
 func MountCmd() string   { return mountCmd }

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -1,0 +1,43 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distro
+
+// Distro-specific settings that can be overridden at link time with e.g.
+// -X github.com/coreos/ignition/internal/distro.mdadmCmd=/opt/bin/mdadm
+var (
+	// Helper programs
+	mdadmCmd   = "/usr/sbin/mdadm"
+	mountCmd   = "/usr/bin/mount"
+	sgdiskCmd  = "/usr/sbin/sgdisk"
+	udevadmCmd = "/usr/bin/udevadm"
+
+	// Filesystem tools
+	btrfsMkfsCmd = "/usr/sbin/mkfs.btrfs"
+	ext4MkfsCmd  = "/usr/sbin/mkfs.ext4"
+	swapMkfsCmd  = "/usr/sbin/mkswap"
+	vfatMkfsCmd  = "/usr/sbin/mkfs.vfat"
+	xfsMkfsCmd   = "/usr/sbin/mkfs.xfs"
+)
+
+func MdadmCmd() string   { return mdadmCmd }
+func MountCmd() string   { return mountCmd }
+func SgdiskCmd() string  { return sgdiskCmd }
+func UdevadmCmd() string { return udevadmCmd }
+
+func BtrfsMkfsCmd() string { return btrfsMkfsCmd }
+func Ext4MkfsCmd() string  { return ext4MkfsCmd }
+func SwapMkfsCmd() string  { return swapMkfsCmd }
+func VfatMkfsCmd() string  { return vfatMkfsCmd }
+func XfsMkfsCmd() string   { return xfsMkfsCmd }

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -14,6 +14,10 @@
 
 package distro
 
+import (
+	"os"
+)
+
 // Distro-specific settings that can be overridden at link time with e.g.
 // -X github.com/coreos/ignition/internal/distro.mdadmCmd=/opt/bin/mdadm
 var (
@@ -45,10 +49,10 @@ var (
 func DiskByIDDir() string       { return diskByIDDir }
 func DiskByLabelDir() string    { return diskByLabelDir }
 func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
-func OEMDevicePath() string     { return oemDevicePath }
+func OEMDevicePath() string     { return fromEnv("OEM_DEVICE", oemDevicePath) }
 
 func KernelCmdlinePath() string { return kernelCmdlinePath }
-func OEMLookasideDir() string   { return oemLookasideDir }
+func OEMLookasideDir() string   { return fromEnv("OEM_LOOKASIDE_DIR", oemLookasideDir) }
 
 func MdadmCmd() string   { return mdadmCmd }
 func MountCmd() string   { return mountCmd }
@@ -60,3 +64,11 @@ func Ext4MkfsCmd() string  { return ext4MkfsCmd }
 func SwapMkfsCmd() string  { return swapMkfsCmd }
 func VfatMkfsCmd() string  { return vfatMkfsCmd }
 func XfsMkfsCmd() string   { return xfsMkfsCmd }
+
+func fromEnv(nameSuffix, defaultValue string) string {
+	value := os.Getenv("IGNITION_" + nameSuffix)
+	if value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -26,14 +26,15 @@ import (
 
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 )
 
 const (
-	configDevice = "/dev/disk/by-id/ata-Virtual_CD"
-	configPath   = "/CustomData.bin"
+	configDeviceID = "ata-Virtual_CD"
+	configPath     = "/CustomData.bin"
 )
 
 // These constants come from <cdrom.h>.
@@ -51,9 +52,11 @@ const (
 )
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+	devicePath := filepath.Join(distro.DiskByIDDir(), configDeviceID)
+
 	logger := f.Logger
 	logger.Debug("waiting for config DVD...")
-	waitForCdrom(logger)
+	waitForCdrom(logger, devicePath)
 
 	mnt, err := ioutil.TempDir("", "ignition-azure")
 	if err != nil {
@@ -63,14 +66,14 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 
 	logger.Debug("mounting config device")
 	if err := logger.LogOp(
-		func() error { return syscall.Mount(configDevice, mnt, "udf", syscall.MS_RDONLY, "") },
-		"mounting %q at %q", configDevice, mnt,
+		func() error { return syscall.Mount(devicePath, mnt, "udf", syscall.MS_RDONLY, "") },
+		"mounting %q at %q", devicePath, mnt,
 	); err != nil {
-		return types.Config{}, report.Report{}, fmt.Errorf("failed to mount device %q at %q: %v", configDevice, mnt, err)
+		return types.Config{}, report.Report{}, fmt.Errorf("failed to mount device %q at %q: %v", devicePath, mnt, err)
 	}
 	defer logger.LogOp(
 		func() error { return syscall.Unmount(mnt, 0) },
-		"unmounting %q at %q", configDevice, mnt,
+		"unmounting %q at %q", devicePath, mnt,
 	)
 
 	logger.Debug("reading config")
@@ -82,15 +85,15 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	return util.ParseConfig(logger, rawConfig)
 }
 
-func waitForCdrom(logger *log.Logger) {
-	for !isCdromPresent(logger) {
+func waitForCdrom(logger *log.Logger, devicePath string) {
+	for !isCdromPresent(logger, devicePath) {
 		time.Sleep(time.Second)
 	}
 }
 
-func isCdromPresent(logger *log.Logger) bool {
+func isCdromPresent(logger *log.Logger, devicePath string) bool {
 	logger.Debug("opening config device")
-	device, err := os.Open(configDevice)
+	device, err := os.Open(devicePath)
 	if err != nil {
 		logger.Info("failed to open config device: %v", err)
 		return false

--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -42,7 +42,6 @@ import (
 )
 
 const (
-	diskByLabelPath         = "/dev/disk/by-label/"
 	configDriveUserdataPath = "/cloudstack/userdata/user_data.txt"
 	LeaseRetryInterval      = 500 * time.Millisecond
 )
@@ -99,7 +98,7 @@ func labelExists(label string) bool {
 }
 
 func getPath(label string) (string, error) {
-	path := diskByLabelPath + label
+	path := filepath.Join(distro.DiskByLabelDir(), label)
 
 	if fileExists(path) {
 		return path, nil

--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coreos/ignition/config"
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -176,7 +177,7 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, label string
 	}
 	defer os.Remove(mnt)
 
-	cmd := exec.Command("/bin/mount", "-o", "ro", "-t", "auto", path, mnt)
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", "auto", path, mnt)
 	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
 		return nil, err
 	}

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
@@ -31,7 +32,6 @@ import (
 )
 
 const (
-	cmdlinePath    = "/proc/cmdline"
 	cmdlineUrlFlag = "coreos.config.url"
 )
 
@@ -56,7 +56,7 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 }
 
 func readCmdline(logger *log.Logger) (*url.URL, error) {
-	args, err := ioutil.ReadFile(cmdlinePath)
+	args, err := ioutil.ReadFile(distro.KernelCmdlinePath())
 	if err != nil {
 		logger.Err("couldn't read cmdline: %v", err)
 		return nil, err

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -40,7 +40,6 @@ import (
 )
 
 const (
-	diskByLabelPath         = "/dev/disk/by-label/"
 	configDriveUserdataPath = "/openstack/latest/user_data"
 )
 
@@ -74,11 +73,11 @@ func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	}
 
 	go dispatch("config drive (config-2)", func() ([]byte, error) {
-		return fetchConfigFromDevice(f.Logger, ctx, diskByLabelPath+"config-2")
+		return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), "config-2"))
 	})
 
 	go dispatch("config drive (CONFIG-2)", func() ([]byte, error) {
-		return fetchConfigFromDevice(f.Logger, ctx, diskByLabelPath+"CONFIG-2")
+		return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), "CONFIG-2"))
 	})
 
 	go dispatch("metadata service", func() ([]byte, error) {

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coreos/ignition/config"
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/resource"
 
@@ -114,7 +115,7 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	}
 	defer os.Remove(mnt)
 
-	cmd := exec.Command("/usr/bin/mount", "-o", "ro", "-t", "auto", path, mnt)
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", "auto", path, mnt)
 	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
 		return nil, err
 	}

--- a/internal/providers/virtualbox/virtualbox.go
+++ b/internal/providers/virtualbox/virtualbox.go
@@ -21,21 +21,23 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/coreos/ignition/config"
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/providers/util"
 	"github.com/coreos/ignition/internal/resource"
 )
 
 const (
-	configPath = "/dev/disk/by-partuuid/99570a8a-f826-4eb0-ba4e-9dd72d55ea13"
+	partUUID = "99570a8a-f826-4eb0-ba4e-9dd72d55ea13"
 )
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
 	f.Logger.Debug("Attempting to read config drive")
-	rawConfig, err := ioutil.ReadFile(configPath)
+	rawConfig, err := ioutil.ReadFile(filepath.Join(distro.DiskByPartUUIDDir(), partUUID))
 	if os.IsNotExist(err) {
 		f.Logger.Info("Path to ignition config does not exist, assuming no config")
 		return types.Config{}, report.Report{}, config.ErrEmpty

--- a/internal/sgdisk/sgdisk.go
+++ b/internal/sgdisk/sgdisk.go
@@ -18,10 +18,9 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/log"
 )
-
-const sgdiskPath = "/sbin/sgdisk"
 
 type Operation struct {
 	logger *log.Logger
@@ -58,10 +57,10 @@ func (op *Operation) WipeTable(wipe bool) {
 // Commit commits an partitioning operation.
 func (op *Operation) Commit() error {
 	if op.wipe {
-		cmd := exec.Command(sgdiskPath, "--zap-all", op.dev)
+		cmd := exec.Command(distro.SgdiskCmd(), "--zap-all", op.dev)
 		if _, err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
 			op.logger.Info("potential error encountered while wiping table... retrying")
-			cmd = exec.Command(sgdiskPath, "--zap-all", op.dev)
+			cmd = exec.Command(distro.SgdiskCmd(), "--zap-all", op.dev)
 			if _, err := op.logger.LogCmd(cmd, "wiping table on %q", op.dev); err != nil {
 				return fmt.Errorf("wipe failed: %v", err)
 			}
@@ -81,7 +80,7 @@ func (op *Operation) Commit() error {
 			}
 		}
 		opts = append(opts, op.dev)
-		cmd := exec.Command(sgdiskPath, opts...)
+		cmd := exec.Command(distro.SgdiskCmd(), opts...)
 		if _, err := op.logger.LogCmd(cmd, "creating %d partitions on %q", len(op.parts), op.dev); err != nil {
 			return fmt.Errorf("create partitions failed: %v", err)
 		}

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -158,6 +158,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	var rootLocation string
 
 	// Setup
+	createFilesFromSlice(t, oemLookasideDir, test.OEMLookasideFiles)
 	for i, disk := range test.In {
 		// Set image file path
 		disk.ImageFile = filepath.Join(os.TempDir(), fmt.Sprintf("hd%d", i))
@@ -189,7 +190,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 			prepareRootPartitionForPasswd(t, disk.Partitions)
 		}
 		mountPartitions(t, disk.Partitions)
-		createFiles(t, disk.Partitions)
+		createFilesForPartitions(t, disk.Partitions)
 		unmountPartitions(t, disk.Partitions)
 
 		// Mount device name substitution

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -152,6 +152,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	defer os.Setenv("TMPDIR", originalTmpDir)
 	defer os.RemoveAll(tmpDirectory)
 
+	oemLookasideDir := filepath.Join(os.TempDir(), "oem-lookaside")
 	var rootLocation string
 
 	// Setup
@@ -236,8 +237,12 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	}
 
 	// Ignition
-	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, negativeTests)
-	files := runIgnition(t, "files", rootLocation, tmpDirectory, negativeTests)
+	appendEnv := []string{
+		"IGNITION_OEM_DEVICE=" + test.In[0].Partitions.GetPartition("OEM").Device,
+		"IGNITION_OEM_LOOKASIDE_DIR=" + oemLookasideDir,
+	}
+	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, appendEnv, negativeTests)
+	files := runIgnition(t, "files", rootLocation, tmpDirectory, appendEnv, negativeTests)
 	if negativeTests && disks && files {
 		t.Fatal("Expected failure and ignition succeeded")
 	}

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -81,6 +81,8 @@ fdsa`))
                 }]
         }
 }`))
+	} else {
+		return fmt.Errorf("no such file %q", filename)
 	}
 
 	_, err := rf.ReadFrom(buf)

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -86,11 +86,12 @@ func getRootLocation(partitions []*types.Partition) string {
 }
 
 // returns true if no error, false if error
-func runIgnition(t *testing.T, stage, root, cwd string, expectFail bool) bool {
+func runIgnition(t *testing.T, stage, root, cwd string, appendEnv []string, expectFail bool) bool {
 	args := []string{"-clear-cache", "-oem", "file", "-stage", stage, "-root", root}
 	cmd := exec.Command("ignition", args...)
 	t.Log("ignition", args)
 	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), appendEnv...)
 	out, err := cmd.CombinedOutput()
 	if err != nil && !expectFail {
 		t.Fatal(args, err, string(out))

--- a/tests/negative/files/invalid_hash.go
+++ b/tests/negative/files/invalid_hash.go
@@ -54,14 +54,19 @@ func InvalidHash() types.Test {
 			}]}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func InvalidHashFromHTTPURL() types.Test {
 	name := "Invalid File Hash from HTTP URL"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -85,5 +90,10 @@ func InvalidHashFromHTTPURL() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -29,7 +29,6 @@ func MissingRemoteContentsHTTP() types.Test {
 	name := "Missing File from Remote Contents - HTTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -42,14 +41,18 @@ func MissingRemoteContentsHTTP() types.Test {
 	    }]
 	  }
 	}`
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func MissingRemoteContentsTFTP() types.Test {
 	name := "Missing File from Remote Contents - TFTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": { "version": "2.1.0" },
           "storage": {
@@ -62,14 +65,18 @@ func MissingRemoteContentsTFTP() types.Test {
             }]
           }
         }`
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func MissingRemoteContentsOEM() types.Test {
 	name := "Create Files from Remote Contents - OEM"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -82,5 +89,10 @@ func MissingRemoteContentsOEM() types.Test {
 	    }]
 	  }
 	}`
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -1,0 +1,86 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, MissingRemoteContentsHTTP())
+	register.Register(register.NegativeTest, MissingRemoteContentsTFTP())
+	register.Register(register.NegativeTest, MissingRemoteContentsOEM())
+}
+
+func MissingRemoteContentsHTTP() types.Test {
+	name := "Missing File from Remote Contents - HTTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": { "version": "2.1.0" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "http://127.0.0.1:8080/asdf"
+	      }
+	    }]
+	  }
+	}`
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func MissingRemoteContentsTFTP() types.Test {
+	name := "Missing File from Remote Contents - TFTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+          "ignition": { "version": "2.1.0" },
+          "storage": {
+            "files": [{
+              "filesystem": "root",
+              "path": "/foo/bar",
+              "contents": {
+                "source": "tftp://127.0.0.1:69/asdf"
+              }
+            }]
+          }
+        }`
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func MissingRemoteContentsOEM() types.Test {
+	name := "Create Files from Remote Contents - OEM"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": { "version": "2.1.0" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "oem:///source"
+	      }
+	    }]
+	  }
+	}`
+	return types.Test{name, in, out, mntDevices, config}
+}

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -52,7 +52,13 @@ func ReplaceConfigWithInvalidHash() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func AppendConfigWithInvalidHash() types.Test {
@@ -84,14 +90,19 @@ func AppendConfigWithInvalidHash() types.Test {
       }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReplaceConfigWithMissingFileHTTP() types.Test {
 	name := "Replace Config with Missing File - HTTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.1.0",
@@ -103,14 +114,18 @@ func ReplaceConfigWithMissingFileHTTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithMissingFileTFTP() types.Test {
 	name := "Replace Config with Missing File - TFTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.1.0",
@@ -122,14 +137,18 @@ func ReplaceConfigWithMissingFileTFTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithMissingFileOEM() types.Test {
 	name := "Replace Config with Missing File - OEM"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.1.0",
@@ -141,14 +160,18 @@ func ReplaceConfigWithMissingFileOEM() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithMissingFileHTTP() types.Test {
 	name := "Append Config with Missing File - HTTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.1.0",
@@ -160,14 +183,18 @@ func AppendConfigWithMissingFileHTTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithMissingFileTFTP() types.Test {
 	name := "Append Config with Missing File - TFTP"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.1.0",
@@ -179,14 +206,18 @@ func AppendConfigWithMissingFileTFTP() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithMissingFileOEM() types.Test {
 	name := "Append Config with Missing File - OEM"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.1.0",
@@ -198,5 +229,10 @@ func AppendConfigWithMissingFileOEM() types.Test {
 	  }
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -22,6 +22,12 @@ import (
 func init() {
 	register.Register(register.NegativeTest, ReplaceConfigWithInvalidHash())
 	register.Register(register.NegativeTest, AppendConfigWithInvalidHash())
+	register.Register(register.NegativeTest, ReplaceConfigWithMissingFileHTTP())
+	register.Register(register.NegativeTest, ReplaceConfigWithMissingFileTFTP())
+	register.Register(register.NegativeTest, ReplaceConfigWithMissingFileOEM())
+	register.Register(register.NegativeTest, AppendConfigWithMissingFileHTTP())
+	register.Register(register.NegativeTest, AppendConfigWithMissingFileTFTP())
+	register.Register(register.NegativeTest, AppendConfigWithMissingFileOEM())
 }
 
 func ReplaceConfigWithInvalidHash() types.Test {
@@ -76,6 +82,120 @@ func AppendConfigWithInvalidHash() types.Test {
           "contents": { "source": "data:,another%20example%20file%0A" }
         }]
       }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func ReplaceConfigWithMissingFileHTTP() types.Test {
+	name := "Replace Config with Missing File - HTTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.1.0",
+	    "config": {
+	      "replace": {
+	        "source": "http://127.0.0.1:8080/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func ReplaceConfigWithMissingFileTFTP() types.Test {
+	name := "Replace Config with Missing File - TFTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.1.0",
+	    "config": {
+	      "replace": {
+	        "source": "tftp://127.0.0.1:69/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func ReplaceConfigWithMissingFileOEM() types.Test {
+	name := "Replace Config with Missing File - OEM"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.1.0",
+	    "config": {
+	      "replace": {
+	        "source": "oem:///asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithMissingFileHTTP() types.Test {
+	name := "Append Config with Missing File - HTTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.1.0",
+	    "config": {
+	      "append": {
+	        "source": "http://127.0.0.1:8080/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithMissingFileTFTP() types.Test {
+	name := "Append Config with Missing File - TFTP"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.1.0",
+	    "config": {
+	      "append": {
+	        "source": "tftp://127.0.0.1:69/asdf"
+	      }
+	    }
+	  }
+	}`
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func AppendConfigWithMissingFileOEM() types.Test {
+	name := "Append Config with Missing File - OEM"
+	in := types.GetBaseDisk()
+	out := in
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": {
+	    "version": "2.1.0",
+	    "config": {
+	      "append": {
+	        "source": "oem:///asdf"
+	      }
+	    }
+	  }
 	}`
 
 	return types.Test{name, in, out, mntDevices, config}

--- a/tests/negative/general/invalid_version.go
+++ b/tests/negative/general/invalid_version.go
@@ -27,7 +27,6 @@ func InvalidVersion() types.Test {
 	name := "Invalid Version"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "4.0.0"},
 		"storage": {
@@ -38,5 +37,10 @@ func InvalidVersion() types.Test {
 			}]}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/regression/filesystem.go
+++ b/tests/negative/regression/filesystem.go
@@ -47,5 +47,11 @@ func VFATIgnoresWipeFilesystem() types.Test {
                         }
         }`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/negative/storage/invalid_filesystem.go
+++ b/tests/negative/storage/invalid_filesystem.go
@@ -27,7 +27,6 @@ func InvalidFilesystem() types.Test {
 	name := "Invalid Filesystem"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.0.0"},
 		"storage": {
@@ -38,5 +37,10 @@ func InvalidFilesystem() types.Test {
 			}]}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/storage/no_device.go
+++ b/tests/negative/storage/no_device.go
@@ -30,7 +30,6 @@ func NoDevice() types.Test {
 	name := "No Device"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -43,14 +42,18 @@ func NoDevice() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func NoDeviceWithForce() types.Test {
 	name := "No Device w/ Force"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.0.0"},
 		"storage": {
@@ -66,14 +69,18 @@ func NoDeviceWithForce() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func NoDeviceWithWipeFilesystemTrue() types.Test {
 	name := "No Device w/ wipeFilesystem true"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -87,14 +94,18 @@ func NoDeviceWithWipeFilesystemTrue() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func NoDeviceWithWipeFilesystemFalse() types.Test {
 	name := "No Device w/ wipeFilesystem false"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -108,5 +119,10 @@ func NoDeviceWithWipeFilesystemFalse() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/negative/storage/no_filesystem_type.go
+++ b/tests/negative/storage/no_filesystem_type.go
@@ -47,7 +47,13 @@ func NoFilesystemType() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func NoFilesystemTypeWithForce() types.Test {
@@ -75,7 +81,13 @@ func NoFilesystemTypeWithForce() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func NoFilesystemTypeWithWipeFilesystem() types.Test {
@@ -101,5 +113,11 @@ func NoFilesystemTypeWithWipeFilesystem() types.Test {
 		}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/negative/timeouts/timeouts.go
+++ b/tests/negative/timeouts/timeouts.go
@@ -40,7 +40,6 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 	name := "Decrease HTTP Response Headers Timeout"
 	in := types.GetBaseDisk()
 	out := in
-	var mntDevices []types.MntDevice
 	config := fmt.Sprintf(`{
 		"ignition": {
 			"version": "2.1.0",
@@ -62,5 +61,10 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 		}
 	}`, respondDelayServer.URL)
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/directory.go
+++ b/tests/positive/files/directory.go
@@ -27,7 +27,6 @@ func CreateDirectoryOnRoot() types.Test {
 	name := "Create a Directory on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -46,5 +45,10 @@ func CreateDirectoryOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -31,7 +31,6 @@ func CreateFileOnRoot() types.Test {
 	name := "Create Files on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -52,14 +51,18 @@ func CreateFileOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func UserGroupByID_2_0_0() types.Test {
 	name := "2.0.0 User/Group by id"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -84,14 +87,18 @@ func UserGroupByID_2_0_0() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func UserGroupByID_2_1_0() types.Test {
 	name := "2.1.0 User/Group by id"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -116,14 +123,18 @@ func UserGroupByID_2_1_0() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func UserGroupByName_2_1_0() types.Test {
 	name := "2.1.0 User/Group by name"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -148,5 +159,10 @@ func UserGroupByName_2_1_0() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/hash.go
+++ b/tests/positive/files/hash.go
@@ -28,7 +28,6 @@ func ValidateFileHashFromDataURL() types.Test {
 	name := "Validate File Hash from Data URL"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -52,14 +51,18 @@ func ValidateFileHashFromDataURL() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ValidateFileHashFromHTTPURL() types.Test {
 	name := "Validate File Hash from HTTP URL"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -83,5 +86,10 @@ func ValidateFileHashFromHTTPURL() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/link.go
+++ b/tests/positive/files/link.go
@@ -28,7 +28,6 @@ func CreateHardLinkOnRoot() types.Test {
 	name := "Create a Hard Link on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -67,14 +66,18 @@ func CreateHardLinkOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func CreateSymlinkOnRoot() types.Test {
 	name := "Create a Symlink on the Root Filesystem"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -105,5 +108,10 @@ func CreateSymlinkOnRoot() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -29,7 +29,6 @@ func CreateFileFromRemoteContentsHTTP() types.Test {
 	name := "Create Files from Remote Contents - HTTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "storage": {
@@ -52,14 +51,18 @@ func CreateFileFromRemoteContentsHTTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func CreateFileFromRemoteContentsTFTP() types.Test {
 	name := "Create Files from Remote Contents - TFTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": { "version": "2.1.0" },
           "storage": {
@@ -82,14 +85,18 @@ func CreateFileFromRemoteContentsTFTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func CreateFileFromRemoteContentsOEM() types.Test {
 	name := "Create Files from Remote Contents - OEM"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.1.0" },
 	  "storage": {
@@ -120,5 +127,10 @@ func CreateFileFromRemoteContentsOEM() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -22,6 +22,7 @@ import (
 func init() {
 	register.Register(register.PositiveTest, CreateFileFromRemoteContentsHTTP())
 	register.Register(register.PositiveTest, CreateFileFromRemoteContentsTFTP())
+	register.Register(register.PositiveTest, CreateFileFromRemoteContentsOEM())
 }
 
 func CreateFileFromRemoteContentsHTTP() types.Test {
@@ -71,6 +72,44 @@ func CreateFileFromRemoteContentsTFTP() types.Test {
             }]
           }
         }`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+			},
+			Contents: "asdf\nfdsa",
+		},
+	})
+
+	return types.Test{name, in, out, mntDevices, config}
+}
+
+func CreateFileFromRemoteContentsOEM() types.Test {
+	name := "Create Files from Remote Contents - OEM"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	var mntDevices []types.MntDevice
+	config := `{
+	  "ignition": { "version": "2.1.0" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "oem:///source"
+	      }
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddFiles("OEM", []types.File{
+		{
+			Node: types.Node{
+				Name: "source",
+			},
+			Contents: "asdf\nfdsa",
+		},
+	})
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -70,14 +70,19 @@ func ReformatFilesystemAndWriteFile() types.Test {
 		},
 	}
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 	name := "Replacing the Config with a Remote Config from HTTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -99,14 +104,18 @@ func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 	name := "Replacing the Config with a Remote Config from TFTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.1.0",
@@ -128,14 +137,18 @@ func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ReplaceConfigWithRemoteConfigOEM() types.Test {
 	name := "Replacing the Config with a Remote Config from OEM"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.1.0",
@@ -174,14 +187,18 @@ func ReplaceConfigWithRemoteConfigOEM() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithRemoteConfigHTTP() types.Test {
 	name := "Appending to the Config with a Remote Config from HTTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": {
 	    "version": "2.0.0",
@@ -217,14 +234,18 @@ func AppendConfigWithRemoteConfigHTTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithRemoteConfigTFTP() types.Test {
 	name := "Appending to the Config with a Remote Config from TFTP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.1.0",
@@ -260,14 +281,18 @@ func AppendConfigWithRemoteConfigTFTP() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendConfigWithRemoteConfigOEM() types.Test {
 	name := "Appending to the Config with a Remote Config from OEM"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
           "ignition": {
             "version": "2.1.0",
@@ -320,27 +345,40 @@ func AppendConfigWithRemoteConfigOEM() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func VersionOnlyConfig() types.Test {
 	name := "Version Only Config"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"}
 	}`
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func EmptyUserdata() types.Test {
 	name := "Empty Userdata"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := ``
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/networkd/create_unit.go
+++ b/tests/positive/networkd/create_unit.go
@@ -27,7 +27,6 @@ func CreateNetworkdUnit() types.Test {
 	name := "Create a networkd unit"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": { "version": "2.1.0" },
 		"networkd": {
@@ -47,5 +46,10 @@ func CreateNetworkdUnit() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/oem/oem.go
+++ b/tests/positive/oem/oem.go
@@ -1,0 +1,86 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oem
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.PositiveTest, OEMSearchPath())
+}
+
+func OEMSearchPath() types.Test {
+	name := "Read files from multiple locations in OEM search path"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+		"ignition": {"version": "2.1.0"},
+		"storage": {
+			"files": [
+				{
+					"filesystem": "root",
+					"path": "/ignition/out-1",
+					"contents": {"source": "oem:///source-1"}
+				},
+				{
+					"filesystem": "root",
+					"path": "/ignition/out-2",
+					"contents": {"source": "oem:///source-2"}
+				}
+			]}
+	}`
+	lookasideFiles := []types.File{
+		{
+			Node: types.Node{
+				Name: "source-1",
+			},
+			Contents: "source-a",
+		},
+	}
+	in[0].Partitions.AddFiles("OEM", []types.File{
+		{
+			Node: types.Node{
+				Name: "source-2",
+			},
+			Contents: "source-b",
+		},
+	})
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "out-1",
+				Directory: "ignition",
+			},
+			Contents: "source-a",
+		},
+		{
+			Node: types.Node{
+				Name:      "out-2",
+				Directory: "ignition",
+			},
+			Contents: "source-b",
+		},
+	})
+
+	return types.Test{
+		Name:              name,
+		In:                in,
+		Out:               out,
+		OEMLookasideFiles: lookasideFiles,
+		Config:            config,
+	}
+}

--- a/tests/positive/passwd/users.go
+++ b/tests/positive/passwd/users.go
@@ -27,7 +27,6 @@ func AddPasswdUsers() types.Test {
 	name := "Adding users"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {
 			"version": "2.0.0"
@@ -151,5 +150,10 @@ ENCRYPT_METHOD SHA512
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/regression/filesystem.go
+++ b/tests/positive/regression/filesystem.go
@@ -54,7 +54,13 @@ func EquivalentFilesystemUUIDsTreatedDistinctEXT4() types.Test {
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "6ABE925E-6DAF-4FAD-BC09-8D56BE8822DE"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "6ABE925E-6DAF-4FAD-BC09-8D56BE8822DE"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func EquivalentFilesystemUUIDsTreatedDistinctVFAT() types.Test {
@@ -86,5 +92,11 @@ func EquivalentFilesystemUUIDsTreatedDistinctVFAT() types.Test {
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "2e24ec82"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "vfat"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/positive/storage/creation.go
+++ b/tests/positive/storage/creation.go
@@ -69,7 +69,13 @@ func ForceNewFilesystemOfSameType() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func WipeFilesystemWithSameType() types.Test {
@@ -113,14 +119,19 @@ func WipeFilesystemWithSameType() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func CreateNewPartitions() types.Test {
 	name := "Create new partitions"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {"version": "2.1.0"},
 		"storage": {
@@ -188,14 +199,18 @@ func CreateNewPartitions() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func AppendPartition() types.Test {
 	name := "Append partition to an existing partition table"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": {
 			"version": "2.1.0"
@@ -259,5 +274,10 @@ func AppendPartition() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/storage/reformat_filesystem.go
+++ b/tests/positive/storage/reformat_filesystem.go
@@ -57,7 +57,13 @@ func ReformatToBTRFS_2_0_0() types.Test {
 	}`
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToXFS_2_0_0() types.Test {
@@ -87,7 +93,13 @@ func ReformatToXFS_2_0_0() types.Test {
 	}`
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "xfs"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToVFAT_2_0_0() types.Test {
@@ -118,7 +130,13 @@ func ReformatToVFAT_2_0_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "vfat"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToEXT4_2_0_0() types.Test {
@@ -150,7 +168,13 @@ func ReformatToEXT4_2_0_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToBTRFS_2_1_0() types.Test {
@@ -180,7 +204,13 @@ func ReformatToBTRFS_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToXFS_2_1_0() types.Test {
@@ -210,7 +240,13 @@ func ReformatToXFS_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "xfs"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToVFAT_2_1_0() types.Test {
@@ -240,7 +276,13 @@ func ReformatToVFAT_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "vfat"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "2e24ec82"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToEXT4_2_1_0() types.Test {
@@ -271,7 +313,13 @@ func ReformatToEXT4_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }
 
 func ReformatToSWAP_2_1_0() types.Test {
@@ -302,5 +350,11 @@ func ReformatToSWAP_2_1_0() types.Test {
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "swap"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "CA7D7CCB-63ED-4C53-861C-1742536059CC"
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/positive/storage/reuse_filesystem.go
+++ b/tests/positive/storage/reuse_filesystem.go
@@ -92,5 +92,11 @@ func ReuseExistingFilesystem() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
 }

--- a/tests/positive/systemd/create_unit.go
+++ b/tests/positive/systemd/create_unit.go
@@ -27,7 +27,6 @@ func CreateSystemdService() types.Test {
 	name := "Create a systemd service"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 		"ignition": { "version": "2.0.0" },
 		"systemd": {
@@ -55,5 +54,10 @@ func CreateSystemdService() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/systemd/modify_service.go
+++ b/tests/positive/systemd/modify_service.go
@@ -28,7 +28,6 @@ func ModifySystemdService() types.Test {
 	name := "Modify Services"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "systemd": {
@@ -51,14 +50,18 @@ func ModifySystemdService() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func MaskSystemdServices() types.Test {
 	name := "Mask Services"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := `{
 	  "ignition": { "version": "2.0.0" },
 	  "systemd": {
@@ -79,5 +82,10 @@ func MaskSystemdServices() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/positive/timeouts/timeouts.go
+++ b/tests/positive/timeouts/timeouts.go
@@ -53,7 +53,6 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 	name := "Increase HTTP Response Headers Timeout"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := fmt.Sprintf(`{
 		"ignition": {
 			"version": "2.1.0",
@@ -83,14 +82,18 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }
 
 func ConfirmHTTPBackoffWorks() types.Test {
 	name := "Confirm HTTP Backoff Works"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
-	var mntDevices []types.MntDevice
 	config := fmt.Sprintf(`{
 		"ignition": {
 			"version": "2.1.0"
@@ -117,5 +120,10 @@ func ConfirmHTTPBackoffWorks() types.Test {
 		},
 	})
 
-	return types.Test{name, in, out, mntDevices, config}
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
 }

--- a/tests/registry/registry.go
+++ b/tests/registry/registry.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/coreos/ignition/tests/positive/files"
 	_ "github.com/coreos/ignition/tests/positive/general"
 	_ "github.com/coreos/ignition/tests/positive/networkd"
+	_ "github.com/coreos/ignition/tests/positive/oem"
 	_ "github.com/coreos/ignition/tests/positive/passwd"
 	_ "github.com/coreos/ignition/tests/positive/regression"
 	_ "github.com/coreos/ignition/tests/positive/storage"

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -76,11 +76,12 @@ type MntDevice struct {
 }
 
 type Test struct {
-	Name       string
-	In         []Disk
-	Out        []Disk
-	MntDevices []MntDevice
-	Config     string
+	Name              string
+	In                []Disk
+	Out               []Disk
+	MntDevices        []MntDevice
+	OEMLookasideFiles []File
+	Config            string
 }
 
 func (ps Partitions) GetPartition(label string) *Partition {


### PR DESCRIPTION
Centralize distro-specific compile-time constants into a package and allow them to be overridden at link time. Additionally allow OEM paths to be overridden via environment variables, then use this functionality to test `oem://` resource URLs.  Replaces https://github.com/coreos/ignition/pull/455.

Answering some questions from #455:

- @crawford: The profile was indeed unnecessary. The proper way to support the blackbox tests is probably to move them into a chroot or mount namespace, but for now I've punted on that in favor of env vars. Those add API surface, but since there's no user-accessible way to modify Ignition's environment, they hopefully shouldn't create a compatibility constraint. The env vars may be useful for manual testing as well.

- @arithx: I've written the new tests as 2.1.0-only for now. The environment variable overrides aren't as intrusive as profiles were in #455, so this PR still has the test driver passing them unconditionally. Are you okay with not conditionally enabling them via a flag in `Test`?