### PR TITLE
config/v2_1: use config/v2_1/types in append.go

### DIFF
--- a/.github/tailor.yaml
+++ b/.github/tailor.yaml
@@ -2,7 +2,7 @@ rules:
   - name: commit title
     description: all commit titles must have a scope and be no more than 72 characters
     expression:  |-
-      .commits all(((.title test "^[a-z/*_.-]+: [[:alnum:] -'.:/_,-]+$") and (.title length < 73)) or (.title test "^Revert"))
+      .commits all(((.title test "^[a-z0-9/*_.-]+: [[:alnum:] -'.:/_,-]+$") and (.title length < 73)) or (.title test "^Revert"))
 
   - name: commit description
     description: all commit descriptions must have lines no longer than 72 characters

--- a/config/v2_1/append.go
+++ b/config/v2_1/append.go
@@ -17,7 +17,7 @@ package v2_1
 import (
 	"reflect"
 
-	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/config/v2_1/types"
 )
 
 // Append appends newConfig to oldConfig and returns the result. Appending one

--- a/config/v2_1/append_test.go
+++ b/config/v2_1/append_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 
-	"github.com/coreos/ignition/config/types"
+	"github.com/coreos/ignition/config/v2_1/types"
 )
 
 func TestAppend(t *testing.T) {


### PR DESCRIPTION
The config/v2_1 package should only work with 2.1.0 configs, so change
the import from config/types to config/v2_1/types.

Ignition-the-binary translates all configs to 2.2.0-experimental before appending them, so this change is only for the benefit of Ignition-the-library consumers.

Noticed by @dghubble.