### PR TITLE
Network dropins

### DIFF
--- a/config/translate.go
+++ b/config/translate.go
@@ -132,7 +132,7 @@ func TranslateFromV1(old v1.Config) types.Config {
 		}
 
 		for _, oldDropIn := range oldUnit.DropIns {
-			unit.Dropins = append(unit.Dropins, types.Dropin{
+			unit.Dropins = append(unit.Dropins, types.SystemdDropin{
 				Name:     string(oldDropIn.Name),
 				Contents: oldDropIn.Contents,
 			})
@@ -346,7 +346,7 @@ func TranslateFromV2_0(old v2_0.Config) types.Config {
 		}
 
 		for _, oldDropIn := range oldUnit.DropIns {
-			unit.Dropins = append(unit.Dropins, types.Dropin{
+			unit.Dropins = append(unit.Dropins, types.SystemdDropin{
 				Name:     string(oldDropIn.Name),
 				Contents: oldDropIn.Contents,
 			})
@@ -675,10 +675,10 @@ func TranslateFromV2_1(old v2_1.Config) types.Config {
 		}
 		return res
 	}
-	translateSystemdDropinSlice := func(old []v2_1.Dropin) []types.Dropin {
-		var res []types.Dropin
+	translateSystemdDropinSlice := func(old []v2_1.Dropin) []types.SystemdDropin {
+		var res []types.SystemdDropin
 		for _, x := range old {
-			res = append(res, types.Dropin{
+			res = append(res, types.SystemdDropin{
 				Contents: x.Contents,
 				Name:     x.Name,
 			})

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -281,7 +281,7 @@ func TestTranslateFromV1(t *testing.T) {
 							Name:     "test1.service",
 							Enable:   true,
 							Contents: "test1 contents",
-							Dropins: []types.Dropin{
+							Dropins: []types.SystemdDropin{
 								{
 									Name:     "conf1.conf",
 									Contents: "conf1 contents",
@@ -792,7 +792,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Name:     "test1.service",
 							Enable:   true,
 							Contents: "test1 contents",
-							Dropins: []types.Dropin{
+							Dropins: []types.SystemdDropin{
 								{
 									Name:     "conf1.conf",
 									Contents: "conf1 contents",
@@ -1592,7 +1592,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Name:     "test1.service",
 							Enable:   true,
 							Contents: "test1 contents",
-							Dropins: []types.Dropin{
+							Dropins: []types.SystemdDropin{
 								{
 									Name:     "conf1.conf",
 									Contents: "conf1 contents",

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -39,11 +39,6 @@ type Disk struct {
 	WipeTable  bool        `json:"wipeTable,omitempty"`
 }
 
-type Dropin struct {
-	Contents string `json:"contents,omitempty"`
-	Name     string `json:"name,omitempty"`
-}
-
 type File struct {
 	Node
 	FileEmbedded1
@@ -105,9 +100,15 @@ type Networkd struct {
 	Units []Networkdunit `json:"units,omitempty"`
 }
 
-type Networkdunit struct {
+type NetworkdDropin struct {
 	Contents string `json:"contents,omitempty"`
 	Name     string `json:"name,omitempty"`
+}
+
+type Networkdunit struct {
+	Contents string           `json:"contents,omitempty"`
+	Dropins  []NetworkdDropin `json:"dropins,omitempty"`
+	Name     string           `json:"name,omitempty"`
 }
 
 type Node struct {
@@ -187,18 +188,23 @@ type Systemd struct {
 	Units []Unit `json:"units,omitempty"`
 }
 
+type SystemdDropin struct {
+	Contents string `json:"contents,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
 type Timeouts struct {
 	HTTPResponseHeaders *int `json:"httpResponseHeaders,omitempty"`
 	HTTPTotal           *int `json:"httpTotal,omitempty"`
 }
 
 type Unit struct {
-	Contents string   `json:"contents,omitempty"`
-	Dropins  []Dropin `json:"dropins,omitempty"`
-	Enable   bool     `json:"enable,omitempty"`
-	Enabled  *bool    `json:"enabled,omitempty"`
-	Mask     bool     `json:"mask,omitempty"`
-	Name     string   `json:"name,omitempty"`
+	Contents string          `json:"contents,omitempty"`
+	Dropins  []SystemdDropin `json:"dropins,omitempty"`
+	Enable   bool            `json:"enable,omitempty"`
+	Enabled  *bool           `json:"enabled,omitempty"`
+	Mask     bool            `json:"mask,omitempty"`
+	Name     string          `json:"name,omitempty"`
 }
 
 type Usercreate struct {

--- a/config/types/unit.go
+++ b/config/types/unit.go
@@ -98,6 +98,28 @@ func (u Networkdunit) Validate() report.Report {
 	return r
 }
 
+func (d NetworkdDropin) Validate() report.Report {
+	r := report.Report{}
+
+	if err := validateUnitContent(d.Contents); err != nil {
+		r.Add(report.Entry{
+			Message: err.Error(),
+			Kind:    report.EntryError,
+		})
+	}
+
+	switch path.Ext(d.Name) {
+	case ".conf":
+	default:
+		r.Add(report.Entry{
+			Message: fmt.Sprintf("invalid networkd unit drop-in extension: %q", path.Ext(d.Name)),
+			Kind:    report.EntryError,
+		})
+	}
+
+	return r
+}
+
 func validateUnitContent(content string) error {
 	c := bytes.NewBufferString(content)
 	_, err := unit.Deserialize(c)

--- a/config/types/unit.go
+++ b/config/types/unit.go
@@ -54,7 +54,7 @@ func (u Unit) ValidateName() report.Report {
 	return r
 }
 
-func (d Dropin) Validate() report.Report {
+func (d SystemdDropin) Validate() report.Report {
 	r := report.Report{}
 
 	if err := validateUnitContent(d.Contents); err != nil {

--- a/config/types/unit_test.go
+++ b/config/types/unit_test.go
@@ -43,7 +43,7 @@ func TestSystemdUnitValidateContents(t *testing.T) {
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
 		},
 		{
-			in:  in{unit: Unit{Name: "test.service", Contents: "", Dropins: []Dropin{{}}}},
+			in:  in{unit: Unit{Name: "test.service", Contents: "", Dropins: []SystemdDropin{{}}}},
 			out: out{err: nil},
 		},
 	}
@@ -92,7 +92,7 @@ func TestSystemdUnitValidateName(t *testing.T) {
 
 func TestSystemdUnitDropInValidate(t *testing.T) {
 	type in struct {
-		unit Dropin
+		unit SystemdDropin
 	}
 	type out struct {
 		err error
@@ -103,11 +103,11 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		out out
 	}{
 		{
-			in:  in{unit: Dropin{Name: "test.conf", Contents: "[Foo]\nQux=Bar"}},
+			in:  in{unit: SystemdDropin{Name: "test.conf", Contents: "[Foo]\nQux=Bar"}},
 			out: out{err: nil},
 		},
 		{
-			in:  in{unit: Dropin{Name: "test.conf", Contents: "[Foo"}},
+			in:  in{unit: SystemdDropin{Name: "test.conf", Contents: "[Foo"}},
 			out: out{err: errors.New("invalid unit content: unable to find end of section")},
 		},
 	}

--- a/config/types/unit_test.go
+++ b/config/types/unit_test.go
@@ -187,3 +187,33 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		}
 	}
 }
+
+func TestNetworkdUnitDropInValidate(t *testing.T) {
+	type in struct {
+		unit NetworkdDropin
+	}
+	type out struct {
+		err error
+	}
+
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in:  in{unit: NetworkdDropin{Name: "test.conf", Contents: "[Foo]\nQux=Bar"}},
+			out: out{err: nil},
+		},
+		{
+			in:  in{unit: NetworkdDropin{Name: "test.conf", Contents: "[Foo"}},
+			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+		},
+	}
+
+	for i, test := range tests {
+		err := test.in.unit.Validate()
+		if !reflect.DeepEqual(report.ReportFromError(test.out.err, report.EntryError), err) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out.err, err)
+		}
+	}
+}

--- a/doc/configuration-v2_2-experimental.md
+++ b/doc/configuration-v2_2-experimental.md
@@ -97,6 +97,9 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_units_** (list of objects): the list of networkd files.
     * **name** (string): the name of the file. This must be suffixed with a valid unit type (e.g. "00-eth0.network").
     * **_contents_** (string): the contents of the networkd file.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
 * **_passwd_** (object): describes the desired additions to the passwd database.
   * **_users_** (list of objects): the list of accounts that shall exist.
     * **name** (string): the username for the account.

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -374,14 +374,14 @@ func (s stage) writeSystemdUnit(unit types.Unit) error {
 				continue
 			}
 
-			f, err := util.FileFromUnitDropin(unit, dropin)
+			f, err := util.FileFromSystemdUnitDropin(unit, dropin)
 			if err != nil {
-				s.Logger.Crit("error converting dropin: %v", err)
+				s.Logger.Crit("error converting systemd dropin: %v", err)
 				return err
 			}
 			if err := s.Logger.LogOp(
 				func() error { return s.PerformFetch(f) },
-				"writing drop-in %q at %q", dropin.Name, f.Path,
+				"writing systemd drop-in %q at %q", dropin.Name, f.Path,
 			); err != nil {
 				return err
 			}

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -407,10 +407,28 @@ func (s stage) writeSystemdUnit(unit types.Unit) error {
 	}, "processing unit %q", unit.Name)
 }
 
-// writeNetworkdUnit creates the specified unit. If the contents of the unit or
-// are empty, the unit is not created.
+// writeNetworkdUnit creates the specified unit and any dropins for that unit.
+// If the contents of the unit or are empty, the unit is not created. The same
+// applies to the unit's dropins.
 func (s stage) writeNetworkdUnit(unit types.Networkdunit) error {
 	return s.Logger.LogOp(func() error {
+		for _, dropin := range unit.Dropins {
+			if dropin.Contents == "" {
+				continue
+			}
+
+			f, err := util.FileFromNetworkdUnitDropin(unit, dropin)
+			if err != nil {
+				s.Logger.Crit("error converting networkd dropin: %v", err)
+				return err
+			}
+			if err := s.Logger.LogOp(
+				func() error { return s.PerformFetch(f) },
+				"writing networkd drop-in %q at %q", dropin.Name, f.Path,
+			); err != nil {
+				return err
+			}
+		}
 		if unit.Contents == "" {
 			return nil
 		}

--- a/internal/exec/util/path.go
+++ b/internal/exec/util/path.go
@@ -29,3 +29,7 @@ func NetworkdUnitsPath() string {
 func SystemdDropinsPath(unitName string) string {
 	return filepath.Join("etc", "systemd", "system", unitName+".d")
 }
+
+func NetworkdDropinsPath(unitName string) string {
+	return filepath.Join("etc", "systemd", "network", unitName+".d")
+}

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -54,7 +54,7 @@ func FileFromNetworkdUnit(unit types.Networkdunit) (*FetchOp, error) {
 	}, nil
 }
 
-func FileFromUnitDropin(unit types.Unit, dropin types.Dropin) (*FetchOp, error) {
+func FileFromSystemdUnitDropin(unit types.Unit, dropin types.SystemdDropin) (*FetchOp, error) {
 	u, err := url.Parse(dataurl.EncodeBytes([]byte(dropin.Contents)))
 	if err != nil {
 		return nil, err

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -66,6 +66,18 @@ func FileFromSystemdUnitDropin(unit types.Unit, dropin types.SystemdDropin) (*Fe
 	}, nil
 }
 
+func FileFromNetworkdUnitDropin(unit types.Networkdunit, dropin types.NetworkdDropin) (*FetchOp, error) {
+	u, err := url.Parse(dataurl.EncodeBytes([]byte(dropin.Contents)))
+	if err != nil {
+		return nil, err
+	}
+	return &FetchOp{
+		Path: filepath.Join(NetworkdDropinsPath(string(unit.Name)), string(dropin.Name)),
+		Url:  *u,
+		Mode: DefaultFilePermissions,
+	}, nil
+}
+
 func (u Util) MaskUnit(unit types.Unit) error {
 	path := u.JoinPath(SystemdUnitsPath(), string(unit.Name))
 	if err := MkdirForFile(path); err != nil {

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -405,6 +405,23 @@
             },
             "contents": {
               "type": "string"
+            },
+            "dropins": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/networkd/definitions/dropin"
+              }
+            }
+          }
+        },
+        "dropin": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "contents": {
+              "type": "string"
             }
           }
         }


### PR DESCRIPTION
Systemd v232 [added networkd drop-ins](https://github.com/systemd/systemd/blob/5e0aff564c86838e08c4b1bdd8df182d233a36b8/NEWS#L1204-L1205).

This PR adds a "dropins" section to networkd, and includes relevant renaming for the systemd dropins (since they're not the only dropins any more).

Tested with the following config:
```json
{
  "ignition": {
    "version": "2.2.0-experimental",
    "config": {}
  },
  "storage": {},
  "systemd": {},
  "networkd": {
    "units": [
      {
        "name": "zz-default.network",
	"dropins": [
          {
            "name": "disable-dhcp.conf",
            "contents": "[Network]\nDHCP=no"
          }
	]
      }
    ]
  },
  "passwd": {}
}
```

Fixes https://github.com/coreos/bugs/issues/2250