### PR TITLE
news: add news for v0.23.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+12-Mar-2018 IGNITION v0.23.0
+
+  Changes
+
+    - Latest experimental package has been moved from config/types to
+      config/v2_3_experimental.
+    - Each config package's Parse function will now transparently handle any
+      configs of a lesser version than itself (e.g. config/v2_2 will handle a
+      2.0.0 config).
+    - Validation in config/v1 reworked to use config/validate.
+    - Common error types from the config package moved to config/errors.
+
 09-Feb-2018 IGNITION v0.22.0
 
   Changes


### PR DESCRIPTION
This release shouldn't have any user-facing impacts, so the release notes are only calling out the changes that impact consumers of Ignition as a library.