### PR TITLE
Blackbox test improvements

### DIFF
--- a/.github/tailor.yaml
+++ b/.github/tailor.yaml
@@ -2,7 +2,7 @@ rules:
   - name: commit title
     description: all commit titles must have a scope and be no more than 72 characters
     expression:  |-
-      .commits all(((.title test "^[a-z/*_.-]+: [[:alnum:] -'.:/_-]+$") and (.title length < 73)) or (.title test "^Revert"))
+      .commits all(((.title test "^[a-z/*_.-]+: [[:alnum:] -'.:/_,-]+$") and (.title length < 73)) or (.title test "^Revert"))
 
   - name: commit description
     description: all commit descriptions must have lines no longer than 72 characters

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -83,7 +83,7 @@ func runIgnition(t *testing.T, stage, root, cwd string, appendEnv []string, expe
 	cmd.Env = append(os.Environ(), appendEnv...)
 	out, err := cmd.CombinedOutput()
 	t.Logf("PID: %d", cmd.Process.Pid)
-	if err != nil && !expectFail {
+	if (err != nil && !expectFail) || strings.Contains(string(out), "panic") {
 		t.Fatal(args, err, string(out))
 	}
 	return err == nil

--- a/tests/negative/files/preexisting_nodes.go
+++ b/tests/negative/files/preexisting_nodes.go
@@ -189,14 +189,6 @@ func ForceFileCreationOverNonemptyDir() types.Test {
 	    }]
 	  }
 	}`
-	in[0].Partitions.AddDirectories("ROOT", []types.Directory{
-		{
-			Node: types.Node{
-				Directory: "foo",
-				Name:      "bar",
-			},
-		},
-	})
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -236,14 +228,6 @@ func ForceLinkCreationOverNonemptyDir() types.Test {
 	    }]
 	  }
 	}`
-	in[0].Partitions.AddDirectories("ROOT", []types.Directory{
-		{
-			Node: types.Node{
-				Directory: "foo",
-				Name:      "bar",
-			},
-		},
-	})
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/files/directory.go
+++ b/tests/positive/files/directory.go
@@ -109,14 +109,6 @@ func ForceDirCreationOverNonemptyDir() types.Test {
 	    }]
 	  }
 	}`
-	in[0].Partitions.AddDirectories("ROOT", []types.Directory{
-		{
-			Node: types.Node{
-				Directory: "foo",
-				Name:      "bar",
-			},
-		},
-	})
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -30,12 +30,12 @@ const (
 type File struct {
 	Node
 	Contents string
-	Mode     string
+	Mode     int
 }
 
 type Directory struct {
 	Node
-	Mode string
+	Mode int
 }
 
 type Link struct {

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -159,6 +159,7 @@ func validateFile(t *testing.T, partition *types.Partition, file types.File) {
 		}
 	}
 
+	validateMode(t, path, file.Mode)
 	validateNode(t, fileInfo, file.Node)
 }
 
@@ -222,19 +223,16 @@ func validateLink(t *testing.T, partition *types.Partition, link types.Link) {
 	validateNode(t, linkInfo, link.Node)
 }
 
-func validateMode(t *testing.T, path string, mode string) {
-	if mode != "" {
+func validateMode(t *testing.T, path string, mode int) {
+	if mode != 0 {
 		fileInfo, err := os.Stat(path)
 		if err != nil {
 			t.Error("Error running stat on node", path, err)
 			return
 		}
 
-		// converts to a string containing the base-10 mode
-		actualMode := strconv.Itoa(int(fileInfo.Mode()) & 07777)
-
-		if mode != actualMode {
-			t.Error("Node Mode does not match", path, mode, actualMode)
+		if fileInfo.Mode() != os.FileMode(mode) {
+			t.Error("Node Mode does not match", path, mode, fileInfo.Mode())
 		}
 	}
 }


### PR DESCRIPTION
Fixes a few things I noticed in the blackbox tests:
- do a `strings.Contains` on Ignition's output for `panic`, fail if it's found. Negative tests are expecting Ignition to exit with a non-zero exit code, so panics were unnoticed.
- create directories and links specified in the input disks of the tests
- store the mode of files and directories as an int

These fixes are required for the blackbox tests in the append flag PR to pass.