### PR TITLE
.github/tailor.yaml: allow periods in scope

### DIFF
--- a/.github/tailor.yaml
+++ b/.github/tailor.yaml
@@ -2,7 +2,7 @@ rules:
   - name: commit title
     description: all commit titles must have a scope and be no more than 72 characters
     expression:  |-
-      .commits all(((.title test "^[a-z/*_-]+: [[:alnum:] -'.:/_-]+$") and (.title length < 73)) or (.title test "^Revert"))
+      .commits all(((.title test "^[a-z/*_.-]+: [[:alnum:] -'.:/_-]+$") and (.title length < 73)) or (.title test "^Revert"))
 
   - name: commit description
     description: all commit descriptions must have lines no longer than 72 characters


### PR DESCRIPTION
Sometimes a scope is a single file, allow periods in scope so filenames
can be used as a scope.