### PR TITLE
default file mode warnings

### DIFF
--- a/config/translate.go
+++ b/config/translate.go
@@ -109,7 +109,7 @@ func TranslateFromV1(old v1.Config) types.Config {
 					Group:      types.NodeGroup{ID: intToPtr(oldFile.Gid)},
 				},
 				FileEmbedded1: types.FileEmbedded1{
-					Mode: int(oldFile.Mode),
+					Mode: intToPtr(int(oldFile.Mode)),
 					Contents: types.FileContents{
 						Source: (&url.URL{
 							Scheme: "data",
@@ -325,7 +325,7 @@ func TranslateFromV2_0(old v2_0.Config) types.Config {
 				Group:      types.NodeGroup{ID: intToPtr(oldFile.Group.Id)},
 			},
 			FileEmbedded1: types.FileEmbedded1{
-				Mode: int(oldFile.Mode),
+				Mode: intToPtr(int(oldFile.Mode)),
 				Contents: types.FileContents{
 					Compression:  string(oldFile.Contents.Compression),
 					Source:       oldFile.Contents.Source.String(),
@@ -545,7 +545,7 @@ func TranslateFromV2_1(old v2_1.Config) types.Config {
 			res = append(res, types.Directory{
 				Node: translateNode(x.Node),
 				DirectoryEmbedded1: types.DirectoryEmbedded1{
-					Mode: x.DirectoryEmbedded1.Mode,
+					Mode: intToPtr(x.DirectoryEmbedded1.Mode),
 				},
 			})
 		}
@@ -589,7 +589,7 @@ func TranslateFromV2_1(old v2_1.Config) types.Config {
 							Hash: x.Contents.Verification.Hash,
 						},
 					},
-					Mode: x.Mode,
+					Mode: intToPtr(x.Mode),
 				},
 			})
 		}

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -199,7 +199,7 @@ func TestTranslateFromV1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0664,
+								Mode: intToPtr(0664),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -216,7 +216,7 @@ func TestTranslateFromV1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0644,
+								Mode: intToPtr(0644),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -233,7 +233,7 @@ func TestTranslateFromV1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0400,
+								Mode: intToPtr(0400),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -710,7 +710,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0664,
+								Mode: intToPtr(0664),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -727,7 +727,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0644,
+								Mode: intToPtr(0644),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -744,7 +744,7 @@ func TestTranslateFromV2_0(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0400,
+								Mode: intToPtr(0400),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -1332,7 +1332,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0664,
+								Mode: intToPtr(0664),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -1352,7 +1352,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0644,
+								Mode: intToPtr(0644),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -1370,7 +1370,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
-								Mode: 0400,
+								Mode: intToPtr(0400),
 								Contents: types.FileContents{
 									Source: (&url.URL{
 										Scheme: "data",
@@ -1436,7 +1436,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(501)},
 							},
 							DirectoryEmbedded1: types.DirectoryEmbedded1{
-								Mode: 0664,
+								Mode: intToPtr(0664),
 							},
 						},
 						{
@@ -1447,7 +1447,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(503)},
 							},
 							DirectoryEmbedded1: types.DirectoryEmbedded1{
-								Mode: 0644,
+								Mode: intToPtr(0644),
 							},
 						},
 						{
@@ -1458,7 +1458,7 @@ func TestTranslateFromV2_1(t *testing.T) {
 								Group:      types.NodeGroup{ID: intToPtr(1001)},
 							},
 							DirectoryEmbedded1: types.DirectoryEmbedded1{
-								Mode: 0400,
+								Mode: intToPtr(0400),
 							},
 						},
 					},

--- a/config/types/directory.go
+++ b/config/types/directory.go
@@ -26,5 +26,11 @@ func (d Directory) ValidateMode() report.Report {
 			Kind:    report.EntryError,
 		})
 	}
+	if d.Mode == nil {
+		r.Add(report.Entry{
+			Message: "directory permissions unset, defaulting to 0000",
+			Kind:    report.EntryWarning,
+		})
+	}
 	return r
 }

--- a/config/types/file.go
+++ b/config/types/file.go
@@ -33,6 +33,12 @@ func (f File) ValidateMode() report.Report {
 			Kind:    report.EntryError,
 		})
 	}
+	if f.Mode == nil {
+		r.Add(report.Entry{
+			Message: "file permissions unset, defaulting to 0000",
+			Kind:    report.EntryWarning,
+		})
+	}
 	return r
 }
 

--- a/config/types/mode.go
+++ b/config/types/mode.go
@@ -22,8 +22,8 @@ var (
 	ErrFileIllegalMode = errors.New("illegal file mode")
 )
 
-func validateMode(m int) error {
-	if m < 0 || m > 07777 {
+func validateMode(m *int) error {
+	if m != nil && (*m < 0 || *m > 07777) {
 		return ErrFileIllegalMode
 	}
 	return nil

--- a/config/types/mode_test.go
+++ b/config/types/mode_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestModeValidate(t *testing.T) {
 	type in struct {
-		mode int
+		mode *int
 	}
 	type out struct {
 		err error
@@ -32,23 +32,27 @@ func TestModeValidate(t *testing.T) {
 		out out
 	}{
 		{
-			in:  in{mode: 0},
+			in:  in{mode: nil},
 			out: out{},
 		},
 		{
-			in:  in{mode: 0644},
+			in:  in{mode: intToPtr(0)},
 			out: out{},
 		},
 		{
-			in:  in{mode: 01755},
+			in:  in{mode: intToPtr(0644)},
 			out: out{},
 		},
 		{
-			in:  in{mode: 07777},
+			in:  in{mode: intToPtr(01755)},
 			out: out{},
 		},
 		{
-			in:  in{mode: 010000},
+			in:  in{mode: intToPtr(07777)},
+			out: out{},
+		},
+		{
+			in:  in{mode: intToPtr(010000)},
 			out: out{ErrFileIllegalMode},
 		},
 	}

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -30,7 +30,7 @@ type Directory struct {
 }
 
 type DirectoryEmbedded1 struct {
-	Mode int `json:"mode,omitempty"`
+	Mode *int `json:"mode,omitempty"`
 }
 
 type Disk struct {
@@ -52,7 +52,7 @@ type FileContents struct {
 
 type FileEmbedded1 struct {
 	Contents FileContents `json:"contents,omitempty"`
-	Mode     int          `json:"mode,omitempty"`
+	Mode     *int         `json:"mode,omitempty"`
 }
 
 type Filesystem struct {

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -168,12 +168,16 @@ func (tmp dirEntry) create(l *log.Logger, u util.Util) error {
 			newPaths = append(newPaths, p)
 		}
 
-		if err := os.MkdirAll(path, os.FileMode(d.Mode)); err != nil {
+		if d.Mode == nil {
+			d.Mode = internalUtil.IntToPtr(0)
+		}
+
+		if err := os.MkdirAll(path, os.FileMode(*d.Mode)); err != nil {
 			return err
 		}
 
 		for _, newPath := range newPaths {
-			if err := os.Chmod(newPath, os.FileMode(d.Mode)); err != nil {
+			if err := os.Chmod(newPath, os.FileMode(*d.Mode)); err != nil {
 				return err
 			}
 			if err := os.Chown(newPath, *d.User.ID, *d.Group.ID); err != nil {

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -90,10 +90,14 @@ func (u Util) PrepareFetch(l *log.Logger, f types.File) *FetchOp {
 		return nil
 	}
 
+	if f.Mode == nil {
+		f.Mode = internalUtil.IntToPtr(0)
+	}
+
 	return &FetchOp{
 		Path: f.Path,
 		Hash: hasher,
-		Mode: os.FileMode(f.Mode),
+		Mode: os.FileMode(*f.Mode),
 		Uid:  *f.User.ID,
 		Gid:  *f.Group.ID,
 		Url:  *uri,

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -182,7 +182,7 @@
               "type": "object",
               "properties": {
                 "mode": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
                 },
                 "contents": {
                   "$ref": "#/definitions/storage/definitions/file-contents"
@@ -200,7 +200,7 @@
                 "type": "object",
                 "properties": {
                     "mode": {
-                        "type": "integer"
+                        "type": ["integer", "null"]
                     }
                 }
               }


### PR DESCRIPTION
Emit warnings if a config doesn't specify file modes.

Related to https://github.com/coreos/container-linux-config-transpiler/pull/134.

Based on a pre-holiday conversation with @ajeddeloh and @bgilbert