### PR TITLE
blackbox: validate configs that we expect to be valid

### DIFF
--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pin/tftp"
 
+	"github.com/coreos/ignition/config"
 	"github.com/coreos/ignition/tests/register"
 	"github.com/coreos/ignition/tests/types"
 
@@ -234,6 +235,18 @@ func outer(t *testing.T, test types.Test, negativeTests bool) {
 	for _, d := range test.MntDevices {
 		if strings.Contains(test.Config, d.Substitution) {
 			t.Fatalf("Didn't find a drive with label: %s", d.Substitution)
+		}
+	}
+
+	// If we're not expecting the config to be bad, make sure it passes
+	// validation.
+	if !test.ConfigShouldBeBad {
+		_, rpt, err := config.Parse([]byte(test.Config))
+		if rpt.IsFatal() {
+			t.Fatalf("test has bad config: %s", rpt.String())
+		}
+		if err != nil {
+			t.Fatalf("error parsing config: %v", err)
 		}
 	}
 

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -176,9 +176,9 @@ func AppendConfigWithMissingFileHTTP() types.Test {
 	  "ignition": {
 	    "version": "2.1.0",
 	    "config": {
-	      "append": {
+	      "append": [{
 	        "source": "http://127.0.0.1:8080/asdf"
-	      }
+	      }]
 	    }
 	  }
 	}`
@@ -199,9 +199,9 @@ func AppendConfigWithMissingFileTFTP() types.Test {
 	  "ignition": {
 	    "version": "2.1.0",
 	    "config": {
-	      "append": {
+	      "append": [{
 	        "source": "tftp://127.0.0.1:69/asdf"
-	      }
+	      }]
 	    }
 	  }
 	}`
@@ -222,9 +222,9 @@ func AppendConfigWithMissingFileOEM() types.Test {
 	  "ignition": {
 	    "version": "2.1.0",
 	    "config": {
-	      "append": {
+	      "append": [{
 	        "source": "oem:///asdf"
-	      }
+	      }]
 	    }
 	  }
 	}`

--- a/tests/negative/general/invalid_version.go
+++ b/tests/negative/general/invalid_version.go
@@ -38,9 +38,10 @@ func InvalidVersion() types.Test {
 	}`
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }

--- a/tests/negative/networkd/dropins.go
+++ b/tests/negative/networkd/dropins.go
@@ -41,9 +41,10 @@ func NetworkdDropinInvalidExtension() types.Test {
 	}`
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }

--- a/tests/negative/regression/filesystem.go
+++ b/tests/negative/regression/filesystem.go
@@ -31,7 +31,7 @@ func VFATIgnoresWipeFilesystem() types.Test {
 	out := in
 	mntDevices := []types.MntDevice{
 		{
-			Label:        "EFI-SYSTEM",
+			Label:        "OEM",
 			Substitution: "$DEVICE",
 		},
 	}
@@ -43,7 +43,7 @@ func VFATIgnoresWipeFilesystem() types.Test {
                                         "device": "$DEVICE",
                                         "format": "vfat",
                                         "wipeFilesystem": false
-                                }}],
+                                }}]
                         }
         }`
 

--- a/tests/negative/storage/no_device.go
+++ b/tests/negative/storage/no_device.go
@@ -43,10 +43,11 @@ func NoDevice() types.Test {
 	}`
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }
 
@@ -64,16 +65,17 @@ func NoDeviceWithForce() types.Test {
 						"force": true
 					}
 				},
-				"name": "foobar",
+				"name": "foobar"
 			}]
 		}
 	}`
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }
 
@@ -95,10 +97,11 @@ func NoDeviceWithWipeFilesystemTrue() types.Test {
 	}`
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }
 
@@ -120,9 +123,10 @@ func NoDeviceWithWipeFilesystemFalse() types.Test {
 	}`
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }

--- a/tests/negative/storage/no_filesystem_type.go
+++ b/tests/negative/storage/no_filesystem_type.go
@@ -48,11 +48,12 @@ func NoFilesystemType() types.Test {
 	}`
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		MntDevices:        mntDevices,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }
 
@@ -76,17 +77,18 @@ func NoFilesystemTypeWithForce() types.Test {
 						"force": true
 					}
 				},
-				"name": "foobar",
+				"name": "foobar"
 			}]
 		}
 	}`
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		MntDevices:        mntDevices,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }
 
@@ -114,10 +116,11 @@ func NoFilesystemTypeWithWipeFilesystem() types.Test {
 	}`
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		MntDevices:        mntDevices,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }

--- a/tests/negative/timeouts/timeouts.go
+++ b/tests/negative/timeouts/timeouts.go
@@ -70,7 +70,7 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 			"version": "2.1.0",
 			"timeouts": {
 				"httpResponseHeaders": 1,
-				"httpTotal": 10,
+				"httpTotal": 10
 			}
 		},
 		"storage": {

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -443,9 +443,10 @@ func EmptyUserdata() types.Test {
 	config := ``
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		ConfigShouldBeBad: true,
 	}
 }

--- a/tests/positive/general/preemption.go
+++ b/tests/positive/general/preemption.go
@@ -119,10 +119,11 @@ func makePreemptTest(components string) types.Test {
 	}
 
 	return types.Test{
-		Name:           name,
-		In:             in,
-		Out:            out,
-		Config:         config,
-		SystemDirFiles: systemFiles,
+		Name:              name,
+		In:                in,
+		Out:               out,
+		Config:            config,
+		SystemDirFiles:    systemFiles,
+		ConfigShouldBeBad: true,
 	}
 }

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -93,6 +93,7 @@ type Test struct {
 	OEMLookasideFiles []File
 	SystemDirFiles    []File
 	Config            string
+	ConfigShouldBeBad bool
 }
 
 func (ps Partitions) GetPartition(label string) *Partition {


### PR DESCRIPTION
There was a class of negative tests in the blackbox tests that had invalid configs, but passed because we were expecting Ignition to fail. This adds a check to manually validate configs we expect to be correct before running Ignition.