### PR TITLE
tests/negative/security/tls: disable tls handshake error logging

### DIFF
--- a/tests/negative/security/tls.go
+++ b/tests/negative/security/tls.go
@@ -17,6 +17,8 @@ package security
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 
@@ -31,6 +33,7 @@ func init() {
 	}
 	config := &tls.Config{Certificates: []tls.Certificate{cer}}
 	customCAServer.TLS = config
+	customCAServer.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
 	customCAServer.StartTLS()
 
 	register.Register(register.NegativeTest, AppendConfigCustomCert())


### PR DESCRIPTION
The Golang HTTP server automatically logs to stdout if no error logger is
present. This causes TLS handshake errors to be spewed out during negative test
runs. Adds a custom logger to the negative tests HTTPServer which uses an
`ioutil.Discard` writer.