### PR TITLE
resource/http: prefer the go resolver over libc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ language: go
 go_import_path: github.com/coreos/ignition
 
 go:
-  - 1.7
   - 1.8
+  - 1.9
 
 env:
-  global:
-   - GO15VENDOREXPERIMENT=1
   matrix:
    - TARGET=amd64
    - TARGET=arm64 GIMME_ARCH=arm64 GIMME_CGO_ENABLED=1

--- a/internal/resource/http.go
+++ b/internal/resource/http.go
@@ -66,6 +66,9 @@ func NewHttpClient(logger *log.Logger, timeouts types.Timeouts) HttpClient {
 				Dial: (&net.Dialer{
 					Timeout:   30 * time.Second,
 					KeepAlive: 30 * time.Second,
+					Resolver: &net.Resolver{
+						PreferGo: true,
+					},
 				}).Dial,
 				TLSHandshakeTimeout: 10 * time.Second,
 			},


### PR DESCRIPTION
The default implementation of the HTTP library in Go doesn't play nicely
with the libc resolver. When resolving a record with multiple records
(round robin DNS), the resolver returns a list of IPs to the HTTP
library, in the order that was returned by libc. This order is defined
by [RFC 6724]. The HTTP library, however, doesn't attempt to use all of
those IPs in the event of a connection error - it only ever uses the
first.

Generally speaking, the order of addresses returned by libc appears to
be random but in reality, [RFC 6724] defines the order. This is
problematic because if a particular address is always first in that
list, it will result in that address receiving an unbalanced amount of
traffic. Ignition should actually use a random resolver to ensure that
the traffic is actually balanced.

This patch uses the temporary solution of using the Go resolver by
default. This works because Go decided not to apply [rule 9] to IPv4
addresses. The effect is a randomization of addresses.

This will need to be fixed properly with the use of a random resolver or
a patch to the HTTP library but this should be sufficient for now.

[RFC 6724]: https://tools.ietf.org/html/rfc6724#section-6
[rule 9]: https://go-review.googlesource.com/c/go/+/34914