### PR TITLE
tests/networkd: add tests for drop-ins

### DIFF
--- a/tests/negative/networkd/dropins.go
+++ b/tests/negative/networkd/dropins.go
@@ -1,0 +1,49 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkd
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, NetworkdDropinInvalidExtension())
+}
+
+func NetworkdDropinInvalidExtension() types.Test {
+	name := "Create a networkd drop-in"
+	in := types.GetBaseDisk()
+	out := in
+	config := `{
+		"ignition": { "version": "2.2.0-experimental" },
+		"networkd": {
+			"units": [{
+				"name": "static.network",
+				"dropins": [{
+					"name": "dropin.network",
+					"contents": "[Match]\nName=enp2s0\n\n[Network]\nAddress=192.168.0.15/24\nGateway=192.168.0.1\n"
+				}]
+			}]
+		}
+	}`
+
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
+}

--- a/tests/positive/networkd/dropins.go
+++ b/tests/positive/networkd/dropins.go
@@ -1,0 +1,58 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkd
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.PositiveTest, CreateNetworkdDropin())
+}
+
+func CreateNetworkdDropin() types.Test {
+	name := "Create a networkd drop-in"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+		"ignition": { "version": "2.2.0-experimental" },
+		"networkd": {
+			"units": [{
+				"name": "static.network",
+				"dropins": [{
+					"name": "dropin.conf",
+					"contents": "[Match]\nName=enp2s0\n\n[Network]\nAddress=192.168.0.15/24\nGateway=192.168.0.1\n"
+				}]
+			}]
+		}
+	}`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "dropin.conf",
+				Directory: "etc/systemd/network/static.network.d",
+			},
+			Contents: "[Match]\nName=enp2s0\n\n[Network]\nAddress=192.168.0.15/24\nGateway=192.168.0.1\n",
+		},
+	})
+
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
+}

--- a/tests/registry/registry.go
+++ b/tests/registry/registry.go
@@ -18,6 +18,7 @@ package registry
 import (
 	_ "github.com/coreos/ignition/tests/negative/files"
 	_ "github.com/coreos/ignition/tests/negative/general"
+	_ "github.com/coreos/ignition/tests/negative/networkd"
 	_ "github.com/coreos/ignition/tests/negative/regression"
 	_ "github.com/coreos/ignition/tests/negative/storage"
 	_ "github.com/coreos/ignition/tests/negative/timeouts"


### PR DESCRIPTION
Add tests around networkd drop-ins after support was added in #482.

Fixes https://github.com/coreos/bugs/issues/2309