### PR TITLE
Add field for user-provided raid options

### DIFF
--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -168,11 +168,14 @@ type PasswdUser struct {
 }
 
 type Raid struct {
-	Devices []Device `json:"devices,omitempty"`
-	Level   string   `json:"level,omitempty"`
-	Name    string   `json:"name,omitempty"`
-	Spares  int      `json:"spares,omitempty"`
+	Devices []Device     `json:"devices,omitempty"`
+	Level   string       `json:"level,omitempty"`
+	Name    string       `json:"name,omitempty"`
+	Options []RaidOption `json:"options,omitempty"`
+	Spares  int          `json:"spares,omitempty"`
 }
+
+type RaidOption string
 
 type SSHAuthorizedKey string
 

--- a/doc/configuration-v2_2-experimental.md
+++ b/doc/configuration-v2_2-experimental.md
@@ -34,6 +34,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
     * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
     * **_spares_** (integer): the number of spares (if applicable) in the array.
+    * **_options_** (list of strings): any additional options to be passed to mdadm.
   * **_filesystems_** (list of objects): the list of filesystems to be configured and/or used in the "files" section. Either "mount" or "path" needs to be specified.
     * **_name_** (string): the identifier for the filesystem, internal to Ignition. This is only required if the filesystem needs to be referenced in the "files" section.
     * **_mount_** (object): contains the set of mount and formatting options for the filesystem. A non-null entry indicates that the filesystem should be mounted before it is used by Ignition.

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -255,6 +255,10 @@ func (s stage) createRaids(config types.Config) error {
 			args = append(args, "--spare-devices", fmt.Sprintf("%d", md.Spares))
 		}
 
+		for _, o := range md.Options {
+			args = append(args, string(o))
+		}
+
 		for _, dev := range md.Devices {
 			args = append(args, util.DeviceAlias(string(dev)))
 		}

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -156,6 +156,12 @@
               "items": {
                 "type": "string"
               }
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },


### PR DESCRIPTION
Allows users to provide additional arguments to `mdadm`. Not sure if there's any validation we can do on the options field.

Still needs to be tested.