### PR TITLE
Append to files

### DIFF
--- a/config/translate.go
+++ b/config/translate.go
@@ -105,8 +105,8 @@ func TranslateFromV1(old v1.Config) types.Config {
 				Node: types.Node{
 					Filesystem: filesystem.Name,
 					Path:       string(oldFile.Path),
-					User:       types.NodeUser{ID: intToPtr(oldFile.Uid)},
-					Group:      types.NodeGroup{ID: intToPtr(oldFile.Gid)},
+					User:       &types.NodeUser{ID: intToPtr(oldFile.Uid)},
+					Group:      &types.NodeGroup{ID: intToPtr(oldFile.Gid)},
 				},
 				FileEmbedded1: types.FileEmbedded1{
 					Mode: intToPtr(int(oldFile.Mode)),
@@ -321,8 +321,8 @@ func TranslateFromV2_0(old v2_0.Config) types.Config {
 			Node: types.Node{
 				Filesystem: oldFile.Filesystem,
 				Path:       string(oldFile.Path),
-				User:       types.NodeUser{ID: intToPtr(oldFile.User.Id)},
-				Group:      types.NodeGroup{ID: intToPtr(oldFile.Group.Id)},
+				User:       &types.NodeUser{ID: intToPtr(oldFile.User.Id)},
+				Group:      &types.NodeGroup{ID: intToPtr(oldFile.Group.Id)},
 			},
 			FileEmbedded1: types.FileEmbedded1{
 				Mode: intToPtr(int(oldFile.Mode)),
@@ -519,14 +519,14 @@ func TranslateFromV2_1(old v2_1.Config) types.Config {
 		}
 		return res
 	}
-	translateNodeGroup := func(old v2_1.NodeGroup) types.NodeGroup {
-		return types.NodeGroup{
+	translateNodeGroup := func(old v2_1.NodeGroup) *types.NodeGroup {
+		return &types.NodeGroup{
 			ID:   old.ID,
 			Name: old.Name,
 		}
 	}
-	translateNodeUser := func(old v2_1.NodeUser) types.NodeUser {
-		return types.NodeUser{
+	translateNodeUser := func(old v2_1.NodeUser) *types.NodeUser {
+		return &types.NodeUser{
 			ID:   old.ID,
 			Name: old.Name,
 		}

--- a/config/translate_test.go
+++ b/config/translate_test.go
@@ -195,8 +195,8 @@ func TestTranslateFromV1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "_translate-filesystem-0",
 								Path:       "/opt/file1",
-								User:       types.NodeUser{ID: intToPtr(500)},
-								Group:      types.NodeGroup{ID: intToPtr(501)},
+								User:       &types.NodeUser{ID: intToPtr(500)},
+								Group:      &types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0664),
@@ -212,8 +212,8 @@ func TestTranslateFromV1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "_translate-filesystem-0",
 								Path:       "/opt/file2",
-								User:       types.NodeUser{ID: intToPtr(502)},
-								Group:      types.NodeGroup{ID: intToPtr(503)},
+								User:       &types.NodeUser{ID: intToPtr(502)},
+								Group:      &types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0644),
@@ -229,8 +229,8 @@ func TestTranslateFromV1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "_translate-filesystem-1",
 								Path:       "/opt/file3",
-								User:       types.NodeUser{ID: intToPtr(1000)},
-								Group:      types.NodeGroup{ID: intToPtr(1001)},
+								User:       &types.NodeUser{ID: intToPtr(1000)},
+								Group:      &types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0400),
@@ -706,8 +706,8 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-0",
 								Path:       "/opt/file1",
-								User:       types.NodeUser{ID: intToPtr(500)},
-								Group:      types.NodeGroup{ID: intToPtr(501)},
+								User:       &types.NodeUser{ID: intToPtr(500)},
+								Group:      &types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0664),
@@ -723,8 +723,8 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-0",
 								Path:       "/opt/file2",
-								User:       types.NodeUser{ID: intToPtr(502)},
-								Group:      types.NodeGroup{ID: intToPtr(503)},
+								User:       &types.NodeUser{ID: intToPtr(502)},
+								Group:      &types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0644),
@@ -740,8 +740,8 @@ func TestTranslateFromV2_0(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-1",
 								Path:       "/opt/file3",
-								User:       types.NodeUser{ID: intToPtr(1000)},
-								Group:      types.NodeGroup{ID: intToPtr(1001)},
+								User:       &types.NodeUser{ID: intToPtr(1000)},
+								Group:      &types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0400),
@@ -1328,8 +1328,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-0",
 								Path:       "/opt/file1",
-								User:       types.NodeUser{ID: intToPtr(500)},
-								Group:      types.NodeGroup{ID: intToPtr(501)},
+								User:       &types.NodeUser{ID: intToPtr(500)},
+								Group:      &types.NodeGroup{ID: intToPtr(501)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0664),
@@ -1348,8 +1348,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-0",
 								Path:       "/opt/file2",
-								User:       types.NodeUser{ID: intToPtr(502)},
-								Group:      types.NodeGroup{ID: intToPtr(503)},
+								User:       &types.NodeUser{ID: intToPtr(502)},
+								Group:      &types.NodeGroup{ID: intToPtr(503)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0644),
@@ -1366,8 +1366,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-1",
 								Path:       "/opt/file3",
-								User:       types.NodeUser{ID: intToPtr(1000)},
-								Group:      types.NodeGroup{ID: intToPtr(1001)},
+								User:       &types.NodeUser{ID: intToPtr(1000)},
+								Group:      &types.NodeGroup{ID: intToPtr(1001)},
 							},
 							FileEmbedded1: types.FileEmbedded1{
 								Mode: intToPtr(0400),
@@ -1432,8 +1432,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-1",
 								Path:       "/opt/dir1",
-								User:       types.NodeUser{ID: intToPtr(500)},
-								Group:      types.NodeGroup{ID: intToPtr(501)},
+								User:       &types.NodeUser{ID: intToPtr(500)},
+								Group:      &types.NodeGroup{ID: intToPtr(501)},
 							},
 							DirectoryEmbedded1: types.DirectoryEmbedded1{
 								Mode: intToPtr(0664),
@@ -1443,8 +1443,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-2",
 								Path:       "/opt/dir2",
-								User:       types.NodeUser{ID: intToPtr(502)},
-								Group:      types.NodeGroup{ID: intToPtr(503)},
+								User:       &types.NodeUser{ID: intToPtr(502)},
+								Group:      &types.NodeGroup{ID: intToPtr(503)},
 							},
 							DirectoryEmbedded1: types.DirectoryEmbedded1{
 								Mode: intToPtr(0644),
@@ -1454,8 +1454,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-2",
 								Path:       "/opt/dir3",
-								User:       types.NodeUser{ID: intToPtr(1000)},
-								Group:      types.NodeGroup{ID: intToPtr(1001)},
+								User:       &types.NodeUser{ID: intToPtr(1000)},
+								Group:      &types.NodeGroup{ID: intToPtr(1001)},
 							},
 							DirectoryEmbedded1: types.DirectoryEmbedded1{
 								Mode: intToPtr(0400),
@@ -1517,8 +1517,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-1",
 								Path:       "/opt/link1",
-								User:       types.NodeUser{ID: intToPtr(500)},
-								Group:      types.NodeGroup{ID: intToPtr(501)},
+								User:       &types.NodeUser{ID: intToPtr(500)},
+								Group:      &types.NodeGroup{ID: intToPtr(501)},
 							},
 							LinkEmbedded1: types.LinkEmbedded1{
 								Hard:   false,
@@ -1529,8 +1529,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-2",
 								Path:       "/opt/link2",
-								User:       types.NodeUser{ID: intToPtr(502)},
-								Group:      types.NodeGroup{ID: intToPtr(503)},
+								User:       &types.NodeUser{ID: intToPtr(502)},
+								Group:      &types.NodeGroup{ID: intToPtr(503)},
 							},
 							LinkEmbedded1: types.LinkEmbedded1{
 								Hard:   true,
@@ -1541,8 +1541,8 @@ func TestTranslateFromV2_1(t *testing.T) {
 							Node: types.Node{
 								Filesystem: "filesystem-2",
 								Path:       "/opt/link3",
-								User:       types.NodeUser{ID: intToPtr(1000)},
-								Group:      types.NodeGroup{ID: intToPtr(1001)},
+								User:       &types.NodeUser{ID: intToPtr(1000)},
+								Group:      &types.NodeGroup{ID: intToPtr(1001)},
 							},
 							LinkEmbedded1: types.LinkEmbedded1{
 								Hard:   true,

--- a/config/types/file.go
+++ b/config/types/file.go
@@ -22,8 +22,16 @@ import (
 )
 
 var (
+	ErrAppendAndOverwrite = errors.New("cannot set both append and overwrite to true")
 	ErrCompressionInvalid = errors.New("invalid compression method")
 )
+
+func (f File) Validate() report.Report {
+	if f.Overwrite != nil && *f.Overwrite && f.Append {
+		return report.ReportFromError(ErrAppendAndOverwrite, report.EntryError)
+	}
+	return report.Report{}
+}
 
 func (f File) ValidateMode() report.Report {
 	r := report.Report{}

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -51,6 +51,7 @@ type FileContents struct {
 }
 
 type FileEmbedded1 struct {
+	Append   bool         `json:"append,omitempty"`
 	Contents FileContents `json:"contents,omitempty"`
 	Mode     *int         `json:"mode,omitempty"`
 }

--- a/config/types/schema.go
+++ b/config/types/schema.go
@@ -112,11 +112,11 @@ type Networkdunit struct {
 }
 
 type Node struct {
-	Filesystem string    `json:"filesystem,omitempty"`
-	Group      NodeGroup `json:"group,omitempty"`
-	Overwrite  *bool     `json:"overwrite,omitempty"`
-	Path       string    `json:"path,omitempty"`
-	User       NodeUser  `json:"user,omitempty"`
+	Filesystem string     `json:"filesystem,omitempty"`
+	Group      *NodeGroup `json:"group,omitempty"`
+	Overwrite  *bool      `json:"overwrite,omitempty"`
+	Path       string     `json:"path,omitempty"`
+	User       *NodeUser  `json:"user,omitempty"`
 }
 
 type NodeGroup struct {

--- a/doc/configuration-v2_2-experimental.md
+++ b/doc/configuration-v2_2-experimental.md
@@ -51,6 +51,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **filesystem** (string): the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier.
     * **path** (string): the absolute path to the file.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to true.
+    * **_append_** (boolean): whether to append to the specified file. Creates a new file if nothing exists at the path. Cannot be set if overwrite is set to true.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the file contents. Supported schemes are http, https, tftp, s3, and [data][rfc2397]. When using http, it is advisable to use the verification option to ensure the contents haven't been modified.

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -123,6 +123,11 @@ func (tmp fileEntry) create(l *log.Logger, u util.Util) error {
 		return fmt.Errorf("failed to resolve file %q", f.Path)
 	}
 
+	msg := "writing file %q"
+	if f.Append {
+		msg = "appending to file %q"
+	}
+
 	if err := l.LogOp(
 		func() error {
 			err := u.DeletePathOnOverwrite(f.Node)
@@ -131,7 +136,7 @@ func (tmp fileEntry) create(l *log.Logger, u util.Util) error {
 			}
 
 			return u.PerformFetch(fetchOp)
-		}, "writing file %q", string(f.Path),
+		}, msg, string(f.Path),
 	); err != nil {
 		return fmt.Errorf("failed to create file %q: %v", fetchOp.Path, err)
 	}

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -28,7 +28,6 @@ import (
 	"github.com/coreos/ignition/config/types"
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/resource"
-	internalUtil "github.com/coreos/ignition/internal/util"
 )
 
 const (
@@ -39,12 +38,11 @@ const (
 type FetchOp struct {
 	Hash         hash.Hash
 	Path         string
-	Mode         os.FileMode
-	Uid          int
-	Gid          int
 	Url          url.URL
+	Mode         *int
 	FetchOptions resource.FetchOptions
 	Overwrite    *bool
+	Node         types.Node
 }
 
 // newHashedReader returns a new ReadCloser that also writes to the provided hash.
@@ -87,22 +85,12 @@ func (u Util) PrepareFetch(l *log.Logger, f types.File) *FetchOp {
 		}
 	}
 
-	f.User.ID, f.Group.ID = u.GetUserGroupID(l, f.User, f.Group)
-	if f.User.ID == nil || f.Group.ID == nil {
-		return nil
-	}
-
-	if f.Mode == nil {
-		f.Mode = internalUtil.IntToPtr(0)
-	}
-
 	return &FetchOp{
 		Path:      f.Path,
 		Hash:      hasher,
-		Mode:      os.FileMode(*f.Mode),
-		Uid:       *f.User.ID,
-		Gid:       *f.Group.ID,
+		Node:      f.Node,
 		Url:       *uri,
+		Mode:      f.Mode,
 		Overwrite: f.Overwrite,
 		FetchOptions: resource.FetchOptions{
 			Hash:        hasher,
@@ -128,7 +116,12 @@ func (u Util) WriteLink(s types.Link) error {
 		return err
 	}
 
-	if err := os.Lchown(path, *s.User.ID, *s.Group.ID); err != nil {
+	uid, gid, err := u.ResolveNodeUidAndGid(s.Node, 0, 0)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Lchown(path, uid, gid); err != nil {
 		return err
 	}
 
@@ -195,11 +188,22 @@ func (u Util) PerformFetch(f *FetchOp) error {
 	// by using syscall.Fchown() and syscall.Fchmod()
 
 	// Ensure the ownership and mode are as requested (since WriteFile can be affected by sticky bit)
-	if err = os.Chown(tmp.Name(), f.Uid, f.Gid); err != nil {
+
+	mode := os.FileMode(0)
+	if f.Mode != nil {
+		mode = os.FileMode(*f.Mode)
+	}
+
+	uid, gid, err := u.ResolveNodeUidAndGid(f.Node, 0, 0)
+	if err != nil {
 		return err
 	}
 
-	if err = os.Chmod(tmp.Name(), f.Mode); err != nil {
+	if err = os.Chown(tmp.Name(), uid, gid); err != nil {
+		return err
+	}
+
+	if err = os.Chmod(tmp.Name(), mode); err != nil {
 		return err
 	}
 
@@ -210,49 +214,64 @@ func (u Util) PerformFetch(f *FetchOp) error {
 	return nil
 }
 
-func (u Util) GetUserGroupID(l *log.Logger, user types.NodeUser, group types.NodeGroup) (*int, *int) {
-	if user.Name != "" {
-		usr, err := u.userLookup(user.Name)
-		if err != nil {
-			l.Crit("No such user %q: %v", user.Name, err)
-			return nil, nil
-		}
-		uid, err := strconv.ParseInt(usr.Uid, 0, 0)
-		if err != nil {
-			l.Crit("Couldn't parse uid %q: %v", usr.Uid, err)
-			return nil, nil
-		}
-		tmp := int(uid)
-		user.ID = &tmp
-	}
-	if group.Name != "" {
-		g, err := u.groupLookup(group.Name)
-		if err != nil {
-			l.Crit("No such group %q: %v", group.Name, err)
-			return nil, nil
-		}
-		gid, err := strconv.ParseInt(g.Gid, 0, 0)
-		if err != nil {
-			l.Crit("Couldn't parse gid %q: %v", g.Gid, err)
-			return nil, nil
-		}
-		tmp := int(gid)
-		group.ID = &tmp
-	}
-
-	if user.ID == nil {
-		user.ID = internalUtil.IntToPtr(0)
-	}
-	if group.ID == nil {
-		group.ID = internalUtil.IntToPtr(0)
-	}
-
-	return user.ID, group.ID
-}
-
 // MkdirForFile helper creates the directory components of path.
 func MkdirForFile(path string) error {
 	return os.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions)
+}
+
+// ResolveNodeUidAndGid attempts to convert a types.Node into a concrete uid and
+// gid. If the node has the User.ID field set, that's used for the uid. If the
+// node has the User.Name field set, a username -> uid lookup is performed. If
+// neither are set, it returns the passed in defaultUid. The logic is identical
+// for gids with equivalent fields.
+func (u Util) ResolveNodeUidAndGid(n types.Node, defaultUid, defaultGid int) (int, int, error) {
+	var err error
+	uid, gid := defaultUid, defaultGid
+	if n.User != nil {
+		if n.User.ID != nil {
+			uid = *n.User.ID
+		} else if n.User.Name != "" {
+			uid, err = u.getUserID(n.User.Name)
+			if err != nil {
+				return 0, 0, err
+			}
+		}
+	}
+	if n.Group != nil {
+		if n.Group.ID != nil {
+			gid = *n.Group.ID
+		} else if n.Group.Name != "" {
+			gid, err = u.getGroupID(n.Group.Name)
+			if err != nil {
+				return 0, 0, err
+			}
+		}
+	}
+	return uid, gid, nil
+}
+
+func (u Util) getUserID(name string) (int, error) {
+	usr, err := u.userLookup(name)
+	if err != nil {
+		return 0, fmt.Errorf("No such user %q: %v", name, err)
+	}
+	uid, err := strconv.ParseInt(usr.Uid, 0, 0)
+	if err != nil {
+		return 0, fmt.Errorf("Couldn't parse uid %q: %v", usr.Uid, err)
+	}
+	return int(uid), nil
+}
+
+func (u Util) getGroupID(name string) (int, error) {
+	g, err := u.groupLookup(name)
+	if err != nil {
+		return 0, fmt.Errorf("No such group %q: %v", name, err)
+	}
+	gid, err := strconv.ParseInt(g.Gid, 0, 0)
+	if err != nil {
+		return 0, fmt.Errorf("Couldn't parse gid %q: %v", g.Gid, err)
+	}
+	return int(gid), nil
 }
 
 func (u Util) DeletePathOnOverwrite(n types.Node) error {

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/ignition/config/types"
+	internalUtil "github.com/coreos/ignition/internal/util"
 
 	"github.com/vincent-petithory/dataurl"
 )
@@ -38,7 +39,7 @@ func FileFromSystemdUnit(unit types.Unit) (*FetchOp, error) {
 	return &FetchOp{
 		Path: filepath.Join(SystemdUnitsPath(), string(unit.Name)),
 		Url:  *u,
-		Mode: DefaultFilePermissions,
+		Mode: internalUtil.IntToPtr(int(DefaultFilePermissions)),
 	}, nil
 }
 
@@ -50,7 +51,7 @@ func FileFromNetworkdUnit(unit types.Networkdunit) (*FetchOp, error) {
 	return &FetchOp{
 		Path: filepath.Join(NetworkdUnitsPath(), string(unit.Name)),
 		Url:  *u,
-		Mode: DefaultFilePermissions,
+		Mode: internalUtil.IntToPtr(int(DefaultFilePermissions)),
 	}, nil
 }
 
@@ -62,7 +63,7 @@ func FileFromSystemdUnitDropin(unit types.Unit, dropin types.SystemdDropin) (*Fe
 	return &FetchOp{
 		Path: filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
 		Url:  *u,
-		Mode: DefaultFilePermissions,
+		Mode: internalUtil.IntToPtr(int(DefaultFilePermissions)),
 	}, nil
 }
 
@@ -74,7 +75,7 @@ func FileFromNetworkdUnitDropin(unit types.Networkdunit, dropin types.NetworkdDr
 	return &FetchOp{
 		Path: filepath.Join(NetworkdDropinsPath(string(unit.Name)), string(dropin.Name)),
 		Url:  *u,
-		Mode: DefaultFilePermissions,
+		Mode: internalUtil.IntToPtr(int(DefaultFilePermissions)),
 	}, nil
 }
 

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -314,7 +314,7 @@
               "type": ["boolean", "null"]
             },
             "user": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "id": {
                   "type": ["integer", "null"]
@@ -325,7 +325,7 @@
               }
             },
             "group": {
-              "type": "object",
+              "type": ["object", "null"],
               "properties": {
                 "id": {
                   "type": ["integer", "null"]

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -186,6 +186,9 @@
                 },
                 "contents": {
                   "$ref": "#/definitions/storage/definitions/file-contents"
+                },
+                "append": {
+                    "type": "boolean"
                 }
               }
             }

--- a/tests/negative/files/append.go
+++ b/tests/negative/files/append.go
@@ -1,0 +1,99 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, AppendToDirectory())
+	register.Register(register.NegativeTest, AppendAndOverwrite())
+}
+
+func AppendToDirectory() types.Test {
+	name := "Append To Directory"
+	in := types.GetBaseDisk()
+	out := in
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "EFI-SYSTEM",
+			Substitution: "$DEVICE",
+		},
+	}
+
+	config := `{
+	    "ignition": {"version": "2.2.0-experimental"},
+	    "storage": {
+	      "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:,hello%20world%0A" },
+	      "append": true
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddDirectories("ROOT", []types.Directory{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+		},
+	})
+
+	return types.Test{
+		Name:       name,
+		In:         in,
+		Out:        out,
+		MntDevices: mntDevices,
+		Config:     config,
+	}
+}
+
+func AppendAndOverwrite() types.Test {
+	name := "Append and Overwrite"
+	in := types.GetBaseDisk()
+	out := in
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "EFI-SYSTEM",
+			Substitution: "$DEVICE",
+		},
+	}
+
+	config := `{
+		"ignition": {"version": "2.2.0-experimental"},
+		"storage": {
+		  "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:,hello%20world%0A" },
+	      "append": true,
+		  "overwrite": true
+	    }]
+	  }
+	}`
+
+	return types.Test{
+		Name:              name,
+		In:                in,
+		Out:               out,
+		MntDevices:        mntDevices,
+		Config:            config,
+		ConfigShouldBeBad: true,
+	}
+}

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -25,6 +25,8 @@ func init() {
 	register.Register(register.PositiveTest, UserGroupByID_2_1_0())
 	register.Register(register.PositiveTest, ForceFileCreation())
 	register.Register(register.PositiveTest, ForceFileCreationNoOverwrite())
+	register.Register(register.PositiveTest, AppendToAFile())
+	register.Register(register.PositiveTest, AppendToNonexistentFile())
 	// TODO: Investigate why ignition's C code hates our environment
 	// register.Register(register.PositiveTest, UserGroupByName_2_1_0())
 }
@@ -245,6 +247,83 @@ func ForceFileCreationNoOverwrite() types.Test {
 				Name:      "bar",
 			},
 			Contents: "asdf\nfdsa",
+		},
+	})
+
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
+}
+
+func AppendToAFile() types.Test {
+	name := "Append to a file"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "2.2.0-experimental" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:,example%20file%0A" },
+	      "user": {"id": 500},
+	      "group": {"id": 500}
+	    },{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:,hello%20world%0A" },
+	      "group": {"id": 0},
+	      "append": true
+	    }]
+	  }
+	}`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+				User:      500,
+				Group:     0,
+			},
+			Contents: "example file\nhello world\n",
+		},
+	})
+
+	return types.Test{
+		Name:   name,
+		In:     in,
+		Out:    out,
+		Config: config,
+	}
+}
+
+func AppendToNonexistentFile() types.Test {
+	name := "Append to a non-existent file"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "2.2.0-experimental" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:,hello%20world%0A" },
+	      "group": {"id": 500},
+	      "append": true
+	    }]
+	  }
+	}`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+				Group:     500,
+			},
+			Contents: "hello world\n",
 		},
 	})
 


### PR DESCRIPTION
Adds an append flag to the file object. When set to true, the contents referenced will be appended to the given file, instead of replacing it. If the file doesn't exist, it will be created. If the mode or ownership is unspecified in the Ignition config, the mode and ownership on the file being appended to will not be changed.

What this looks like:

```
{
  "ignition": { "version": "2.2.0-experimental" },
  "storage": {
    "files": [{
      "filesystem": "root",
      "path": "/foo/bar",
      "contents": { "source": "data:,hello%20world%0A" },
      "append": true
    }]
  }
}
```

Fixes https://github.com/coreos/bugs/issues/1997