### PR TITLE
 config: avoid some buffer allocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.PHONY: all
+all:
+	./build
 
 .PHONY: vendor
 vendor:

--- a/config/v2_0/types/unit.go
+++ b/config/v2_0/types/unit.go
@@ -15,10 +15,10 @@
 package types
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
@@ -101,7 +101,7 @@ func (n NetworkdUnitName) Validate() report.Report {
 }
 
 func validateUnitContent(content string) error {
-	c := bytes.NewBufferString(content)
+	c := strings.NewReader(content)
 	_, err := unit.Deserialize(c)
 	if err != nil {
 		return fmt.Errorf("invalid unit content: %s", err)

--- a/config/v2_1/types/unit.go
+++ b/config/v2_1/types/unit.go
@@ -15,10 +15,10 @@
 package types
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
@@ -38,6 +38,7 @@ func (u Unit) ValidateContents() report.Report {
 			Kind:    report.EntryError,
 		})
 	}
+
 	return r
 }
 
@@ -99,7 +100,7 @@ func (u Networkdunit) Validate() report.Report {
 }
 
 func validateUnitContent(content string) error {
-	c := bytes.NewBufferString(content)
+	c := strings.NewReader(content)
 	_, err := unit.Deserialize(c)
 	if err != nil {
 		return fmt.Errorf("invalid unit content: %s", err)

--- a/config/v2_2/types/unit.go
+++ b/config/v2_2/types/unit.go
@@ -15,10 +15,10 @@
 package types
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
@@ -121,7 +121,7 @@ func (d NetworkdDropin) Validate() report.Report {
 }
 
 func validateUnitContent(content string) error {
-	c := bytes.NewBufferString(content)
+	c := strings.NewReader(content)
 	_, err := unit.Deserialize(c)
 	if err != nil {
 		return fmt.Errorf("invalid unit content: %s", err)

--- a/config/v2_3_experimental/types/unit.go
+++ b/config/v2_3_experimental/types/unit.go
@@ -15,10 +15,10 @@
 package types
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
@@ -121,7 +121,7 @@ func (d NetworkdDropin) Validate() report.Report {
 }
 
 func validateUnitContent(content string) error {
-	c := bytes.NewBufferString(content)
+	c := strings.NewReader(content)
 	_, err := unit.Deserialize(c)
 	if err != nil {
 		return fmt.Errorf("invalid unit content: %s", err)


### PR DESCRIPTION
strings.NewReader just uses a couple ints to keep track of where it's
reading whereas the bytes variant copies all of the contents of the
string.

This is a microoptimization, but I think it's also mildly cleaner code.

I double checked my understanding that strings.NewReader doesn't allocate so much in the [playground](https://play.golang.org/p/ncF4-yYei0h). In reality, units are pretty small so the difference will be minuscule. 