### PR TITLE
news: add news for v0.20.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+12-Jan-2018 IGNITION v0.20.1
+
+  Changes
+
+    - Add support for fetching S3 objects from non-default AWS partitions when
+      running in one such partition
+
 13-Dec-2017 IGNITION v0.20.0
 
   Features


### PR DESCRIPTION
I made a new branch on the main repo, `v0.20.1`, to represent the patch release. It contains one commit on top of `v0.20.0`, which is the cherry-picked commit that fixes S3 object retrieval when running in non-default AWS partitions.

This PR is the update to the NEWS file on that branch for the patch release.