### PR TITLE
Apply config timeouts when resolving config chains

### DIFF
--- a/config/append.go
+++ b/config/append.go
@@ -64,7 +64,11 @@ func appendStruct(vOld, vNew reflect.Value) reflect.Value {
 		case reflect.Slice:
 			vfRes.Set(reflect.AppendSlice(vfOld, vfNew))
 		default:
-			vfRes.Set(vfNew)
+			if vfNew.Kind() == reflect.Ptr && vfNew.IsNil() {
+				vfRes.Set(vfOld)
+			} else {
+				vfRes.Set(vfNew)
+			}
 		}
 	}
 

--- a/config/append_test.go
+++ b/config/append_test.go
@@ -15,10 +15,10 @@
 package config
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/coreos/ignition/config/types"
 )
@@ -188,12 +188,37 @@ func TestAppend(t *testing.T) {
 				},
 			}},
 		},
+
+		// when the newconfig doesn't set a value
+		{
+			in: in{
+				oldConfig: types.Config{
+					Ignition: types.Ignition{
+						Timeouts: types.Timeouts{
+							HTTPTotal: intToPtr(1),
+						},
+					},
+				},
+				newConfig: types.Config{
+					Ignition: types.Ignition{
+						Timeouts: types.Timeouts{
+							HTTPTotal: nil,
+						},
+					},
+				},
+			},
+			out: out{types.Config{
+				Ignition: types.Ignition{
+					Timeouts: types.Timeouts{
+						HTTPTotal: intToPtr(1),
+					},
+				},
+			}},
+		},
 	}
 
 	for i, test := range tests {
 		config := Append(test.in.oldConfig, test.in.newConfig)
-		if !reflect.DeepEqual(test.out.config, config) {
-			t.Errorf("#%d: bad config: want %+v, got %+v", i, test.out.config, config)
-		}
+		assert.Equal(t, test.out.config, config, "#%d: bad config", i)
 	}
 }


### PR DESCRIPTION
Changes Ignition to apply config timeouts while resolving config chains, instead of after the config chains are resolved.

Changes the append logic to keep old values when the new value is nil (the motivator being that one config's timeouts could be overriden by a new config that didn't set any timeouts).

Adds a few blackbox tests to make sure this all works as expected.