### PR TITLE
news: add news for v0.22.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+09-Feb-2018 IGNITION v0.22.0
+
+  Changes
+
+    - Mark the 2.2.0 config spec as stable
+    - No longer accept configs with version 2.2.0-experimental
+    - Create new 2.3.0-experimental config spec from 2.2.0
+
 26-Jan-2018 IGNITION v0.21.0
 
   Features

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-26-Jan-2017 IGNITION v0.21.0
+26-Jan-2018 IGNITION v0.21.0
 
   Features
 


### PR DESCRIPTION
v0.22.0 marks the `2.2.0` spec as stable, and creates a new `2.3.0-experimental` spec. `2.2.0-experimental` specs will no longer be accepted.

This PR also fixes a typo in the release notes for v0.21.0.