### PR TITLE
tests: make running bb tests locally easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ script:
                 GOARCH="${TARGET}" ./build && file "bin/${TARGET}/ignition" | egrep 'aarch64';
         fi
   -     if [ "${TARGET}" == "amd64" ]; then
-                GOARCH="${TARGET}" ACTION=COMPILE ./test;
+                GOARCH="${TARGET}" ./build_blackbox_tests;
         elif [ "${TARGET}" == "arm64" ]; then
                 export CGO_LDFLAGS="-L ${PWD}";
-                GOARCH="${TARGET}" ACTION=COMPILE ./test && file "tests.test" | egrep 'aarch64';
+                GOARCH="${TARGET}" ./build_blackbox_tests && file "tests.test" | egrep 'aarch64';
         fi

--- a/build
+++ b/build
@@ -6,7 +6,8 @@ NAME="ignition"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}"
 VERSION=$(git describe --dirty)
-GLDFLAGS="-X github.com/coreos/ignition/internal/version.Raw=${VERSION}"
+GLDFLAGS=${GLDFLAGS:-}
+GLDFLAGS+="-X github.com/coreos/ignition/internal/version.Raw=${VERSION}"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}
@@ -22,15 +23,3 @@ export CGO_ENABLED=1
 echo "Building ${NAME}..."
 go build -ldflags "${GLDFLAGS}" -o ${GOBIN}/${NAME} ${REPO_PATH}/internal
 
-for D in tests/stubs/*; do
-	if [ -d "${D}" ]; then
-		echo "Building ${D}"
-		if [ "$GOHOSTARCH" == "$GOARCH" ]; then
-			go install ${REPO_PATH}/${D}
-		else 
-			# Don't try to go install things when cross compiling because
-			# go install disallows it.
-			go build ${REPO_PATH}/${D}
-		fi
-	fi
-done

--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ "${HELPERS:-CL}" == "HOST" ]; then
+	GLDFLAGS="-X github.com/coreos/ignition/internal/distro.mdadmCmd=$(sudo which mdadm) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.mountCmd=$(sudo which mount) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.sgdiskCmd=$(sudo which sgdisk) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.udevadmCmd=$(sudo which udevadm) "
+
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.btrfsMkfsCmd=$(sudo which mkfs.btrfs) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.ext4MkfsCmd=$(sudo which mkfs.ext4) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.swapMkfsCmd=$(sudo which mkswap) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.vfatMkfsCmd=$(sudo which mkfs.vfat) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.xfsMkfsCmd=$(sudo which mkfs.xfs) "
+fi
+
+. build
+
+PKG=$(cd gopath/src/${REPO_PATH}; go list ./tests/...)
+
+echo "Compiling tests..."
+for p in ${PKG}; do
+	go test -c $p
+done
+
+for D in tests/stubs/*; do
+	if [ -d "${D}" ]; then
+		echo "Building ${D}"
+		if [ "$GOHOSTARCH" == "$GOARCH" ]; then
+			go install ${REPO_PATH}/${D}
+		else
+			# Don't try to go install things when cross compiling because
+			# go install disallows it.
+			go build ${REPO_PATH}/${D}
+		fi
+	fi
+done
+
+echo "Success"

--- a/doc/development.md
+++ b/doc/development.md
@@ -46,8 +46,18 @@ example it will be building from the ignition-builder-1.8 image and targeting
 the amd64 architecture.
 
 ```sh
-docker run --rm -e TARGET=amd64 -e ACTION=COMPILE -v "$PWD":/usr/src/myapp -w /usr/src/myapp quay.io/coreos/ignition-builder-1.8 ./test
+docker run --rm -e TARGET=amd64 -v "$PWD":/usr/src/myapp -w /usr/src/myapp quay.io/coreos/ignition-builder-1.8 ./build_blackbox_tests
 sudo -E PATH=$PWD/bin/amd64:$PATH ./tests.test
+```
+
+## Runnning Blackbox Tests on platforms other than Container Linux
+
+Build Ignition and the test binaries with HELPERS=HOST to use the paths of the binaries from your host system instead of those found in
+Container linux. Then run blackbox tests. The subshell ensures the root PATH is used instead of your user's.
+
+```sh
+HELPERS=HOST ./build_blackbox_tests
+sudo sh -c 'PATH=$PWD/bin/amd64:$PATH ./tests.test'
 ```
 
 ## Test Host System Dependencies
@@ -62,6 +72,7 @@ The following packages are required by the Blackbox Test:
 * `uuid-runtime`
 * `gdisk`
 * `coreutils`
+* `mdadm`
 
 ## Writing Blackbox Tests
 

--- a/test
+++ b/test
@@ -27,16 +27,7 @@ fi
 echo "Checking govet..."
 go vet $PKG_VET
 
-if [ "${ACTION:-TEST}" != "COMPILE" ]; then
-	echo "Running tests..."
-	go test -timeout 60s -cover $@ ${PKG} --race
-else
-	PKG=$(cd gopath/src/${REPO_PATH}; go list ./... | \
-		grep --invert-match vendor | grep tests)
-	echo "Compiling tests..."
-	for p in ${PKG}; do
-		go test -c $p
-	done
-fi
+echo "Running tests..."
+go test -timeout 60s -cover $@ ${PKG} --race
 
 echo "Success"


### PR DESCRIPTION
Add a script to configure the helper programs paths to those found on
the host system. Source this script when running build with
HELPERS=HOST.