### PR TITLE
Add force flag to node creation

### DIFF
--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -114,6 +114,7 @@ type Networkdunit struct {
 type Node struct {
 	Filesystem string    `json:"filesystem,omitempty"`
 	Group      NodeGroup `json:"group,omitempty"`
+	Overwrite  *bool     `json:"overwrite,omitempty"`
 	Path       string    `json:"path,omitempty"`
 	User       NodeUser  `json:"user,omitempty"`
 }

--- a/doc/configuration-v2_2-experimental.md
+++ b/doc/configuration-v2_2-experimental.md
@@ -50,6 +50,7 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_files_** (list of objects): the list of files to be written.
     * **filesystem** (string): the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to true.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the file contents. Supported schemes are http, https, tftp, s3, and [data][rfc2397]. When using http, it is advisable to use the verification option to ensure the contents haven't been modified.
@@ -65,6 +66,7 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_directories_** (list of objects): the list of directories to be created.
     * **filesystem** (string): the internal identifier of the filesystem in which to create the directory. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path.
     * **_mode_** (integer): the directory's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0755 -> 493).
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
@@ -75,6 +77,7 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_links_** (list of objects): the list of links to be created
     * **filesystem** (string): the internal identifier of the filesystem in which to write the link. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -310,6 +310,9 @@
             "path": {
               "type": "string"
             },
+            "overwrite": {
+              "type": ["boolean", "null"]
+            },
             "user": {
               "type": "object",
               "properties": {

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -23,6 +23,8 @@ func init() {
 	register.Register(register.PositiveTest, CreateFileOnRoot())
 	register.Register(register.PositiveTest, UserGroupByID_2_0_0())
 	register.Register(register.PositiveTest, UserGroupByID_2_1_0())
+	register.Register(register.PositiveTest, ForceFileCreation())
+	register.Register(register.PositiveTest, ForceFileCreationNoOverwrite())
 	// TODO: Investigate why ignition's C code hates our environment
 	// register.Register(register.PositiveTest, UserGroupByName_2_1_0())
 }
@@ -156,6 +158,93 @@ func UserGroupByName_2_1_0() types.Test {
 				Group:     500,
 			},
 			Contents: "example file\n",
+		},
+	})
+
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
+}
+
+func ForceFileCreation() types.Test {
+	name := "Force File Creation"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "2.2.0-experimental" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "http://127.0.0.1:8080/contents"
+	      },
+		  "overwrite": true
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+			Contents: "hello, world",
+		},
+	})
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+			Contents: "asdf\nfdsa",
+		},
+	})
+
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
+}
+
+func ForceFileCreationNoOverwrite() types.Test {
+	name := "Force File Creation No Overwrite"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "2.2.0-experimental" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "http://127.0.0.1:8080/contents"
+	      }
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+			Contents: "hello, world",
+		},
+	})
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+			Contents: "asdf\nfdsa",
 		},
 	})
 


### PR DESCRIPTION
When creating a filesystem node (i.e. file/dir/link) sometimes a preexisting node will cause this to fail. This PR adds a `force` flag to the `node` object to delete preexisting nodes when set.

This PR was prompted by @ethernetdan who wanted to set the timezone via:

```
{
 "ignition": { "version": "2.1.0" },
 "storage": {
   "links": [{
     "filesystem": "root",
     "path": "/etc/localtime",
     "target": "/usr/share/zoneinfo/US/Pacific"
   }]
 }
}
```

which failed via:

```
[    9.364136] ignition[416]: files: createFilesystemsFiles: createFiles: op(a): [failed]   writing link "/etc/localtime" -> "/usr/share/zoneinfo/US/Arizona": symlink /usr/share/zoneinfo/US/Arizona /sysroot/etc/localtime: file exists
```
  
Fixes https://github.com/coreos/bugs/issues/2311