### PR TITLE
build and build_releases VERSION override

### DIFF
--- a/build
+++ b/build
@@ -5,8 +5,13 @@ set -eu
 NAME="ignition"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}"
-VERSION=$(git describe --dirty)
 GLDFLAGS=${GLDFLAGS:-}
+
+if [ -z ${VERSION+a} ]; then
+	echo "Using version from git..."
+	VERSION=$(git describe --dirty)
+fi
+
 GLDFLAGS+="-X github.com/coreos/ignition/internal/version.Raw=${VERSION}"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then

--- a/build_releases
+++ b/build_releases
@@ -5,8 +5,13 @@ set -eu
 NAME="ignition"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}"
-VERSION=$(git describe --dirty)
 GLDFLAGS=${GLDFLAGS:-}
+
+if [ -z ${VERSION+a} ]; then
+	echo "Using version from git..."
+	VERSION=$(git describe --dirty)
+fi
+
 GLDFLAGS+="-X github.com/coreos/ignition/internal/version.Raw=${VERSION}"
 
 if [[ -n "$(git status -s)" ]]; then


### PR DESCRIPTION
Currently a source checkout requires extra work to build the artifacts. Example:

```
[steve@qward ignition-0.23.0] $ ./build
Using version from git...
fatal: Not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

Overriding doesn't work out of the box:

```
[steve@qward ignition-0.23.0]$ VERSION=1 ./build
fatal: Not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

This change allows for ``VERSION`` to be overridden in both ``build`` and ``build_releases`` via:

```
[steve@qward ignition-0.23.0] $ VERSION=0.23.0 ./build
```

If ``VERSION`` is not set then ``VERSION`` defaults to what it is able to get via ``git`` (or fails as it did before if not a git checkout).