### PR TITLE
Stop hardcoding base and default configs in Ignition binary

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -81,6 +81,12 @@ replacements that need to be done to the Ignition config before Ignition is
 run. This is done so that disks which are created during the test run can be
 referenced inside of an Ignition config.
 
+OEMLookasideFiles: `[]File` object which describes the Files that should be
+written into the OEM lookaside directory before Ignition is run.
+
+SystemDirFiles: `[]File` object which describes the Files that should be
+written into Ignition's system config directory before Ignition is run.
+
 Config: `string`
 
 The test should be added to the init function inside of the test file. If the

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -29,6 +29,8 @@ var (
 
 	// File paths
 	kernelCmdlinePath = "/proc/cmdline"
+	// initramfs directory containing distro-provided base config
+	systemConfigDir = "/usr/lib/ignition"
 	// initramfs directory to check before retrieving file from OEM partition
 	oemLookasideDir = "/usr/share/oem"
 
@@ -52,6 +54,7 @@ func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
 func OEMDevicePath() string     { return fromEnv("OEM_DEVICE", oemDevicePath) }
 
 func KernelCmdlinePath() string { return kernelCmdlinePath }
+func SystemConfigDir() string   { return fromEnv("SYSTEM_CONFIG_DIR", systemConfigDir) }
 func OEMLookasideDir() string   { return fromEnv("OEM_LOOKASIDE_DIR", oemLookasideDir) }
 
 func MdadmCmd() string   { return mdadmCmd }

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -51,6 +51,16 @@ type Engine struct {
 // Run executes the stage of the given name. It returns true if the stage
 // successfully ran and false if there were any errors.
 func (e Engine) Run(stageName string) bool {
+	baseConfig := types.Config{
+		Ignition: types.Ignition{Version: types.MaxVersion.String()},
+		Storage: types.Storage{
+			Filesystems: []types.Filesystem{{
+				Name: "root",
+				Path: internalUtil.StringToPtr(e.Root),
+			}},
+		},
+	}
+
 	cfg, f, err := e.acquireConfig()
 	switch err {
 	case nil:
@@ -64,16 +74,6 @@ func (e Engine) Run(stageName string) bool {
 
 	e.Logger.PushPrefix(stageName)
 	defer e.Logger.PopPrefix()
-
-	baseConfig := types.Config{
-		Ignition: types.Ignition{Version: types.MaxVersion.String()},
-		Storage: types.Storage{
-			Filesystems: []types.Filesystem{{
-				Name: "root",
-				Path: internalUtil.StringToPtr(e.Root),
-			}},
-		},
-	}
 
 	return stages.Get(stageName).Create(e.Logger, e.Root, f).Run(config.Append(baseConfig, config.Append(e.OEMConfig.BaseConfig(), cfg)))
 }

--- a/internal/providers/system/system.go
+++ b/internal/providers/system/system.go
@@ -25,11 +25,13 @@ import (
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/util"
+	"github.com/coreos/ignition/internal/resource"
 )
 
 const (
 	baseFilename    = "base.ign"
 	defaultFilename = "default.ign"
+	userFilename    = "user.ign"
 )
 
 func FetchBaseConfig(logger *log.Logger) (types.Config, report.Report, error) {
@@ -38,6 +40,10 @@ func FetchBaseConfig(logger *log.Logger) (types.Config, report.Report, error) {
 
 func FetchDefaultConfig(logger *log.Logger) (types.Config, report.Report, error) {
 	return fetchConfig(logger, defaultFilename)
+}
+
+func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+	return fetchConfig(f.Logger, userFilename)
 }
 
 func fetchConfig(logger *log.Logger, filename string) (types.Config, report.Report, error) {

--- a/internal/providers/system/system.go
+++ b/internal/providers/system/system.go
@@ -1,0 +1,56 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/distro"
+	"github.com/coreos/ignition/internal/log"
+	"github.com/coreos/ignition/internal/providers"
+	"github.com/coreos/ignition/internal/providers/util"
+)
+
+const (
+	baseFilename    = "base.ign"
+	defaultFilename = "default.ign"
+)
+
+func FetchBaseConfig(logger *log.Logger) (types.Config, report.Report, error) {
+	return fetchConfig(logger, baseFilename)
+}
+
+func FetchDefaultConfig(logger *log.Logger) (types.Config, report.Report, error) {
+	return fetchConfig(logger, defaultFilename)
+}
+
+func fetchConfig(logger *log.Logger, filename string) (types.Config, report.Report, error) {
+	path := filepath.Join(distro.SystemConfigDir(), filename)
+	logger.Info("reading system config file %q", path)
+
+	rawConfig, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		logger.Info("no config at %q", path)
+		return types.Config{}, report.Report{}, providers.ErrNoProvider
+	} else if err != nil {
+		logger.Err("couldn't read config %q: %v", path, err)
+		return types.Config{}, report.Report{}, err
+	}
+	return util.ParseConfig(logger, rawConfig)
+}

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -155,10 +155,12 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	defer os.RemoveAll(tmpDirectory)
 
 	oemLookasideDir := filepath.Join(os.TempDir(), "oem-lookaside")
+	systemConfigDir := filepath.Join(os.TempDir(), "system")
 	var rootLocation string
 
 	// Setup
 	createFilesFromSlice(t, oemLookasideDir, test.OEMLookasideFiles)
+	createFilesFromSlice(t, systemConfigDir, test.SystemDirFiles)
 	for i, disk := range test.In {
 		// Set image file path
 		disk.ImageFile = filepath.Join(os.TempDir(), fmt.Sprintf("hd%d", i))
@@ -243,6 +245,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	appendEnv := []string{
 		"IGNITION_OEM_DEVICE=" + test.In[0].Partitions.GetPartition("OEM").Device,
 		"IGNITION_OEM_LOOKASIDE_DIR=" + oemLookasideDir,
+		"IGNITION_SYSTEM_CONFIG_DIR=" + systemConfigDir,
 	}
 	disks := runIgnition(t, "disks", rootLocation, tmpDirectory, appendEnv, negativeTests)
 	files := runIgnition(t, "files", rootLocation, tmpDirectory, appendEnv, negativeTests)

--- a/tests/positive/general/preemption.go
+++ b/tests/positive/general/preemption.go
@@ -1,0 +1,128 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package general
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	// Default config is applied
+	register.Register(register.PositiveTest, makePreemptTest("D"))
+	// Base and default configs are both applied
+	register.Register(register.PositiveTest, makePreemptTest("BD"))
+	// Base and provider configs are both applied
+	register.Register(register.PositiveTest, makePreemptTest("BP"))
+	// Provider config is applied; default config is ignored
+	register.Register(register.PositiveTest, makePreemptTest("dP"))
+	// Base and user configs are applied; provider and default
+	// configs are ignored
+	register.Register(register.PositiveTest, makePreemptTest("BdUp"))
+	// No configs provided; Ignition should still run successfully
+	register.Register(register.PositiveTest, makePreemptTest(""))
+}
+
+// makePreemptTest returns a config preemption test that executes some
+// combination of "b"ase, "d"efault, "u"ser (user.ign), and "p"rovider
+// (IGNITION_CONFIG_FILE) configs. Capital letters indicate configs that
+// Ignition should apply.
+func makePreemptTest(components string) types.Test {
+	longnames := map[string]string{
+		"b": "base",
+		"d": "default",
+		"u": "user",
+		"p": "provider",
+	}
+	makeConfig := func(component string) string {
+		return fmt.Sprintf(`{
+			"ignition": {"version": "2.1.0"},
+			"storage": {
+				"files": [{
+					"filesystem": "root",
+					"path": "/ignition/%s",
+					"contents": {"source": "data:,%s"}
+				}]}
+		}`, longnames[component], component)
+	}
+	enabled := func(component string) bool {
+		return strings.Contains(strings.ToLower(components), component)
+	}
+
+	var longnameList []string
+	for _, component := range strings.Split(strings.ToLower(components), "") {
+		longnameList = append(longnameList, longnames[component])
+	}
+	if len(longnameList) == 0 {
+		longnameList = append(longnameList, "no")
+	}
+	name := "Preemption with " + strings.Join(longnameList, ", ") + " config"
+
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+
+	var config string
+	if enabled("p") {
+		config = makeConfig("p")
+	}
+
+	var systemFiles []types.File
+	for _, component := range []string{"b", "d", "u"} {
+		if enabled(component) {
+			systemFiles = append(systemFiles, types.File{
+				Node: types.Node{
+					Name: longnames[component] + ".ign",
+				},
+				Contents: makeConfig(component),
+			})
+		}
+	}
+
+	for component, longname := range longnames {
+		in[0].Partitions.AddFiles("ROOT", []types.File{
+			{
+				Node: types.Node{
+					Name:      longname,
+					Directory: "ignition",
+				},
+				Contents: "unset",
+			},
+		})
+		result := "unset"
+		if strings.Contains(components, strings.ToUpper(component)) {
+			result = component
+		}
+		out[0].Partitions.AddFiles("ROOT", []types.File{
+			{
+				Node: types.Node{
+					Name:      longname,
+					Directory: "ignition",
+				},
+				Contents: result,
+			},
+		})
+	}
+
+	return types.Test{
+		Name:           name,
+		In:             in,
+		Out:            out,
+		Config:         config,
+		SystemDirFiles: systemFiles,
+	}
+}

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -81,6 +81,7 @@ type Test struct {
 	Out               []Disk
 	MntDevices        []MntDevice
 	OEMLookasideFiles []File
+	SystemDirFiles    []File
 	Config            string
 }
 


### PR DESCRIPTION
Add a new "system config dir" (defaulting to `/usr/lib/ignition` in the initramfs) which contains `base.ign` and `default.ign`. Both files are optional. Read `base.ign` instead of `oem.BaseConfig()` and `default.ign` instead of `oem.DefaultUserConfig()`; no longer ship those configs in `oem.go`. This improves the distro-independence of the codebase and allows the OEM configs to be updated independently of an Ignition release.

Also add an optional `user.ign` in the system config dir, which is lower priority than `coreos.config.url` but higher priority than the regular config provider. This allows tools like `coreos-install` to write a user config to disk without also modifying `grub.cfg`.

The idea is for bootengine to mount the OEM partition, copy the three Ignition config files into `/usr/lib/ignition` in the initramfs, unmount, and then run Ignition. That is implemented in https://github.com/coreos/bootengine/pull/135.

Addresses https://github.com/coreos/bugs/issues/2004.