### PR TITLE
Improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,11 @@ script:
                 GOARCH="${TARGET}" ./test;
         elif [ "${TARGET}" == "arm64" ]; then
                 export CGO_LDFLAGS="-L ${PWD}";
-                GOARCH="${TARGET}" ./build;
-                file "bin/${TARGET}/ignition" | egrep 'aarch64';
+                GOARCH="${TARGET}" ./build && file "bin/${TARGET}/ignition" | egrep 'aarch64';
+        fi
+  -     if [ "${TARGET}" == "amd64" ]; then
+                GOARCH="${TARGET}" ACTION=COMPILE ./test;
+        elif [ "${TARGET}" == "arm64" ]; then
+                export CGO_LDFLAGS="-L ${PWD}";
+                GOARCH="${TARGET}" ACTION=COMPILE ./test && file "tests.test" | egrep 'aarch64';
         fi

--- a/build
+++ b/build
@@ -25,6 +25,12 @@ go build -ldflags "${GLDFLAGS}" -o ${GOBIN}/${NAME} ${REPO_PATH}/internal
 for D in tests/stubs/*; do
 	if [ -d "${D}" ]; then
 		echo "Building ${D}"
-		go install ${REPO_PATH}/${D}
+		if [ "$GOHOSTARCH" == "$GOARCH" ]; then
+			go install ${REPO_PATH}/${D}
+		else 
+			# Don't try to go install things when cross compiling because
+			# go install disallows it.
+			go build ${REPO_PATH}/${D}
+		fi
 	fi
 done

--- a/test
+++ b/test
@@ -4,8 +4,7 @@ set -eu
 
 source ./build
 
-SRC=$(find . -name '*.go' \
-  -not -path "./vendor/*")
+SRC=$(find . -name '*.go' -not -path "./vendor/*")
 
 PKG=$(cd gopath/src/${REPO_PATH}; go list ./... | \
 	grep --invert-match vendor | grep --invert-match tests)
@@ -29,13 +28,13 @@ echo "Checking govet..."
 go vet $PKG_VET
 
 if [ "${ACTION:-TEST}" != "COMPILE" ]; then
-    echo "Running tests..."
-    go test -timeout 60s -cover $@ ${PKG} --race
+	echo "Running tests..."
+	go test -timeout 60s -cover $@ ${PKG} --race
 else
-    PKG=$(cd gopath/src/${REPO_PATH}; go list ./... | \
-    	grep --invert-match vendor)
-    echo "Compiling tests..."
-    for p in ${PKG}; do
+	PKG=$(cd gopath/src/${REPO_PATH}; go list ./... | \
+		grep --invert-match vendor | grep tests)
+	echo "Compiling tests..."
+	for p in ${PKG}; do
 		go test -c $p
 	done
 fi

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -93,6 +93,7 @@ func runIgnition(t *testing.T, stage, root, cwd string, appendEnv []string, expe
 	cmd.Dir = cwd
 	cmd.Env = append(os.Environ(), appendEnv...)
 	out, err := cmd.CombinedOutput()
+	t.Logf("PID: %d", cmd.Process.Pid)
 	if err != nil && !expectFail {
 		t.Fatal(args, err, string(out))
 	}


### PR DESCRIPTION
Minor quality of life fixes: don't compile things we don't need to and log Ignition's PID when running in a BB test so you can look at the logs more easily.

Depends on https://github.com/coreos/ignition/pull/481