### PR TITLE
add support for s3 all aws partitions

### DIFF
--- a/internal/providers/ec2/ec2.go
+++ b/internal/providers/ec2/ec2.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -56,9 +57,16 @@ func NewFetcher(l *log.Logger, c *resource.HttpClient) (resource.Fetcher, error)
 		return resource.Fetcher{}, err
 	}
 	sess.Config.Credentials = ec2rolecreds.NewCredentials(sess)
+
+	// Determine the partition and region this ec2 is in
+	regionHint, err := ec2metadata.New(sess).Region()
+	if err != nil {
+		regionHint = "us-east-1"
+	}
 	return resource.Fetcher{
-		Logger:     l,
-		Client:     c,
-		AWSSession: sess,
+		Logger:       l,
+		Client:       c,
+		AWSSession:   sess,
+		S3RegionHint: regionHint,
 	}, nil
 }


### PR DESCRIPTION
This is an (untested) attempt to add support for autodetecting the current machine region when using the s3 protocol for replacing ignition config. Hence adding support for all aws partitions, this is needed by the tectonic installer in order to deploy into GovCloud/China partitions (aws-us-gov, aws-cn)
Fix https://github.com/coreos/bugs/issues/2216