### PR TITLE
Disallow colons in partition labels

### DIFF
--- a/config/types/partition.go
+++ b/config/types/partition.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -29,6 +30,7 @@ const (
 var (
 	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
 	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrLabelContainsColon   = errors.New("partition label will be truncated to text before the colon")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -42,6 +44,14 @@ func (p Partition) ValidateLabel() report.Report {
 		r.Add(report.Entry{
 			Message: ErrLabelTooLong.Error(),
 			Kind:    report.EntryError,
+		})
+	}
+
+	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
+	if strings.Contains(p.Label, ":") {
+		r.Add(report.Entry{
+			Message: ErrLabelContainsColon.Error(),
+			Kind:    report.EntryWarning,
 		})
 	}
 	return r

--- a/config/types/partition_test.go
+++ b/config/types/partition_test.go
@@ -48,6 +48,10 @@ func TestValidateLabel(t *testing.T) {
 			in{"1111111111111111111111111111111111111"},
 			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
 		},
+		{
+			in{"test:"},
+			out{report.ReportFromError(ErrLabelContainsColon, report.EntryWarning)},
+		},
 	}
 	for i, test := range tests {
 		r := Partition{Label: test.in.label}.ValidateLabel()

--- a/config/v2_0/types/partition.go
+++ b/config/v2_0/types/partition.go
@@ -17,6 +17,7 @@ package types
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -39,6 +40,9 @@ func (n PartitionLabel) Validate() report.Report {
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(string(n)) > 36 {
 		return report.ReportFromError(fmt.Errorf("partition labels may not exceed 36 characters"), report.EntryError)
+	}
+	if strings.Contains(string(n), ":") {
+		return report.ReportFromError(fmt.Errorf("partition label will be truncated to text before the colon"), report.EntryWarning)
 	}
 	return report.Report{}
 }

--- a/config/v2_1/types/partition.go
+++ b/config/v2_1/types/partition.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -29,6 +30,7 @@ const (
 var (
 	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
 	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrLabelContainsColon   = errors.New("partition label will be truncated to text before the colon")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -42,6 +44,14 @@ func (p Partition) ValidateLabel() report.Report {
 		r.Add(report.Entry{
 			Message: ErrLabelTooLong.Error(),
 			Kind:    report.EntryError,
+		})
+	}
+
+	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
+	if strings.Contains(p.Label, ":") {
+		r.Add(report.Entry{
+			Message: ErrLabelContainsColon.Error(),
+			Kind:    report.EntryWarning,
 		})
 	}
 	return r

--- a/config/v2_1/types/partition_test.go
+++ b/config/v2_1/types/partition_test.go
@@ -48,6 +48,10 @@ func TestValidateLabel(t *testing.T) {
 			in{"1111111111111111111111111111111111111"},
 			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
 		},
+		{
+			in{"test:"},
+			out{report.ReportFromError(ErrLabelContainsColon, report.EntryWarning)},
+		},
 	}
 	for i, test := range tests {
 		r := Partition{Label: test.in.label}.ValidateLabel()


### PR DESCRIPTION
`sgdisk` does not support creating labels with colons; it silently truncates the label to only the characters before the colon. Disallow trying to create labels with colons.