### PR TITLE
Have all config/v*/types packages use common error types

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	// Parsing / general errors
 	ErrInvalid            = errors.New("config is not valid")
 	ErrCloudConfig        = errors.New("not a config (found coreos-cloudconfig)")
 	ErrEmpty              = errors.New("not a config (empty)")
@@ -29,6 +30,65 @@ var (
 	ErrDeprecated         = errors.New("config format deprecated")
 	ErrVersion            = errors.New("incorrect config version")
 	ErrCompressionInvalid = errors.New("invalid compression method")
+
+	// Ignition section errors
+	ErrOldVersion     = errors.New("incorrect config version (too old)")
+	ErrNewVersion     = errors.New("incorrect config version (too new)")
+	ErrInvalidVersion = errors.New("invalid config version (couldn't parse)")
+
+	// Storage section errors
+	ErrPermissionsUnset            = errors.New("permissions unset, defaulting to 0000")
+	ErrDiskDeviceRequired          = errors.New("disk device is required")
+	ErrPartitionNumbersCollide     = errors.New("partition numbers collide")
+	ErrPartitionsOverlap           = errors.New("partitions overlap")
+	ErrPartitionsMisaligned        = errors.New("partitions misaligned")
+	ErrAppendAndOverwrite          = errors.New("cannot set both append and overwrite to true")
+	ErrFilesystemInvalidFormat     = errors.New("invalid filesystem format")
+	ErrFilesystemNoMountPath       = errors.New("filesystem is missing mount or path")
+	ErrFilesystemMountAndPath      = errors.New("filesystem has both mount and path defined")
+	ErrUsedCreateAndMountOpts      = errors.New("cannot use both create object and mount-level options field")
+	ErrUsedCreateAndWipeFilesystem = errors.New("cannot use both create object and wipeFilesystem field")
+	ErrWarningCreateDeprecated     = errors.New("the create object has been deprecated in favor of mount-level options")
+	ErrExt4LabelTooLong            = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
+	ErrBtrfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
+	ErrXfsLabelTooLong             = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")
+	ErrSwapLabelTooLong            = errors.New("filesystem labels cannot be longer than 15 characters when using swap")
+	ErrVfatLabelTooLong            = errors.New("filesystem labels cannot be longer than 11 characters when using vfat")
+	ErrFileIllegalMode             = errors.New("illegal file mode")
+	ErrNoFilesystem                = errors.New("no filesystem specified")
+	ErrBothIDAndNameSet            = errors.New("cannot set both id and name")
+	ErrLabelTooLong                = errors.New("partition labels may not exceed 36 characters")
+	ErrDoesntMatchGUIDRegex        = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
+	ErrLabelContainsColon          = errors.New("partition label will be truncated to text before the colon")
+	ErrPathRelative                = errors.New("path not absolute")
+	ErrSparesUnsupportedForLevel   = errors.New("spares unsupported for arrays with a level greater than 0")
+	ErrUnrecognizedRaidLevel       = errors.New("unrecognized raid level")
+
+	// Passwd section errors
+	ErrPasswdCreateDeprecated      = errors.New("the create object has been deprecated in favor of user-level options")
+	ErrPasswdCreateAndGecos        = errors.New("cannot use both the create object and the user-level gecos field")
+	ErrPasswdCreateAndGroups       = errors.New("cannot use both the create object and the user-level groups field")
+	ErrPasswdCreateAndHomeDir      = errors.New("cannot use both the create object and the user-level homeDir field")
+	ErrPasswdCreateAndNoCreateHome = errors.New("cannot use both the create object and the user-level noCreateHome field")
+	ErrPasswdCreateAndNoLogInit    = errors.New("cannot use both the create object and the user-level noLogInit field")
+	ErrPasswdCreateAndNoUserGroup  = errors.New("cannot use both the create object and the user-level noUserGroup field")
+	ErrPasswdCreateAndPrimaryGroup = errors.New("cannot use both the create object and the user-level primaryGroup field")
+	ErrPasswdCreateAndShell        = errors.New("cannot use both the create object and the user-level shell field")
+	ErrPasswdCreateAndSystem       = errors.New("cannot use both the create object and the user-level system field")
+	ErrPasswdCreateAndUID          = errors.New("cannot use both the create object and the user-level uid field")
+
+	// Systemd and Networkd section errors
+	ErrInvalidSystemdExt        = errors.New("invalid systemd unit extension")
+	ErrInvalidSystemdDropinExt  = errors.New("invalid systemd drop-in extension")
+	ErrInvalidNetworkdExt       = errors.New("invalid networkd unit extension")
+	ErrInvalidNetworkdDropinExt = errors.New("invalid networkd drop-in extension")
+
+	// Misc errors
+	ErrInvalidScheme    = errors.New("invalid url scheme")
+	ErrInvalidUrl       = errors.New("unable to parse url")
+	ErrHashMalformed    = errors.New("malformed hash specifier")
+	ErrHashWrongSize    = errors.New("incorrect size for hash sum")
+	ErrHashUnrecognized = errors.New("unrecognized hash function")
 )
 
 // NewNoInstallSectionError produces an error indicating the given unit, named

--- a/config/v1/config_test.go
+++ b/config/v1/config_test.go
@@ -48,7 +48,7 @@ func TestParse(t *testing.T) {
 				report: report.Report{
 					Entries: []report.Entry{
 						{
-							Message:   types.ErrPathRelative.Error(),
+							Message:   errors.ErrPathRelative.Error(),
 							Kind:      report.EntryError,
 							Line:      1,
 							Column:    87,

--- a/config/v1/types/disk.go
+++ b/config/v1/types/disk.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -31,25 +30,25 @@ func (n Disk) Validate() report.Report {
 	if len(n.Device) == 0 {
 		r.Add(report.Entry{
 			Kind:    report.EntryError,
-			Message: "disk device is required",
+			Message: errors.ErrDiskDeviceRequired.Error(),
 		})
 	}
 	if n.partitionNumbersCollide() {
 		r.Add(report.Entry{
 			Kind:    report.EntryError,
-			Message: fmt.Sprintf("disk %q: partition numbers collide", n.Device),
+			Message: errors.ErrPartitionNumbersCollide.Error(),
 		})
 	}
 	if n.partitionsOverlap() {
 		r.Add(report.Entry{
 			Kind:    report.EntryError,
-			Message: fmt.Sprintf("disk %q: partitions overlap", n.Device),
+			Message: errors.ErrPartitionsOverlap.Error(),
 		})
 	}
 	if n.partitionsMisaligned() {
 		r.Add(report.Entry{
 			Kind:    report.EntryError,
-			Message: fmt.Sprintf("disk %q: partitions misaligned", n.Device),
+			Message: errors.ErrPartitionsMisaligned.Error(),
 		})
 	}
 	// Disks which get to this point will likely succeed in sgdisk

--- a/config/v1/types/file.go
+++ b/config/v1/types/file.go
@@ -15,14 +15,10 @@
 package types
 
 import (
-	"errors"
 	"os"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFileIllegalMode = errors.New("illegal file mode")
 )
 
 type FileMode os.FileMode
@@ -37,7 +33,7 @@ type File struct {
 
 func (m FileMode) Validate() report.Report {
 	if (m &^ 07777) != 0 {
-		return report.ReportFromError(ErrFileIllegalMode, report.EntryError)
+		return report.ReportFromError(errors.ErrFileIllegalMode, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v1/types/file_test.go
+++ b/config/v1/types/file_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -39,7 +40,7 @@ func TestFileModeValidate(t *testing.T) {
 		},
 		{
 			in:  in{data: 9999},
-			out: out{rep: report.ReportFromError(ErrFileIllegalMode, report.EntryError)},
+			out: out{rep: report.ReportFromError(errors.ErrFileIllegalMode, report.EntryError)},
 		},
 	}
 
@@ -81,7 +82,7 @@ func TestFileAssertValid(t *testing.T) {
 		},
 		{
 			in:  in{mode: FileMode(010000)},
-			out: out{rep: report.ReportFromError(ErrFileIllegalMode, report.EntryError)},
+			out: out{rep: report.ReportFromError(errors.ErrFileIllegalMode, report.EntryError)},
 		},
 	}
 

--- a/config/v1/types/filesystem.go
+++ b/config/v1/types/filesystem.go
@@ -15,13 +15,8 @@
 package types
 
 import (
-	"errors"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFilesystemInvalidFormat = errors.New("invalid filesystem format")
 )
 
 type Filesystem struct {
@@ -43,7 +38,7 @@ func (f FilesystemFormat) Validate() report.Report {
 	case "ext4", "btrfs", "xfs":
 		return report.Report{}
 	default:
-		return report.ReportFromError(ErrFilesystemInvalidFormat, report.EntryError)
+		return report.ReportFromError(errors.ErrFilesystemInvalidFormat, report.EntryError)
 	}
 }
 

--- a/config/v1/types/filesystem_test.go
+++ b/config/v1/types/filesystem_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -43,7 +44,7 @@ func TestFilesystemFormatValidate(t *testing.T) {
 		},
 		{
 			in:  in{format: FilesystemFormat("")},
-			out: out{rep: report.ReportFromError(ErrFilesystemInvalidFormat, report.EntryError)},
+			out: out{rep: report.ReportFromError(errors.ErrFilesystemInvalidFormat, report.EntryError)},
 		},
 	}
 

--- a/config/v1/types/partition.go
+++ b/config/v1/types/partition.go
@@ -15,15 +15,11 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrPartitionLabelTooLong = errors.New("partition labels may not exceed 36 characters")
 )
 
 type Partition struct {
@@ -43,7 +39,7 @@ func (n PartitionLabel) Validate() report.Report {
 	// XXX(vc): note GPT calls it a name, we're using label for consistency
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(string(n)) > 36 {
-		return report.ReportFromError(ErrPartitionLabelTooLong, report.EntryError)
+		return report.ReportFromError(errors.ErrLabelTooLong, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v1/types/path.go
+++ b/config/v1/types/path.go
@@ -15,21 +15,17 @@
 package types
 
 import (
-	"errors"
 	"path"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrPathRelative = errors.New("path not absolute")
 )
 
 type Path string
 
 func (d Path) Validate() report.Report {
 	if !path.IsAbs(string(d)) {
-		return report.ReportFromError(ErrPathRelative, report.EntryError)
+		return report.ReportFromError(errors.ErrPathRelative, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v1/types/path_test.go
+++ b/config/v1/types/path_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -51,7 +52,7 @@ func TestPathAssertValid(t *testing.T) {
 		},
 		{
 			in:  in{device: Path("relative/path")},
-			out: out{rep: report.ReportFromError(ErrPathRelative, report.EntryError)},
+			out: out{rep: report.ReportFromError(errors.ErrPathRelative, report.EntryError)},
 		},
 	}
 

--- a/config/v1/types/raid.go
+++ b/config/v1/types/raid.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -31,7 +30,7 @@ func (n Raid) Validate() report.Report {
 	switch n.Level {
 	case "linear", "raid0", "0", "stripe":
 		if n.Spares != 0 {
-			return report.ReportFromError(fmt.Errorf("spares unsupported for %q arrays", n.Level), report.EntryError)
+			return report.ReportFromError(errors.ErrSparesUnsupportedForLevel, report.EntryError)
 		}
 	case "raid1", "1", "mirror":
 	case "raid4", "4":
@@ -39,7 +38,7 @@ func (n Raid) Validate() report.Report {
 	case "raid6", "6":
 	case "raid10", "10":
 	default:
-		return report.ReportFromError(fmt.Errorf("unrecognized raid level: %q", n.Level), report.EntryError)
+		return report.ReportFromError(errors.ErrUnrecognizedRaidLevel, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v1/types/unit.go
+++ b/config/v1/types/unit.go
@@ -15,16 +15,10 @@
 package types
 
 import (
-	"errors"
 	"path"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrSystemdUnitInvalidExt   = errors.New("invalid systemd unit extension")
-	ErrSystemdDropInInvalidExt = errors.New("invalid systemd unit extension")
-	ErrNetworkdUnitInvalidExt  = errors.New("invalid networkd unit extension")
 )
 
 type SystemdUnit struct {
@@ -47,7 +41,7 @@ func (n SystemdUnitName) Validate() report.Report {
 	case ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice", ".scope":
 		return report.Report{}
 	default:
-		return report.ReportFromError(ErrSystemdUnitInvalidExt, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidSystemdExt, report.EntryError)
 	}
 }
 
@@ -58,7 +52,7 @@ func (n SystemdUnitDropInName) Validate() report.Report {
 	case ".conf":
 		return report.Report{}
 	default:
-		return report.ReportFromError(ErrSystemdDropInInvalidExt, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidSystemdDropinExt, report.EntryError)
 	}
 }
 
@@ -74,6 +68,6 @@ func (n NetworkdUnitName) Validate() report.Report {
 	case ".link", ".netdev", ".network":
 		return report.Report{}
 	default:
-		return report.ReportFromError(ErrNetworkdUnitInvalidExt, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidNetworkdExt, report.EntryError)
 	}
 }

--- a/config/v1/types/unit_test.go
+++ b/config/v1/types/unit_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -43,7 +44,7 @@ func TestSystemdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{data: "test.blah"},
-			out: out{rep: report.ReportFromError(ErrSystemdUnitInvalidExt, report.EntryError)},
+			out: out{rep: report.ReportFromError(errors.ErrInvalidSystemdExt, report.EntryError)},
 		},
 	}
 
@@ -81,7 +82,7 @@ func TestNetworkdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{data: "test.blah"},
-			out: out{rep: report.ReportFromError(ErrNetworkdUnitInvalidExt, report.EntryError)},
+			out: out{rep: report.ReportFromError(errors.ErrInvalidNetworkdExt, report.EntryError)},
 		},
 	}
 

--- a/config/v2_0/types/compression.go
+++ b/config/v2_0/types/compression.go
@@ -15,13 +15,8 @@
 package types
 
 import (
-	"errors"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrCompressionInvalid = errors.New("invalid compression method")
 )
 
 type Compression string
@@ -30,7 +25,7 @@ func (c Compression) Validate() report.Report {
 	switch c {
 	case "", "gzip":
 	default:
-		return report.ReportFromError(ErrCompressionInvalid, report.EntryError)
+		return report.ReportFromError(errors.ErrCompressionInvalid, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_0/types/disk.go
+++ b/config/v2_0/types/disk.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -30,25 +29,25 @@ func (n Disk) Validate() report.Report {
 	r := report.Report{}
 	if len(n.Device) == 0 {
 		r.Add(report.Entry{
-			Message: "disk device is required",
+			Message: errors.ErrDiskDeviceRequired.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionNumbersCollide() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partition numbers collide", n.Device),
+			Message: errors.ErrPartitionNumbersCollide.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsOverlap() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions overlap", n.Device),
+			Message: errors.ErrPartitionsOverlap.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsMisaligned() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions misaligned", n.Device),
+			Message: errors.ErrPartitionsMisaligned.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_0/types/file.go
+++ b/config/v2_0/types/file.go
@@ -15,15 +15,10 @@
 package types
 
 import (
-	"errors"
 	"os"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFileIllegalMode = errors.New("illegal file mode")
-	ErrNoFilesystem    = errors.New("no filesystem specified")
 )
 
 type File struct {
@@ -37,7 +32,7 @@ type File struct {
 
 func (f File) Validate() report.Report {
 	if f.Filesystem == "" {
-		return report.ReportFromError(ErrNoFilesystem, report.EntryError)
+		return report.ReportFromError(errors.ErrNoFilesystem, report.EntryError)
 	}
 	return report.Report{}
 }
@@ -60,7 +55,7 @@ type FileMode os.FileMode
 
 func (m FileMode) Validate() report.Report {
 	if (m &^ 07777) != 0 {
-		return report.ReportFromError(ErrFileIllegalMode, report.EntryError)
+		return report.ReportFromError(errors.ErrFileIllegalMode, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_0/types/file_test.go
+++ b/config/v2_0/types/file_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -51,7 +52,7 @@ func TestFileValidate(t *testing.T) {
 		},
 		{
 			in:  in{mode: FileMode(010000)},
-			out: out{err: ErrFileIllegalMode},
+			out: out{err: errors.ErrFileIllegalMode},
 		},
 	}
 

--- a/config/v2_0/types/filesystem.go
+++ b/config/v2_0/types/filesystem.go
@@ -15,15 +15,8 @@
 package types
 
 import (
-	"errors"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFilesystemInvalidFormat = errors.New("invalid filesystem format")
-	ErrFilesystemNoMountPath   = errors.New("filesystem is missing mount or path")
-	ErrFilesystemMountAndPath  = errors.New("filesystem has both mount and path defined")
 )
 
 type Filesystem struct {
@@ -45,10 +38,10 @@ type FilesystemCreate struct {
 
 func (f Filesystem) Validate() report.Report {
 	if f.Mount == nil && f.Path == nil {
-		return report.ReportFromError(ErrFilesystemNoMountPath, report.EntryError)
+		return report.ReportFromError(errors.ErrFilesystemNoMountPath, report.EntryError)
 	}
 	if f.Mount != nil && f.Path != nil {
-		return report.ReportFromError(ErrFilesystemMountAndPath, report.EntryError)
+		return report.ReportFromError(errors.ErrFilesystemMountAndPath, report.EntryError)
 	}
 	return report.Report{}
 }
@@ -60,7 +53,7 @@ func (f FilesystemFormat) Validate() report.Report {
 	case "ext4", "btrfs", "xfs":
 		return report.Report{}
 	default:
-		return report.ReportFromError(ErrFilesystemInvalidFormat, report.EntryError)
+		return report.ReportFromError(errors.ErrFilesystemInvalidFormat, report.EntryError)
 	}
 }
 

--- a/config/v2_0/types/filesystem_test.go
+++ b/config/v2_0/types/filesystem_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -43,7 +44,7 @@ func TestFilesystemFormatValidate(t *testing.T) {
 		},
 		{
 			in:  in{format: FilesystemFormat("")},
-			out: out{err: ErrFilesystemInvalidFormat},
+			out: out{err: errors.ErrFilesystemInvalidFormat},
 		},
 	}
 
@@ -77,11 +78,11 @@ func TestFilesystemValidate(t *testing.T) {
 		},
 		{
 			in:  in{filesystem: Filesystem{Path: func(p Path) *Path { return &p }("/mount"), Mount: &FilesystemMount{Device: "/foo", Format: "ext4"}}},
-			out: out{err: ErrFilesystemMountAndPath},
+			out: out{err: errors.ErrFilesystemMountAndPath},
 		},
 		{
 			in:  in{filesystem: Filesystem{}},
-			out: out{err: ErrFilesystemNoMountPath},
+			out: out{err: errors.ErrFilesystemNoMountPath},
 		},
 	}
 

--- a/config/v2_0/types/hash.go
+++ b/config/v2_0/types/hash.go
@@ -18,16 +18,10 @@ import (
 	"crypto"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrHashMalformed    = errors.New("malformed hash specifier")
-	ErrHashWrongSize    = errors.New("incorrect size for hash sum")
-	ErrHashUnrecognized = errors.New("unrecognized hash function")
 )
 
 type Hash struct {
@@ -43,7 +37,7 @@ func (h *Hash) UnmarshalJSON(data []byte) error {
 
 	parts := strings.SplitN(th, "-", 2)
 	if len(parts) != 2 {
-		return ErrHashMalformed
+		return errors.ErrHashMalformed
 	}
 
 	h.Function = parts[0]
@@ -67,11 +61,11 @@ func (h Hash) Validate() report.Report {
 	case "sha512":
 		hash = crypto.SHA512
 	default:
-		return report.ReportFromError(ErrHashUnrecognized, report.EntryError)
+		return report.ReportFromError(errors.ErrHashUnrecognized, report.EntryError)
 	}
 
 	if len(h.Sum) != hex.EncodedLen(hash.Size()) {
-		return report.ReportFromError(ErrHashWrongSize, report.EntryError)
+		return report.ReportFromError(errors.ErrHashWrongSize, report.EntryError)
 	}
 
 	return report.Report{}

--- a/config/v2_0/types/hash_test.go
+++ b/config/v2_0/types/hash_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -41,7 +42,7 @@ func TestHashUnmarshalJSON(t *testing.T) {
 		},
 		{
 			in:  in{data: `"xor01234567"`},
-			out: out{err: ErrHashMalformed},
+			out: out{err: errors.ErrHashMalformed},
 		},
 	}
 
@@ -71,15 +72,15 @@ func TestHashValidate(t *testing.T) {
 	}{
 		{
 			in:  in{hash: Hash{}},
-			out: out{err: ErrHashUnrecognized},
+			out: out{err: errors.ErrHashUnrecognized},
 		},
 		{
 			in:  in{hash: Hash{Function: "xor"}},
-			out: out{err: ErrHashUnrecognized},
+			out: out{err: errors.ErrHashUnrecognized},
 		},
 		{
 			in:  in{hash: Hash{Function: "sha512", Sum: "123"}},
-			out: out{err: ErrHashWrongSize},
+			out: out{err: errors.ErrHashWrongSize},
 		},
 		{
 			in:  in{hash: Hash{Function: "sha512", Sum: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}},

--- a/config/v2_0/types/ignition.go
+++ b/config/v2_0/types/ignition.go
@@ -16,16 +16,11 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/coreos/go-semver/semver"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrOldVersion = errors.New("incorrect config version (too old)")
-	ErrNewVersion = errors.New("incorrect config version (too new)")
 )
 
 type Ignition struct {
@@ -60,10 +55,10 @@ func (v IgnitionVersion) MarshalJSON() ([]byte, error) {
 
 func (v IgnitionVersion) Validate() report.Report {
 	if MaxVersion.Major > v.Major {
-		return report.ReportFromError(ErrOldVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrOldVersion, report.EntryError)
 	}
 	if MaxVersion.LessThan(semver.Version(v)) {
-		return report.ReportFromError(ErrNewVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrNewVersion, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_0/types/partition.go
+++ b/config/v2_0/types/partition.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -39,10 +40,10 @@ func (n PartitionLabel) Validate() report.Report {
 	// XXX(vc): note GPT calls it a name, we're using label for consistency
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(string(n)) > 36 {
-		return report.ReportFromError(fmt.Errorf("partition labels may not exceed 36 characters"), report.EntryError)
+		return report.ReportFromError(errors.ErrLabelTooLong, report.EntryError)
 	}
 	if strings.Contains(string(n), ":") {
-		return report.ReportFromError(fmt.Errorf("partition label will be truncated to text before the colon"), report.EntryWarning)
+		return report.ReportFromError(errors.ErrLabelContainsColon, report.EntryWarning)
 	}
 	return report.Report{}
 }
@@ -57,7 +58,7 @@ func (d PartitionTypeGUID) Validate() report.Report {
 		return report.ReportFromError(fmt.Errorf("error matching type-guid regexp: %v", err), report.EntryError)
 	}
 	if !ok {
-		return report.ReportFromError(fmt.Errorf(`partition type-guid must have the form "01234567-89AB-CDEF-EDCB-A98765432101", got: %q`, string(d)), report.EntryError)
+		return report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_0/types/path.go
+++ b/config/v2_0/types/path.go
@@ -15,14 +15,10 @@
 package types
 
 import (
-	"errors"
 	"path"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrPathRelative = errors.New("path not absolute")
 )
 
 type Path string
@@ -33,7 +29,7 @@ func (p Path) MarshalJSON() ([]byte, error) {
 
 func (p Path) Validate() report.Report {
 	if !path.IsAbs(string(p)) {
-		return report.ReportFromError(ErrPathRelative, report.EntryError)
+		return report.ReportFromError(errors.ErrPathRelative, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_0/types/path_test.go
+++ b/config/v2_0/types/path_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -51,7 +52,7 @@ func TestPathValidate(t *testing.T) {
 		},
 		{
 			in:  in{device: Path("relative/path")},
-			out: out{err: ErrPathRelative},
+			out: out{err: errors.ErrPathRelative},
 		},
 	}
 

--- a/config/v2_0/types/raid.go
+++ b/config/v2_0/types/raid.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -31,7 +30,7 @@ func (n Raid) Validate() report.Report {
 	switch n.Level {
 	case "linear", "raid0", "0", "stripe":
 		if n.Spares != 0 {
-			return report.ReportFromError(fmt.Errorf("spares unsupported for %q arrays", n.Level), report.EntryError)
+			return report.ReportFromError(errors.ErrSparesUnsupportedForLevel, report.EntryError)
 		}
 	case "raid1", "1", "mirror":
 	case "raid4", "4":
@@ -39,7 +38,7 @@ func (n Raid) Validate() report.Report {
 	case "raid6", "6":
 	case "raid10", "10":
 	default:
-		return report.ReportFromError(fmt.Errorf("unrecognized raid level: %q", n.Level), report.EntryError)
+		return report.ReportFromError(errors.ErrUnrecognizedRaidLevel, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_0/types/unit.go
+++ b/config/v2_0/types/unit.go
@@ -15,13 +15,13 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/shared/validations"
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -66,7 +66,7 @@ func (n SystemdUnitName) Validate() report.Report {
 	case ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice", ".scope":
 		return report.Report{}
 	default:
-		return report.ReportFromError(errors.New("invalid systemd unit extension"), report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidSystemdExt, report.EntryError)
 	}
 }
 
@@ -77,7 +77,7 @@ func (n SystemdUnitDropInName) Validate() report.Report {
 	case ".conf":
 		return report.Report{}
 	default:
-		return report.ReportFromError(errors.New("invalid systemd unit drop-in extension"), report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidSystemdDropinExt, report.EntryError)
 	}
 }
 
@@ -101,7 +101,7 @@ func (n NetworkdUnitName) Validate() report.Report {
 	case ".link", ".netdev", ".network":
 		return report.Report{}
 	default:
-		return report.ReportFromError(errors.New("invalid networkd unit extension"), report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidNetworkdExt, report.EntryError)
 	}
 }
 

--- a/config/v2_0/types/unit_test.go
+++ b/config/v2_0/types/unit_test.go
@@ -15,10 +15,11 @@
 package types
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -40,7 +41,7 @@ func TestSystemdUnitValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: SystemdUnit{Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 		{
 			in:  in{unit: SystemdUnit{Contents: "", DropIns: []SystemdUnitDropIn{{}}}},
@@ -78,7 +79,7 @@ func TestSystemdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: SystemdUnitName("test.blah")},
-			out: out{err: errors.New("invalid systemd unit extension")},
+			out: out{err: errors.ErrInvalidSystemdExt},
 		},
 	}
 
@@ -108,7 +109,7 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: SystemdUnitDropIn{Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 
@@ -146,7 +147,7 @@ func TestNetworkdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: NetworkdUnitName("test.blah")},
-			out: out{err: errors.New("invalid networkd unit extension")},
+			out: out{err: errors.ErrInvalidNetworkdExt},
 		},
 	}
 
@@ -176,7 +177,7 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: NetworkdUnit{Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 

--- a/config/v2_0/types/url.go
+++ b/config/v2_0/types/url.go
@@ -16,15 +16,12 @@ package types
 
 import (
 	"encoding/json"
-	"errors"
 	"net/url"
 
-	"github.com/coreos/ignition/config/validate/report"
 	"github.com/vincent-petithory/dataurl"
-)
 
-var (
-	ErrInvalidScheme = errors.New("invalid url scheme")
+	"github.com/coreos/ignition/config/shared/errors"
+	"github.com/coreos/ignition/config/validate/report"
 )
 
 type Url url.URL
@@ -37,7 +34,7 @@ func (u *Url) UnmarshalJSON(data []byte) error {
 
 	pu, err := url.Parse(tu)
 	if err != nil {
-		return err
+		return errors.ErrInvalidUrl
 	}
 
 	*u = Url(*pu)
@@ -67,6 +64,6 @@ func (u Url) Validate() report.Report {
 		}
 		return report.Report{}
 	default:
-		return report.ReportFromError(ErrInvalidScheme, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidScheme, report.EntryError)
 	}
 }

--- a/config/v2_0/types/url_test.go
+++ b/config/v2_0/types/url_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -56,7 +57,7 @@ func TestURLValidate(t *testing.T) {
 		},
 		{
 			in:  in{u: "bad://"},
-			out: out{err: ErrInvalidScheme},
+			out: out{err: errors.ErrInvalidScheme},
 		},
 	}
 

--- a/config/v2_1/types/disk.go
+++ b/config/v2_1/types/disk.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -26,7 +25,7 @@ func (n Disk) Validate() report.Report {
 
 func (n Disk) ValidateDevice() report.Report {
 	if len(n.Device) == 0 {
-		return report.ReportFromError(fmt.Errorf("disk device is required"), report.EntryError)
+		return report.ReportFromError(errors.ErrDiskDeviceRequired, report.EntryError)
 	}
 	if err := validatePath(string(n.Device)); err != nil {
 		return report.ReportFromError(err, report.EntryError)
@@ -38,19 +37,19 @@ func (n Disk) ValidatePartitions() report.Report {
 	r := report.Report{}
 	if n.partitionNumbersCollide() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partition numbers collide", n.Device),
+			Message: errors.ErrPartitionNumbersCollide.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsOverlap() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions overlap", n.Device),
+			Message: errors.ErrPartitionsOverlap.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsMisaligned() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions misaligned", n.Device),
+			Message: errors.ErrPartitionsMisaligned.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/file.go
+++ b/config/v2_1/types/file.go
@@ -15,8 +15,6 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
@@ -50,7 +48,7 @@ func (fc FileContents) ValidateSource() report.Report {
 	err := validateURL(fc.Source)
 	if err != nil {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid url %q: %v", fc.Source, err),
+			Message: err.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/filesystem.go
+++ b/config/v2_1/types/filesystem.go
@@ -15,56 +15,40 @@
 package types
 
 import (
-	"errors"
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFilesystemInvalidFormat     = errors.New("invalid filesystem format")
-	ErrFilesystemNoMountPath       = errors.New("filesystem is missing mount or path")
-	ErrFilesystemMountAndPath      = errors.New("filesystem has both mount and path defined")
-	ErrUsedCreateAndMountOpts      = errors.New("cannot use both create object and mount-level options field")
-	ErrUsedCreateAndWipeFilesystem = errors.New("cannot use both create object and wipeFilesystem field")
-	ErrWarningCreateDeprecated     = errors.New("the create object has been deprecated in favor of mount-level options")
-	ErrExt4LabelTooLong            = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
-	ErrBtrfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
-	ErrXfsLabelTooLong             = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")
-	ErrSwapLabelTooLong            = errors.New("filesystem labels cannot be longer than 15 characters when using swap")
-	ErrVfatLabelTooLong            = errors.New("filesystem labels cannot be longer than 11 characters when using vfat")
 )
 
 func (f Filesystem) Validate() report.Report {
 	r := report.Report{}
 	if f.Mount == nil && f.Path == nil {
 		r.Add(report.Entry{
-			Message: ErrFilesystemNoMountPath.Error(),
+			Message: errors.ErrFilesystemNoMountPath.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if f.Mount != nil {
 		if f.Path != nil {
 			r.Add(report.Entry{
-				Message: ErrFilesystemMountAndPath.Error(),
+				Message: errors.ErrFilesystemMountAndPath.Error(),
 				Kind:    report.EntryError,
 			})
 		}
 		if f.Mount.Create != nil {
 			if f.Mount.WipeFilesystem {
 				r.Add(report.Entry{
-					Message: ErrUsedCreateAndWipeFilesystem.Error(),
+					Message: errors.ErrUsedCreateAndWipeFilesystem.Error(),
 					Kind:    report.EntryError,
 				})
 			}
 			if len(f.Mount.Options) > 0 {
 				r.Add(report.Entry{
-					Message: ErrUsedCreateAndMountOpts.Error(),
+					Message: errors.ErrUsedCreateAndMountOpts.Error(),
 					Kind:    report.EntryError,
 				})
 			}
 			r.Add(report.Entry{
-				Message: ErrWarningCreateDeprecated.Error(),
+				Message: errors.ErrWarningCreateDeprecated.Error(),
 				Kind:    report.EntryWarning,
 			})
 		}
@@ -76,7 +60,7 @@ func (f Filesystem) ValidatePath() report.Report {
 	r := report.Report{}
 	if f.Path != nil && validatePath(*f.Path) != nil {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("filesystem %q: path not absolute", f.Name),
+			Message: errors.ErrPathRelative.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -89,7 +73,7 @@ func (m Mount) Validate() report.Report {
 	case "ext4", "btrfs", "xfs", "swap", "vfat":
 	default:
 		r.Add(report.Entry{
-			Message: ErrFilesystemInvalidFormat.Error(),
+			Message: errors.ErrFilesystemInvalidFormat.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -117,7 +101,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 16 {
 			// source: man mkfs.ext4
 			r.Add(report.Entry{
-				Message: ErrExt4LabelTooLong.Error(),
+				Message: errors.ErrExt4LabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -125,7 +109,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 256 {
 			// source: man mkfs.btrfs
 			r.Add(report.Entry{
-				Message: ErrBtrfsLabelTooLong.Error(),
+				Message: errors.ErrBtrfsLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -133,7 +117,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 12 {
 			// source: man mkfs.xfs
 			r.Add(report.Entry{
-				Message: ErrXfsLabelTooLong.Error(),
+				Message: errors.ErrXfsLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -143,7 +127,7 @@ func (m Mount) ValidateLabel() report.Report {
 		// 15 characters, so let's enforce that.
 		if len(*m.Label) > 15 {
 			r.Add(report.Entry{
-				Message: ErrSwapLabelTooLong.Error(),
+				Message: errors.ErrSwapLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -151,7 +135,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 11 {
 			// source: man mkfs.fat
 			r.Add(report.Entry{
-				Message: ErrVfatLabelTooLong.Error(),
+				Message: errors.ErrVfatLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_1/types/filesystem_test.go
+++ b/config/v2_1/types/filesystem_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -43,7 +44,7 @@ func TestMountValidate(t *testing.T) {
 		},
 		{
 			in:  in{format: ""},
-			out: out{err: ErrFilesystemInvalidFormat},
+			out: out{err: errors.ErrFilesystemInvalidFormat},
 		},
 	}
 
@@ -77,11 +78,11 @@ func TestFilesystemValidate(t *testing.T) {
 		},
 		{
 			in:  in{filesystem: Filesystem{Path: func(p string) *string { return &p }("/mount"), Mount: &Mount{Device: "/foo", Format: "ext4"}}},
-			out: out{err: ErrFilesystemMountAndPath},
+			out: out{err: errors.ErrFilesystemMountAndPath},
 		},
 		{
 			in:  in{filesystem: Filesystem{}},
-			out: out{err: ErrFilesystemNoMountPath},
+			out: out{err: errors.ErrFilesystemNoMountPath},
 		},
 	}
 
@@ -117,7 +118,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "ext4", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrExt4LabelTooLong},
+			out: out{err: errors.ErrExt4LabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "btrfs", Label: nil}},
@@ -129,7 +130,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "btrfs", Label: strToPtr("thislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolong")}},
-			out: out{err: ErrBtrfsLabelTooLong},
+			out: out{err: errors.ErrBtrfsLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "xfs", Label: nil}},
@@ -141,7 +142,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "xfs", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrXfsLabelTooLong},
+			out: out{err: errors.ErrXfsLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "swap", Label: nil}},
@@ -153,7 +154,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "swap", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrSwapLabelTooLong},
+			out: out{err: errors.ErrSwapLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "vfat", Label: nil}},
@@ -165,7 +166,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "vfat", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrVfatLabelTooLong},
+			out: out{err: errors.ErrVfatLabelTooLong},
 		},
 	}
 

--- a/config/v2_1/types/ignition.go
+++ b/config/v2_1/types/ignition.go
@@ -15,17 +15,10 @@
 package types
 
 import (
-	"errors"
-
 	"github.com/coreos/go-semver/semver"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrOldVersion     = errors.New("incorrect config version (too old)")
-	ErrNewVersion     = errors.New("incorrect config version (too new)")
-	ErrInvalidVersion = errors.New("invalid config version (couldn't parse)")
 )
 
 func (c ConfigReference) ValidateSource() report.Report {
@@ -47,13 +40,13 @@ func (v Ignition) Semver() (*semver.Version, error) {
 func (v Ignition) Validate() report.Report {
 	tv, err := v.Semver()
 	if err != nil {
-		return report.ReportFromError(ErrInvalidVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidVersion, report.EntryError)
 	}
 	if MaxVersion.Major > tv.Major {
-		return report.ReportFromError(ErrOldVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrOldVersion, report.EntryError)
 	}
 	if MaxVersion.LessThan(*tv) {
-		return report.ReportFromError(ErrNewVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrNewVersion, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_1/types/link.go
+++ b/config/v2_1/types/link.go
@@ -15,18 +15,16 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/coreos/ignition/config/validate/report"
 )
 
-func (s Link) Validate() report.Report {
+func (s LinkEmbedded1) ValidateTarget() report.Report {
 	r := report.Report{}
 	if !s.Hard {
 		err := validatePath(s.Target)
 		if err != nil {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("problem with target path %q: %v", s.Target, err),
+				Message: err.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_1/types/mode.go
+++ b/config/v2_1/types/mode.go
@@ -15,16 +15,12 @@
 package types
 
 import (
-	"errors"
-)
-
-var (
-	ErrFileIllegalMode = errors.New("illegal file mode")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validateMode(m int) error {
 	if m < 0 || m > 07777 {
-		return ErrFileIllegalMode
+		return errors.ErrFileIllegalMode
 	}
 	return nil
 }

--- a/config/v2_1/types/mode_test.go
+++ b/config/v2_1/types/mode_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestModeValidate(t *testing.T) {
@@ -49,7 +51,7 @@ func TestModeValidate(t *testing.T) {
 		},
 		{
 			in:  in{mode: 010000},
-			out: out{ErrFileIllegalMode},
+			out: out{errors.ErrFileIllegalMode},
 		},
 	}
 

--- a/config/v2_1/types/node.go
+++ b/config/v2_1/types/node.go
@@ -15,22 +15,17 @@
 package types
 
 import (
-	"errors"
 	"path/filepath"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrNoFilesystem     = errors.New("no filesystem specified")
-	ErrBothIDAndNameSet = errors.New("cannot set both id and name")
 )
 
 func (n Node) ValidateFilesystem() report.Report {
 	r := report.Report{}
 	if n.Filesystem == "" {
 		r.Add(report.Entry{
-			Message: ErrNoFilesystem.Error(),
+			Message: errors.ErrNoFilesystem.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -60,7 +55,7 @@ func (nu NodeUser) Validate() report.Report {
 	r := report.Report{}
 	if nu.ID != nil && nu.Name != "" {
 		r.Add(report.Entry{
-			Message: ErrBothIDAndNameSet.Error(),
+			Message: errors.ErrBothIDAndNameSet.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -70,7 +65,7 @@ func (ng NodeGroup) Validate() report.Report {
 	r := report.Report{}
 	if ng.ID != nil && ng.Name != "" {
 		r.Add(report.Entry{
-			Message: ErrBothIDAndNameSet.Error(),
+			Message: errors.ErrBothIDAndNameSet.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/node_test.go
+++ b/config/v2_1/types/node_test.go
@@ -18,13 +18,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/util"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 func TestNodeValidatePath(t *testing.T) {
 	node := Node{Path: "not/absolute"}
-	rep := report.ReportFromError(ErrPathRelative, report.EntryError)
+	rep := report.ReportFromError(errors.ErrPathRelative, report.EntryError)
 	if receivedRep := node.ValidatePath(); !reflect.DeepEqual(rep, receivedRep) {
 		t.Errorf("bad error: want %v, got %v", rep, receivedRep)
 	}
@@ -41,7 +42,7 @@ func TestNodeValidateFilesystem(t *testing.T) {
 		},
 		{
 			node: Node{Path: "/"},
-			r:    report.ReportFromError(ErrNoFilesystem, report.EntryError),
+			r:    report.ReportFromError(errors.ErrNoFilesystem, report.EntryError),
 		},
 	}
 	for i, test := range tests {
@@ -70,7 +71,7 @@ func TestNodeValidateUser(t *testing.T) {
 		},
 		{
 			in:  NodeUser{util.IntToPtr(1000), "core"},
-			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+			out: report.ReportFromError(errors.ErrBothIDAndNameSet, report.EntryError),
 		},
 	}
 
@@ -101,7 +102,7 @@ func TestNodeValidateGroup(t *testing.T) {
 		},
 		{
 			in:  NodeGroup{util.IntToPtr(1000), "core"},
-			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+			out: report.ReportFromError(errors.ErrBothIDAndNameSet, report.EntryError),
 		},
 	}
 

--- a/config/v2_1/types/partition.go
+++ b/config/v2_1/types/partition.go
@@ -15,22 +15,16 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 const (
 	guidRegexStr = "^(|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$"
-)
-
-var (
-	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
-	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
-	ErrLabelContainsColon   = errors.New("partition label will be truncated to text before the colon")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -42,7 +36,7 @@ func (p Partition) ValidateLabel() report.Report {
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(p.Label) > 36 {
 		r.Add(report.Entry{
-			Message: ErrLabelTooLong.Error(),
+			Message: errors.ErrLabelTooLong.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -50,7 +44,7 @@ func (p Partition) ValidateLabel() report.Report {
 	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
 	if strings.Contains(p.Label, ":") {
 		r.Add(report.Entry{
-			Message: ErrLabelContainsColon.Error(),
+			Message: errors.ErrLabelContainsColon.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}
@@ -75,7 +69,7 @@ func validateGUID(guid string) report.Report {
 		})
 	} else if !ok {
 		r.Add(report.Entry{
-			Message: ErrDoesntMatchGUIDRegex.Error(),
+			Message: errors.ErrDoesntMatchGUIDRegex.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/partition_test.go
+++ b/config/v2_1/types/partition_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -46,11 +47,11 @@ func TestValidateLabel(t *testing.T) {
 		},
 		{
 			in{"1111111111111111111111111111111111111"},
-			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
+			out{report.ReportFromError(errors.ErrLabelTooLong, report.EntryError)},
 		},
 		{
 			in{"test:"},
-			out{report.ReportFromError(ErrLabelContainsColon, report.EntryWarning)},
+			out{report.ReportFromError(errors.ErrLabelContainsColon, report.EntryWarning)},
 		},
 	}
 	for i, test := range tests {
@@ -82,7 +83,7 @@ func TestValidateTypeGUID(t *testing.T) {
 		},
 		{
 			in{"not-a-valid-typeguid"},
-			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+			out{report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)},
 		},
 	}
 	for i, test := range tests {
@@ -114,7 +115,7 @@ func TestValidateGUID(t *testing.T) {
 		},
 		{
 			in{"not-a-valid-typeguid"},
-			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+			out{report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)},
 		},
 	}
 	for i, test := range tests {

--- a/config/v2_1/types/passwd.go
+++ b/config/v2_1/types/passwd.go
@@ -15,30 +15,15 @@
 package types
 
 import (
-	"errors"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrPasswdCreateDeprecated      = errors.New("the create object has been deprecated in favor of user-level options")
-	ErrPasswdCreateAndGecos        = errors.New("cannot use both the create object and the user-level gecos field")
-	ErrPasswdCreateAndGroups       = errors.New("cannot use both the create object and the user-level groups field")
-	ErrPasswdCreateAndHomeDir      = errors.New("cannot use both the create object and the user-level homeDir field")
-	ErrPasswdCreateAndNoCreateHome = errors.New("cannot use both the create object and the user-level noCreateHome field")
-	ErrPasswdCreateAndNoLogInit    = errors.New("cannot use both the create object and the user-level noLogInit field")
-	ErrPasswdCreateAndNoUserGroup  = errors.New("cannot use both the create object and the user-level noUserGroup field")
-	ErrPasswdCreateAndPrimaryGroup = errors.New("cannot use both the create object and the user-level primaryGroup field")
-	ErrPasswdCreateAndShell        = errors.New("cannot use both the create object and the user-level shell field")
-	ErrPasswdCreateAndSystem       = errors.New("cannot use both the create object and the user-level system field")
-	ErrPasswdCreateAndUID          = errors.New("cannot use both the create object and the user-level uid field")
 )
 
 func (p PasswdUser) Validate() report.Report {
 	r := report.Report{}
 	if p.Create != nil {
 		r.Add(report.Entry{
-			Message: ErrPasswdCreateDeprecated.Error(),
+			Message: errors.ErrPasswdCreateDeprecated.Error(),
 			Kind:    report.EntryWarning,
 		})
 		addErr := func(err error) {
@@ -48,34 +33,34 @@ func (p PasswdUser) Validate() report.Report {
 			})
 		}
 		if p.Gecos != "" {
-			addErr(ErrPasswdCreateAndGecos)
+			addErr(errors.ErrPasswdCreateAndGecos)
 		}
 		if len(p.Groups) > 0 {
-			addErr(ErrPasswdCreateAndGroups)
+			addErr(errors.ErrPasswdCreateAndGroups)
 		}
 		if p.HomeDir != "" {
-			addErr(ErrPasswdCreateAndHomeDir)
+			addErr(errors.ErrPasswdCreateAndHomeDir)
 		}
 		if p.NoCreateHome {
-			addErr(ErrPasswdCreateAndNoCreateHome)
+			addErr(errors.ErrPasswdCreateAndNoCreateHome)
 		}
 		if p.NoLogInit {
-			addErr(ErrPasswdCreateAndNoLogInit)
+			addErr(errors.ErrPasswdCreateAndNoLogInit)
 		}
 		if p.NoUserGroup {
-			addErr(ErrPasswdCreateAndNoUserGroup)
+			addErr(errors.ErrPasswdCreateAndNoUserGroup)
 		}
 		if p.PrimaryGroup != "" {
-			addErr(ErrPasswdCreateAndPrimaryGroup)
+			addErr(errors.ErrPasswdCreateAndPrimaryGroup)
 		}
 		if p.Shell != "" {
-			addErr(ErrPasswdCreateAndShell)
+			addErr(errors.ErrPasswdCreateAndShell)
 		}
 		if p.System {
-			addErr(ErrPasswdCreateAndSystem)
+			addErr(errors.ErrPasswdCreateAndSystem)
 		}
 		if p.UID != nil {
-			addErr(ErrPasswdCreateAndUID)
+			addErr(errors.ErrPasswdCreateAndUID)
 		}
 	}
 	return r

--- a/config/v2_1/types/path.go
+++ b/config/v2_1/types/path.go
@@ -15,17 +15,14 @@
 package types
 
 import (
-	"errors"
 	"path"
-)
 
-var (
-	ErrPathRelative = errors.New("path not absolute")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validatePath(p string) error {
 	if !path.IsAbs(p) {
-		return ErrPathRelative
+		return errors.ErrPathRelative
 	}
 	return nil
 }

--- a/config/v2_1/types/path_test.go
+++ b/config/v2_1/types/path_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestPathValidate(t *testing.T) {
@@ -49,7 +51,7 @@ func TestPathValidate(t *testing.T) {
 		},
 		{
 			in:  in{device: "relative/path"},
-			out: out{err: ErrPathRelative},
+			out: out{err: errors.ErrPathRelative},
 		},
 	}
 

--- a/config/v2_1/types/raid.go
+++ b/config/v2_1/types/raid.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -26,7 +25,7 @@ func (n Raid) ValidateLevel() report.Report {
 	case "linear", "raid0", "0", "stripe":
 		if n.Spares != 0 {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("spares unsupported for %q arrays", n.Level),
+				Message: errors.ErrSparesUnsupportedForLevel.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -37,7 +36,7 @@ func (n Raid) ValidateLevel() report.Report {
 	case "raid10", "10":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("unrecognized raid level: %q", n.Level),
+			Message: errors.ErrUnrecognizedRaidLevel.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -49,7 +48,7 @@ func (n Raid) ValidateDevices() report.Report {
 	for _, d := range n.Devices {
 		if err := validatePath(string(d)); err != nil {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("array %q: device path not absolute: %q", n.Name, d),
+				Message: errors.ErrPathRelative.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_1/types/unit.go
+++ b/config/v2_1/types/unit.go
@@ -15,20 +15,15 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/shared/validations"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrInvalidSystemdExt  = errors.New("invalid systemd unit extension")
-	ErrInvalidNetworkdExt = errors.New("invalid networkd unit extension")
 )
 
 func (u Unit) ValidateContents() report.Report {
@@ -53,7 +48,7 @@ func (u Unit) ValidateName() report.Report {
 	case ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice", ".scope":
 	default:
 		r.Add(report.Entry{
-			Message: ErrInvalidSystemdExt.Error(),
+			Message: errors.ErrInvalidSystemdExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -74,7 +69,7 @@ func (d Dropin) Validate() report.Report {
 	case ".conf":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid systemd unit drop-in extension: %q", path.Ext(d.Name)),
+			Message: errors.ErrInvalidSystemdDropinExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -96,7 +91,7 @@ func (u Networkdunit) Validate() report.Report {
 	case ".link", ".netdev", ".network":
 	default:
 		r.Add(report.Entry{
-			Message: ErrInvalidNetworkdExt.Error(),
+			Message: errors.ErrInvalidNetworkdExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/unit_test.go
+++ b/config/v2_1/types/unit_test.go
@@ -15,10 +15,11 @@
 package types
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -40,7 +41,7 @@ func TestSystemdUnitValidateContents(t *testing.T) {
 		},
 		{
 			in:  in{unit: Unit{Name: "test.service", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 		{
 			in:  in{unit: Unit{Name: "test.service", Contents: "", Dropins: []Dropin{{}}}},
@@ -78,7 +79,7 @@ func TestSystemdUnitValidateName(t *testing.T) {
 		},
 		{
 			in:  in{unit: "test.blah"},
-			out: out{err: ErrInvalidSystemdExt},
+			out: out{err: errors.ErrInvalidSystemdExt},
 		},
 	}
 
@@ -108,7 +109,7 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: Dropin{Name: "test.conf", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 
@@ -146,7 +147,7 @@ func TestNetworkdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: "test.blah"},
-			out: out{err: ErrInvalidNetworkdExt},
+			out: out{err: errors.ErrInvalidNetworkdExt},
 		},
 	}
 
@@ -176,7 +177,7 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: Networkdunit{Name: "test.network", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 

--- a/config/v2_1/types/url.go
+++ b/config/v2_1/types/url.go
@@ -15,14 +15,10 @@
 package types
 
 import (
-	"errors"
 	"net/url"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/vincent-petithory/dataurl"
-)
-
-var (
-	ErrInvalidScheme = errors.New("invalid url scheme")
 )
 
 func validateURL(s string) error {
@@ -32,7 +28,7 @@ func validateURL(s string) error {
 	}
 	u, err := url.Parse(s)
 	if err != nil {
-		return err
+		return errors.ErrInvalidUrl
 	}
 
 	switch u.Scheme {
@@ -44,6 +40,6 @@ func validateURL(s string) error {
 		}
 		return nil
 	default:
-		return ErrInvalidScheme
+		return errors.ErrInvalidScheme
 	}
 }

--- a/config/v2_1/types/url_test.go
+++ b/config/v2_1/types/url_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestURLValidate(t *testing.T) {
@@ -57,7 +59,7 @@ func TestURLValidate(t *testing.T) {
 		},
 		{
 			in:  in{u: "bad://"},
-			out: out{err: ErrInvalidScheme},
+			out: out{err: errors.ErrInvalidScheme},
 		},
 	}
 

--- a/config/v2_1/types/verification.go
+++ b/config/v2_1/types/verification.go
@@ -17,16 +17,10 @@ package types
 import (
 	"crypto"
 	"encoding/hex"
-	"errors"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrHashMalformed    = errors.New("malformed hash specifier")
-	ErrHashWrongSize    = errors.New("incorrect size for hash sum")
-	ErrHashUnrecognized = errors.New("unrecognized hash function")
 )
 
 // HashParts will return the sum and function (in that order) of the hash stored
@@ -38,7 +32,7 @@ func (v Verification) HashParts() (string, string, error) {
 	}
 	parts := strings.SplitN(*v.Hash, "-", 2)
 	if len(parts) != 2 {
-		return "", "", ErrHashMalformed
+		return "", "", errors.ErrHashMalformed
 	}
 
 	return parts[0], parts[1], nil
@@ -66,7 +60,7 @@ func (v Verification) Validate() report.Report {
 		hash = crypto.SHA512
 	default:
 		r.Add(report.Entry{
-			Message: ErrHashUnrecognized.Error(),
+			Message: errors.ErrHashUnrecognized.Error(),
 			Kind:    report.EntryError,
 		})
 		return r
@@ -74,7 +68,7 @@ func (v Verification) Validate() report.Report {
 
 	if len(sum) != hex.EncodedLen(hash.Size()) {
 		r.Add(report.Entry{
-			Message: ErrHashWrongSize.Error(),
+			Message: errors.ErrHashWrongSize.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_1/types/verification_test.go
+++ b/config/v2_1/types/verification_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -38,7 +39,7 @@ func TestHashParts(t *testing.T) {
 		},
 		{
 			in:  in{data: `"sha512:01234567"`},
-			out: out{err: ErrHashMalformed},
+			out: out{err: errors.ErrHashMalformed},
 		},
 	}
 
@@ -71,11 +72,11 @@ func TestHashValidate(t *testing.T) {
 	}{
 		{
 			in:  in{v: Verification{Hash: &h1}},
-			out: out{err: ErrHashUnrecognized},
+			out: out{err: errors.ErrHashUnrecognized},
 		},
 		{
 			in:  in{v: Verification{Hash: &h2}},
-			out: out{err: ErrHashWrongSize},
+			out: out{err: errors.ErrHashWrongSize},
 		},
 		{
 			in:  in{v: Verification{Hash: &h3}},

--- a/config/v2_2/types/ca.go
+++ b/config/v2_2/types/ca.go
@@ -15,17 +15,13 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 func (c CaReference) ValidateSource() report.Report {
 	err := validateURL(c.Source)
 	if err != nil {
-		return report.ReportFromError(
-			fmt.Errorf("invalid url %q: %v", c.Source, err),
-			report.EntryError)
+		return report.ReportFromError(err, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_2/types/directory.go
+++ b/config/v2_2/types/directory.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -28,7 +29,7 @@ func (d Directory) ValidateMode() report.Report {
 	}
 	if d.Mode == nil {
 		r.Add(report.Entry{
-			Message: "directory permissions unset, defaulting to 0000",
+			Message: errors.ErrPermissionsUnset.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}

--- a/config/v2_2/types/disk.go
+++ b/config/v2_2/types/disk.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -26,7 +25,7 @@ func (n Disk) Validate() report.Report {
 
 func (n Disk) ValidateDevice() report.Report {
 	if len(n.Device) == 0 {
-		return report.ReportFromError(fmt.Errorf("disk device is required"), report.EntryError)
+		return report.ReportFromError(errors.ErrDiskDeviceRequired, report.EntryError)
 	}
 	if err := validatePath(string(n.Device)); err != nil {
 		return report.ReportFromError(err, report.EntryError)
@@ -38,19 +37,19 @@ func (n Disk) ValidatePartitions() report.Report {
 	r := report.Report{}
 	if n.partitionNumbersCollide() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partition numbers collide", n.Device),
+			Message: errors.ErrPartitionNumbersCollide.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsOverlap() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions overlap", n.Device),
+			Message: errors.ErrPartitionsOverlap.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsMisaligned() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions misaligned", n.Device),
+			Message: errors.ErrPartitionsMisaligned.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_2/types/file.go
+++ b/config/v2_2/types/file.go
@@ -15,20 +15,13 @@
 package types
 
 import (
-	"errors"
-	"fmt"
-
-	configErrors "github.com/coreos/ignition/config/shared/errors"
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrAppendAndOverwrite = errors.New("cannot set both append and overwrite to true")
 )
 
 func (f File) Validate() report.Report {
 	if f.Overwrite != nil && *f.Overwrite && f.Append {
-		return report.ReportFromError(ErrAppendAndOverwrite, report.EntryError)
+		return report.ReportFromError(errors.ErrAppendAndOverwrite, report.EntryError)
 	}
 	return report.Report{}
 }
@@ -43,7 +36,7 @@ func (f File) ValidateMode() report.Report {
 	}
 	if f.Mode == nil {
 		r.Add(report.Entry{
-			Message: "file permissions unset, defaulting to 0000",
+			Message: errors.ErrPermissionsUnset.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}
@@ -56,7 +49,7 @@ func (fc FileContents) ValidateCompression() report.Report {
 	case "", "gzip":
 	default:
 		r.Add(report.Entry{
-			Message: configErrors.ErrCompressionInvalid.Error(),
+			Message: errors.ErrCompressionInvalid.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -68,7 +61,7 @@ func (fc FileContents) ValidateSource() report.Report {
 	err := validateURL(fc.Source)
 	if err != nil {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid url %q: %v", fc.Source, err),
+			Message: err.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_2/types/filesystem.go
+++ b/config/v2_2/types/filesystem.go
@@ -15,56 +15,40 @@
 package types
 
 import (
-	"errors"
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFilesystemInvalidFormat     = errors.New("invalid filesystem format")
-	ErrFilesystemNoMountPath       = errors.New("filesystem is missing mount or path")
-	ErrFilesystemMountAndPath      = errors.New("filesystem has both mount and path defined")
-	ErrUsedCreateAndMountOpts      = errors.New("cannot use both create object and mount-level options field")
-	ErrUsedCreateAndWipeFilesystem = errors.New("cannot use both create object and wipeFilesystem field")
-	ErrWarningCreateDeprecated     = errors.New("the create object has been deprecated in favor of mount-level options")
-	ErrExt4LabelTooLong            = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
-	ErrBtrfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
-	ErrXfsLabelTooLong             = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")
-	ErrSwapLabelTooLong            = errors.New("filesystem labels cannot be longer than 15 characters when using swap")
-	ErrVfatLabelTooLong            = errors.New("filesystem labels cannot be longer than 11 characters when using vfat")
 )
 
 func (f Filesystem) Validate() report.Report {
 	r := report.Report{}
 	if f.Mount == nil && f.Path == nil {
 		r.Add(report.Entry{
-			Message: ErrFilesystemNoMountPath.Error(),
+			Message: errors.ErrFilesystemNoMountPath.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if f.Mount != nil {
 		if f.Path != nil {
 			r.Add(report.Entry{
-				Message: ErrFilesystemMountAndPath.Error(),
+				Message: errors.ErrFilesystemMountAndPath.Error(),
 				Kind:    report.EntryError,
 			})
 		}
 		if f.Mount.Create != nil {
 			if f.Mount.WipeFilesystem {
 				r.Add(report.Entry{
-					Message: ErrUsedCreateAndWipeFilesystem.Error(),
+					Message: errors.ErrUsedCreateAndWipeFilesystem.Error(),
 					Kind:    report.EntryError,
 				})
 			}
 			if len(f.Mount.Options) > 0 {
 				r.Add(report.Entry{
-					Message: ErrUsedCreateAndMountOpts.Error(),
+					Message: errors.ErrUsedCreateAndMountOpts.Error(),
 					Kind:    report.EntryError,
 				})
 			}
 			r.Add(report.Entry{
-				Message: ErrWarningCreateDeprecated.Error(),
+				Message: errors.ErrWarningCreateDeprecated.Error(),
 				Kind:    report.EntryWarning,
 			})
 		}
@@ -76,7 +60,7 @@ func (f Filesystem) ValidatePath() report.Report {
 	r := report.Report{}
 	if f.Path != nil && validatePath(*f.Path) != nil {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("filesystem %q: path not absolute", f.Name),
+			Message: errors.ErrPathRelative.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -89,7 +73,7 @@ func (m Mount) Validate() report.Report {
 	case "ext4", "btrfs", "xfs", "swap", "vfat":
 	default:
 		r.Add(report.Entry{
-			Message: ErrFilesystemInvalidFormat.Error(),
+			Message: errors.ErrFilesystemInvalidFormat.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -117,7 +101,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 16 {
 			// source: man mkfs.ext4
 			r.Add(report.Entry{
-				Message: ErrExt4LabelTooLong.Error(),
+				Message: errors.ErrExt4LabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -125,7 +109,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 256 {
 			// source: man mkfs.btrfs
 			r.Add(report.Entry{
-				Message: ErrBtrfsLabelTooLong.Error(),
+				Message: errors.ErrBtrfsLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -133,7 +117,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 12 {
 			// source: man mkfs.xfs
 			r.Add(report.Entry{
-				Message: ErrXfsLabelTooLong.Error(),
+				Message: errors.ErrXfsLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -143,7 +127,7 @@ func (m Mount) ValidateLabel() report.Report {
 		// 15 characters, so let's enforce that.
 		if len(*m.Label) > 15 {
 			r.Add(report.Entry{
-				Message: ErrSwapLabelTooLong.Error(),
+				Message: errors.ErrSwapLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -151,7 +135,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 11 {
 			// source: man mkfs.fat
 			r.Add(report.Entry{
-				Message: ErrVfatLabelTooLong.Error(),
+				Message: errors.ErrVfatLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_2/types/filesystem_test.go
+++ b/config/v2_2/types/filesystem_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -43,7 +44,7 @@ func TestMountValidate(t *testing.T) {
 		},
 		{
 			in:  in{format: ""},
-			out: out{err: ErrFilesystemInvalidFormat},
+			out: out{err: errors.ErrFilesystemInvalidFormat},
 		},
 	}
 
@@ -77,11 +78,11 @@ func TestFilesystemValidate(t *testing.T) {
 		},
 		{
 			in:  in{filesystem: Filesystem{Path: func(p string) *string { return &p }("/mount"), Mount: &Mount{Device: "/foo", Format: "ext4"}}},
-			out: out{err: ErrFilesystemMountAndPath},
+			out: out{err: errors.ErrFilesystemMountAndPath},
 		},
 		{
 			in:  in{filesystem: Filesystem{}},
-			out: out{err: ErrFilesystemNoMountPath},
+			out: out{err: errors.ErrFilesystemNoMountPath},
 		},
 	}
 
@@ -117,7 +118,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "ext4", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrExt4LabelTooLong},
+			out: out{err: errors.ErrExt4LabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "btrfs", Label: nil}},
@@ -129,7 +130,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "btrfs", Label: strToPtr("thislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolong")}},
-			out: out{err: ErrBtrfsLabelTooLong},
+			out: out{err: errors.ErrBtrfsLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "xfs", Label: nil}},
@@ -141,7 +142,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "xfs", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrXfsLabelTooLong},
+			out: out{err: errors.ErrXfsLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "swap", Label: nil}},
@@ -153,7 +154,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "swap", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrSwapLabelTooLong},
+			out: out{err: errors.ErrSwapLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "vfat", Label: nil}},
@@ -165,7 +166,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "vfat", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrVfatLabelTooLong},
+			out: out{err: errors.ErrVfatLabelTooLong},
 		},
 	}
 

--- a/config/v2_2/types/ignition.go
+++ b/config/v2_2/types/ignition.go
@@ -15,17 +15,10 @@
 package types
 
 import (
-	"errors"
-
 	"github.com/coreos/go-semver/semver"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrOldVersion     = errors.New("incorrect config version (too old)")
-	ErrNewVersion     = errors.New("incorrect config version (too new)")
-	ErrInvalidVersion = errors.New("invalid config version (couldn't parse)")
 )
 
 func (c ConfigReference) ValidateSource() report.Report {
@@ -47,13 +40,13 @@ func (v Ignition) Semver() (*semver.Version, error) {
 func (v Ignition) Validate() report.Report {
 	tv, err := v.Semver()
 	if err != nil {
-		return report.ReportFromError(ErrInvalidVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidVersion, report.EntryError)
 	}
 	if MaxVersion.Major > tv.Major {
-		return report.ReportFromError(ErrOldVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrOldVersion, report.EntryError)
 	}
 	if MaxVersion.LessThan(*tv) {
-		return report.ReportFromError(ErrNewVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrNewVersion, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_2/types/link.go
+++ b/config/v2_2/types/link.go
@@ -15,18 +15,16 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/coreos/ignition/config/validate/report"
 )
 
-func (s Link) Validate() report.Report {
+func (s LinkEmbedded1) ValidateTarget() report.Report {
 	r := report.Report{}
 	if !s.Hard {
 		err := validatePath(s.Target)
 		if err != nil {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("problem with target path %q: %v", s.Target, err),
+				Message: err.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_2/types/mode.go
+++ b/config/v2_2/types/mode.go
@@ -15,16 +15,12 @@
 package types
 
 import (
-	"errors"
-)
-
-var (
-	ErrFileIllegalMode = errors.New("illegal file mode")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validateMode(m *int) error {
 	if m != nil && (*m < 0 || *m > 07777) {
-		return ErrFileIllegalMode
+		return errors.ErrFileIllegalMode
 	}
 	return nil
 }

--- a/config/v2_2/types/mode_test.go
+++ b/config/v2_2/types/mode_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/util"
 )
 
@@ -55,7 +56,7 @@ func TestModeValidate(t *testing.T) {
 		},
 		{
 			in:  in{mode: util.IntToPtr(010000)},
-			out: out{ErrFileIllegalMode},
+			out: out{errors.ErrFileIllegalMode},
 		},
 	}
 

--- a/config/v2_2/types/node.go
+++ b/config/v2_2/types/node.go
@@ -15,22 +15,17 @@
 package types
 
 import (
-	"errors"
 	"path/filepath"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrNoFilesystem     = errors.New("no filesystem specified")
-	ErrBothIDAndNameSet = errors.New("cannot set both id and name")
 )
 
 func (n Node) ValidateFilesystem() report.Report {
 	r := report.Report{}
 	if n.Filesystem == "" {
 		r.Add(report.Entry{
-			Message: ErrNoFilesystem.Error(),
+			Message: errors.ErrNoFilesystem.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -60,7 +55,7 @@ func (nu NodeUser) Validate() report.Report {
 	r := report.Report{}
 	if nu.ID != nil && nu.Name != "" {
 		r.Add(report.Entry{
-			Message: ErrBothIDAndNameSet.Error(),
+			Message: errors.ErrBothIDAndNameSet.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -70,7 +65,7 @@ func (ng NodeGroup) Validate() report.Report {
 	r := report.Report{}
 	if ng.ID != nil && ng.Name != "" {
 		r.Add(report.Entry{
-			Message: ErrBothIDAndNameSet.Error(),
+			Message: errors.ErrBothIDAndNameSet.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_2/types/node_test.go
+++ b/config/v2_2/types/node_test.go
@@ -18,13 +18,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/util"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 func TestNodeValidatePath(t *testing.T) {
 	node := Node{Path: "not/absolute"}
-	rep := report.ReportFromError(ErrPathRelative, report.EntryError)
+	rep := report.ReportFromError(errors.ErrPathRelative, report.EntryError)
 	if receivedRep := node.ValidatePath(); !reflect.DeepEqual(rep, receivedRep) {
 		t.Errorf("bad error: want %v, got %v", rep, receivedRep)
 	}
@@ -41,7 +42,7 @@ func TestNodeValidateFilesystem(t *testing.T) {
 		},
 		{
 			node: Node{Path: "/"},
-			r:    report.ReportFromError(ErrNoFilesystem, report.EntryError),
+			r:    report.ReportFromError(errors.ErrNoFilesystem, report.EntryError),
 		},
 	}
 	for i, test := range tests {
@@ -70,7 +71,7 @@ func TestNodeValidateUser(t *testing.T) {
 		},
 		{
 			in:  NodeUser{util.IntToPtr(1000), "core"},
-			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+			out: report.ReportFromError(errors.ErrBothIDAndNameSet, report.EntryError),
 		},
 	}
 
@@ -101,7 +102,7 @@ func TestNodeValidateGroup(t *testing.T) {
 		},
 		{
 			in:  NodeGroup{util.IntToPtr(1000), "core"},
-			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+			out: report.ReportFromError(errors.ErrBothIDAndNameSet, report.EntryError),
 		},
 	}
 

--- a/config/v2_2/types/partition.go
+++ b/config/v2_2/types/partition.go
@@ -15,22 +15,16 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 const (
 	guidRegexStr = "^(|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$"
-)
-
-var (
-	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
-	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
-	ErrLabelContainsColon   = errors.New("partition label will be truncated to text before the colon")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -42,7 +36,7 @@ func (p Partition) ValidateLabel() report.Report {
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(p.Label) > 36 {
 		r.Add(report.Entry{
-			Message: ErrLabelTooLong.Error(),
+			Message: errors.ErrLabelTooLong.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -50,7 +44,7 @@ func (p Partition) ValidateLabel() report.Report {
 	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
 	if strings.Contains(p.Label, ":") {
 		r.Add(report.Entry{
-			Message: ErrLabelContainsColon.Error(),
+			Message: errors.ErrLabelContainsColon.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}
@@ -75,7 +69,7 @@ func validateGUID(guid string) report.Report {
 		})
 	} else if !ok {
 		r.Add(report.Entry{
-			Message: ErrDoesntMatchGUIDRegex.Error(),
+			Message: errors.ErrDoesntMatchGUIDRegex.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_2/types/partition_test.go
+++ b/config/v2_2/types/partition_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -46,11 +47,11 @@ func TestValidateLabel(t *testing.T) {
 		},
 		{
 			in{"1111111111111111111111111111111111111"},
-			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
+			out{report.ReportFromError(errors.ErrLabelTooLong, report.EntryError)},
 		},
 		{
 			in{"test:"},
-			out{report.ReportFromError(ErrLabelContainsColon, report.EntryWarning)},
+			out{report.ReportFromError(errors.ErrLabelContainsColon, report.EntryWarning)},
 		},
 	}
 	for i, test := range tests {
@@ -82,7 +83,7 @@ func TestValidateTypeGUID(t *testing.T) {
 		},
 		{
 			in{"not-a-valid-typeguid"},
-			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+			out{report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)},
 		},
 	}
 	for i, test := range tests {
@@ -114,7 +115,7 @@ func TestValidateGUID(t *testing.T) {
 		},
 		{
 			in{"not-a-valid-typeguid"},
-			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+			out{report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)},
 		},
 	}
 	for i, test := range tests {

--- a/config/v2_2/types/passwd.go
+++ b/config/v2_2/types/passwd.go
@@ -15,30 +15,15 @@
 package types
 
 import (
-	"errors"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrPasswdCreateDeprecated      = errors.New("the create object has been deprecated in favor of user-level options")
-	ErrPasswdCreateAndGecos        = errors.New("cannot use both the create object and the user-level gecos field")
-	ErrPasswdCreateAndGroups       = errors.New("cannot use both the create object and the user-level groups field")
-	ErrPasswdCreateAndHomeDir      = errors.New("cannot use both the create object and the user-level homeDir field")
-	ErrPasswdCreateAndNoCreateHome = errors.New("cannot use both the create object and the user-level noCreateHome field")
-	ErrPasswdCreateAndNoLogInit    = errors.New("cannot use both the create object and the user-level noLogInit field")
-	ErrPasswdCreateAndNoUserGroup  = errors.New("cannot use both the create object and the user-level noUserGroup field")
-	ErrPasswdCreateAndPrimaryGroup = errors.New("cannot use both the create object and the user-level primaryGroup field")
-	ErrPasswdCreateAndShell        = errors.New("cannot use both the create object and the user-level shell field")
-	ErrPasswdCreateAndSystem       = errors.New("cannot use both the create object and the user-level system field")
-	ErrPasswdCreateAndUID          = errors.New("cannot use both the create object and the user-level uid field")
 )
 
 func (p PasswdUser) Validate() report.Report {
 	r := report.Report{}
 	if p.Create != nil {
 		r.Add(report.Entry{
-			Message: ErrPasswdCreateDeprecated.Error(),
+			Message: errors.ErrPasswdCreateDeprecated.Error(),
 			Kind:    report.EntryWarning,
 		})
 		addErr := func(err error) {
@@ -48,34 +33,34 @@ func (p PasswdUser) Validate() report.Report {
 			})
 		}
 		if p.Gecos != "" {
-			addErr(ErrPasswdCreateAndGecos)
+			addErr(errors.ErrPasswdCreateAndGecos)
 		}
 		if len(p.Groups) > 0 {
-			addErr(ErrPasswdCreateAndGroups)
+			addErr(errors.ErrPasswdCreateAndGroups)
 		}
 		if p.HomeDir != "" {
-			addErr(ErrPasswdCreateAndHomeDir)
+			addErr(errors.ErrPasswdCreateAndHomeDir)
 		}
 		if p.NoCreateHome {
-			addErr(ErrPasswdCreateAndNoCreateHome)
+			addErr(errors.ErrPasswdCreateAndNoCreateHome)
 		}
 		if p.NoLogInit {
-			addErr(ErrPasswdCreateAndNoLogInit)
+			addErr(errors.ErrPasswdCreateAndNoLogInit)
 		}
 		if p.NoUserGroup {
-			addErr(ErrPasswdCreateAndNoUserGroup)
+			addErr(errors.ErrPasswdCreateAndNoUserGroup)
 		}
 		if p.PrimaryGroup != "" {
-			addErr(ErrPasswdCreateAndPrimaryGroup)
+			addErr(errors.ErrPasswdCreateAndPrimaryGroup)
 		}
 		if p.Shell != "" {
-			addErr(ErrPasswdCreateAndShell)
+			addErr(errors.ErrPasswdCreateAndShell)
 		}
 		if p.System {
-			addErr(ErrPasswdCreateAndSystem)
+			addErr(errors.ErrPasswdCreateAndSystem)
 		}
 		if p.UID != nil {
-			addErr(ErrPasswdCreateAndUID)
+			addErr(errors.ErrPasswdCreateAndUID)
 		}
 	}
 	return r

--- a/config/v2_2/types/path.go
+++ b/config/v2_2/types/path.go
@@ -15,17 +15,14 @@
 package types
 
 import (
-	"errors"
 	"path"
-)
 
-var (
-	ErrPathRelative = errors.New("path not absolute")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validatePath(p string) error {
 	if !path.IsAbs(p) {
-		return ErrPathRelative
+		return errors.ErrPathRelative
 	}
 	return nil
 }

--- a/config/v2_2/types/path_test.go
+++ b/config/v2_2/types/path_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestPathValidate(t *testing.T) {
@@ -49,7 +51,7 @@ func TestPathValidate(t *testing.T) {
 		},
 		{
 			in:  in{device: "relative/path"},
-			out: out{err: ErrPathRelative},
+			out: out{err: errors.ErrPathRelative},
 		},
 	}
 

--- a/config/v2_2/types/raid.go
+++ b/config/v2_2/types/raid.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -26,7 +25,7 @@ func (n Raid) ValidateLevel() report.Report {
 	case "linear", "raid0", "0", "stripe":
 		if n.Spares != 0 {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("spares unsupported for %q arrays", n.Level),
+				Message: errors.ErrSparesUnsupportedForLevel.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -37,7 +36,7 @@ func (n Raid) ValidateLevel() report.Report {
 	case "raid10", "10":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("unrecognized raid level: %q", n.Level),
+			Message: errors.ErrUnrecognizedRaidLevel.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -49,7 +48,7 @@ func (n Raid) ValidateDevices() report.Report {
 	for _, d := range n.Devices {
 		if err := validatePath(string(d)); err != nil {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("array %q: device path not absolute: %q", n.Name, d),
+				Message: errors.ErrPathRelative.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_2/types/unit.go
+++ b/config/v2_2/types/unit.go
@@ -15,20 +15,15 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/shared/validations"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrInvalidSystemdExt  = errors.New("invalid systemd unit extension")
-	ErrInvalidNetworkdExt = errors.New("invalid networkd unit extension")
 )
 
 func (u Unit) ValidateContents() report.Report {
@@ -53,7 +48,7 @@ func (u Unit) ValidateName() report.Report {
 	case ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice", ".scope":
 	default:
 		r.Add(report.Entry{
-			Message: ErrInvalidSystemdExt.Error(),
+			Message: errors.ErrInvalidSystemdExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -74,7 +69,7 @@ func (d SystemdDropin) Validate() report.Report {
 	case ".conf":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid systemd unit drop-in extension: %q", path.Ext(d.Name)),
+			Message: errors.ErrInvalidSystemdDropinExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -96,7 +91,7 @@ func (u Networkdunit) Validate() report.Report {
 	case ".link", ".netdev", ".network":
 	default:
 		r.Add(report.Entry{
-			Message: ErrInvalidNetworkdExt.Error(),
+			Message: errors.ErrInvalidNetworkdExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -118,7 +113,7 @@ func (d NetworkdDropin) Validate() report.Report {
 	case ".conf":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid networkd unit drop-in extension: %q", path.Ext(d.Name)),
+			Message: errors.ErrInvalidNetworkdDropinExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_2/types/unit_test.go
+++ b/config/v2_2/types/unit_test.go
@@ -15,10 +15,11 @@
 package types
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -40,7 +41,7 @@ func TestSystemdUnitValidateContents(t *testing.T) {
 		},
 		{
 			in:  in{unit: Unit{Name: "test.service", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 		{
 			in:  in{unit: Unit{Name: "test.service", Contents: "", Dropins: []SystemdDropin{{}}}},
@@ -78,7 +79,7 @@ func TestSystemdUnitValidateName(t *testing.T) {
 		},
 		{
 			in:  in{unit: "test.blah"},
-			out: out{err: ErrInvalidSystemdExt},
+			out: out{err: errors.ErrInvalidSystemdExt},
 		},
 	}
 
@@ -108,7 +109,7 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: SystemdDropin{Name: "test.conf", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 
@@ -146,7 +147,7 @@ func TestNetworkdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: "test.blah"},
-			out: out{err: ErrInvalidNetworkdExt},
+			out: out{err: errors.ErrInvalidNetworkdExt},
 		},
 	}
 
@@ -176,7 +177,7 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: Networkdunit{Name: "test.network", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 
@@ -206,7 +207,7 @@ func TestNetworkdUnitDropInValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: NetworkdDropin{Name: "test.conf", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 

--- a/config/v2_2/types/url.go
+++ b/config/v2_2/types/url.go
@@ -15,14 +15,11 @@
 package types
 
 import (
-	"errors"
 	"net/url"
 
 	"github.com/vincent-petithory/dataurl"
-)
 
-var (
-	ErrInvalidScheme = errors.New("invalid url scheme")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validateURL(s string) error {
@@ -32,7 +29,7 @@ func validateURL(s string) error {
 	}
 	u, err := url.Parse(s)
 	if err != nil {
-		return err
+		return errors.ErrInvalidUrl
 	}
 
 	switch u.Scheme {
@@ -44,6 +41,6 @@ func validateURL(s string) error {
 		}
 		return nil
 	default:
-		return ErrInvalidScheme
+		return errors.ErrInvalidScheme
 	}
 }

--- a/config/v2_2/types/url_test.go
+++ b/config/v2_2/types/url_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestURLValidate(t *testing.T) {
@@ -57,7 +59,7 @@ func TestURLValidate(t *testing.T) {
 		},
 		{
 			in:  in{u: "bad://"},
-			out: out{err: ErrInvalidScheme},
+			out: out{err: errors.ErrInvalidScheme},
 		},
 	}
 

--- a/config/v2_2/types/verification.go
+++ b/config/v2_2/types/verification.go
@@ -17,16 +17,10 @@ package types
 import (
 	"crypto"
 	"encoding/hex"
-	"errors"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrHashMalformed    = errors.New("malformed hash specifier")
-	ErrHashWrongSize    = errors.New("incorrect size for hash sum")
-	ErrHashUnrecognized = errors.New("unrecognized hash function")
 )
 
 // HashParts will return the sum and function (in that order) of the hash stored
@@ -38,7 +32,7 @@ func (v Verification) HashParts() (string, string, error) {
 	}
 	parts := strings.SplitN(*v.Hash, "-", 2)
 	if len(parts) != 2 {
-		return "", "", ErrHashMalformed
+		return "", "", errors.ErrHashMalformed
 	}
 
 	return parts[0], parts[1], nil
@@ -66,7 +60,7 @@ func (v Verification) Validate() report.Report {
 		hash = crypto.SHA512
 	default:
 		r.Add(report.Entry{
-			Message: ErrHashUnrecognized.Error(),
+			Message: errors.ErrHashUnrecognized.Error(),
 			Kind:    report.EntryError,
 		})
 		return r
@@ -74,7 +68,7 @@ func (v Verification) Validate() report.Report {
 
 	if len(sum) != hex.EncodedLen(hash.Size()) {
 		r.Add(report.Entry{
-			Message: ErrHashWrongSize.Error(),
+			Message: errors.ErrHashWrongSize.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_2/types/verification_test.go
+++ b/config/v2_2/types/verification_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -38,7 +39,7 @@ func TestHashParts(t *testing.T) {
 		},
 		{
 			in:  in{data: `"sha512:01234567"`},
-			out: out{err: ErrHashMalformed},
+			out: out{err: errors.ErrHashMalformed},
 		},
 	}
 
@@ -71,11 +72,11 @@ func TestHashValidate(t *testing.T) {
 	}{
 		{
 			in:  in{v: Verification{Hash: &h1}},
-			out: out{err: ErrHashUnrecognized},
+			out: out{err: errors.ErrHashUnrecognized},
 		},
 		{
 			in:  in{v: Verification{Hash: &h2}},
-			out: out{err: ErrHashWrongSize},
+			out: out{err: errors.ErrHashWrongSize},
 		},
 		{
 			in:  in{v: Verification{Hash: &h3}},

--- a/config/v2_3_experimental/config.go
+++ b/config/v2_3_experimental/config.go
@@ -54,7 +54,7 @@ func Parse(rawConfig []byte) (types.Config, report.Report, error) {
 	}
 
 	if *version != types.MaxVersion {
-		return types.Config{}, report.Report{}, errors.ErrInvalid
+		return types.Config{}, report.Report{}, errors.ErrUnknownVersion
 	}
 
 	rpt := validate.ValidateConfig(rawConfig, config)

--- a/config/v2_3_experimental/types/ca.go
+++ b/config/v2_3_experimental/types/ca.go
@@ -15,17 +15,13 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 func (c CaReference) ValidateSource() report.Report {
 	err := validateURL(c.Source)
 	if err != nil {
-		return report.ReportFromError(
-			fmt.Errorf("invalid url %q: %v", c.Source, err),
-			report.EntryError)
+		return report.ReportFromError(err, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_3_experimental/types/directory.go
+++ b/config/v2_3_experimental/types/directory.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -28,7 +29,7 @@ func (d Directory) ValidateMode() report.Report {
 	}
 	if d.Mode == nil {
 		r.Add(report.Entry{
-			Message: "directory permissions unset, defaulting to 0000",
+			Message: errors.ErrPermissionsUnset.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}

--- a/config/v2_3_experimental/types/disk.go
+++ b/config/v2_3_experimental/types/disk.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -26,7 +25,7 @@ func (n Disk) Validate() report.Report {
 
 func (n Disk) ValidateDevice() report.Report {
 	if len(n.Device) == 0 {
-		return report.ReportFromError(fmt.Errorf("disk device is required"), report.EntryError)
+		return report.ReportFromError(errors.ErrDiskDeviceRequired, report.EntryError)
 	}
 	if err := validatePath(string(n.Device)); err != nil {
 		return report.ReportFromError(err, report.EntryError)
@@ -38,19 +37,19 @@ func (n Disk) ValidatePartitions() report.Report {
 	r := report.Report{}
 	if n.partitionNumbersCollide() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partition numbers collide", n.Device),
+			Message: errors.ErrPartitionNumbersCollide.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsOverlap() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions overlap", n.Device),
+			Message: errors.ErrPartitionsOverlap.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if n.partitionsMisaligned() {
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("disk %q: partitions misaligned", n.Device),
+			Message: errors.ErrPartitionsMisaligned.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_3_experimental/types/file.go
+++ b/config/v2_3_experimental/types/file.go
@@ -15,20 +15,15 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 
-	configErrors "github.com/coreos/ignition/config/shared/errors"
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrAppendAndOverwrite = errors.New("cannot set both append and overwrite to true")
 )
 
 func (f File) Validate() report.Report {
 	if f.Overwrite != nil && *f.Overwrite && f.Append {
-		return report.ReportFromError(ErrAppendAndOverwrite, report.EntryError)
+		return report.ReportFromError(errors.ErrAppendAndOverwrite, report.EntryError)
 	}
 	return report.Report{}
 }
@@ -43,7 +38,7 @@ func (f File) ValidateMode() report.Report {
 	}
 	if f.Mode == nil {
 		r.Add(report.Entry{
-			Message: "file permissions unset, defaulting to 0000",
+			Message: errors.ErrPermissionsUnset.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}
@@ -56,7 +51,7 @@ func (fc FileContents) ValidateCompression() report.Report {
 	case "", "gzip":
 	default:
 		r.Add(report.Entry{
-			Message: configErrors.ErrCompressionInvalid.Error(),
+			Message: errors.ErrCompressionInvalid.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_3_experimental/types/filesystem.go
+++ b/config/v2_3_experimental/types/filesystem.go
@@ -15,56 +15,42 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrFilesystemInvalidFormat     = errors.New("invalid filesystem format")
-	ErrFilesystemNoMountPath       = errors.New("filesystem is missing mount or path")
-	ErrFilesystemMountAndPath      = errors.New("filesystem has both mount and path defined")
-	ErrUsedCreateAndMountOpts      = errors.New("cannot use both create object and mount-level options field")
-	ErrUsedCreateAndWipeFilesystem = errors.New("cannot use both create object and wipeFilesystem field")
-	ErrWarningCreateDeprecated     = errors.New("the create object has been deprecated in favor of mount-level options")
-	ErrExt4LabelTooLong            = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
-	ErrBtrfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
-	ErrXfsLabelTooLong             = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")
-	ErrSwapLabelTooLong            = errors.New("filesystem labels cannot be longer than 15 characters when using swap")
-	ErrVfatLabelTooLong            = errors.New("filesystem labels cannot be longer than 11 characters when using vfat")
 )
 
 func (f Filesystem) Validate() report.Report {
 	r := report.Report{}
 	if f.Mount == nil && f.Path == nil {
 		r.Add(report.Entry{
-			Message: ErrFilesystemNoMountPath.Error(),
+			Message: errors.ErrFilesystemNoMountPath.Error(),
 			Kind:    report.EntryError,
 		})
 	}
 	if f.Mount != nil {
 		if f.Path != nil {
 			r.Add(report.Entry{
-				Message: ErrFilesystemMountAndPath.Error(),
+				Message: errors.ErrFilesystemMountAndPath.Error(),
 				Kind:    report.EntryError,
 			})
 		}
 		if f.Mount.Create != nil {
 			if f.Mount.WipeFilesystem {
 				r.Add(report.Entry{
-					Message: ErrUsedCreateAndWipeFilesystem.Error(),
+					Message: errors.ErrUsedCreateAndWipeFilesystem.Error(),
 					Kind:    report.EntryError,
 				})
 			}
 			if len(f.Mount.Options) > 0 {
 				r.Add(report.Entry{
-					Message: ErrUsedCreateAndMountOpts.Error(),
+					Message: errors.ErrUsedCreateAndMountOpts.Error(),
 					Kind:    report.EntryError,
 				})
 			}
 			r.Add(report.Entry{
-				Message: ErrWarningCreateDeprecated.Error(),
+				Message: errors.ErrWarningCreateDeprecated.Error(),
 				Kind:    report.EntryWarning,
 			})
 		}
@@ -89,7 +75,7 @@ func (m Mount) Validate() report.Report {
 	case "ext4", "btrfs", "xfs", "swap", "vfat":
 	default:
 		r.Add(report.Entry{
-			Message: ErrFilesystemInvalidFormat.Error(),
+			Message: errors.ErrFilesystemInvalidFormat.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -117,7 +103,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 16 {
 			// source: man mkfs.ext4
 			r.Add(report.Entry{
-				Message: ErrExt4LabelTooLong.Error(),
+				Message: errors.ErrExt4LabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -125,7 +111,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 256 {
 			// source: man mkfs.btrfs
 			r.Add(report.Entry{
-				Message: ErrBtrfsLabelTooLong.Error(),
+				Message: errors.ErrBtrfsLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -133,7 +119,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 12 {
 			// source: man mkfs.xfs
 			r.Add(report.Entry{
-				Message: ErrXfsLabelTooLong.Error(),
+				Message: errors.ErrXfsLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -143,7 +129,7 @@ func (m Mount) ValidateLabel() report.Report {
 		// 15 characters, so let's enforce that.
 		if len(*m.Label) > 15 {
 			r.Add(report.Entry{
-				Message: ErrSwapLabelTooLong.Error(),
+				Message: errors.ErrSwapLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -151,7 +137,7 @@ func (m Mount) ValidateLabel() report.Report {
 		if len(*m.Label) > 11 {
 			// source: man mkfs.fat
 			r.Add(report.Entry{
-				Message: ErrVfatLabelTooLong.Error(),
+				Message: errors.ErrVfatLabelTooLong.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_3_experimental/types/filesystem_test.go
+++ b/config/v2_3_experimental/types/filesystem_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -43,7 +44,7 @@ func TestMountValidate(t *testing.T) {
 		},
 		{
 			in:  in{format: ""},
-			out: out{err: ErrFilesystemInvalidFormat},
+			out: out{err: errors.ErrFilesystemInvalidFormat},
 		},
 	}
 
@@ -77,11 +78,11 @@ func TestFilesystemValidate(t *testing.T) {
 		},
 		{
 			in:  in{filesystem: Filesystem{Path: func(p string) *string { return &p }("/mount"), Mount: &Mount{Device: "/foo", Format: "ext4"}}},
-			out: out{err: ErrFilesystemMountAndPath},
+			out: out{err: errors.ErrFilesystemMountAndPath},
 		},
 		{
 			in:  in{filesystem: Filesystem{}},
-			out: out{err: ErrFilesystemNoMountPath},
+			out: out{err: errors.ErrFilesystemNoMountPath},
 		},
 	}
 
@@ -117,7 +118,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "ext4", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrExt4LabelTooLong},
+			out: out{err: errors.ErrExt4LabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "btrfs", Label: nil}},
@@ -129,7 +130,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "btrfs", Label: strToPtr("thislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolongthislabelistoolong")}},
-			out: out{err: ErrBtrfsLabelTooLong},
+			out: out{err: errors.ErrBtrfsLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "xfs", Label: nil}},
@@ -141,7 +142,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "xfs", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrXfsLabelTooLong},
+			out: out{err: errors.ErrXfsLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "swap", Label: nil}},
@@ -153,7 +154,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "swap", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrSwapLabelTooLong},
+			out: out{err: errors.ErrSwapLabelTooLong},
 		},
 		{
 			in:  in{mount: Mount{Format: "vfat", Label: nil}},
@@ -165,7 +166,7 @@ func TestLabelValidate(t *testing.T) {
 		},
 		{
 			in:  in{mount: Mount{Format: "vfat", Label: strToPtr("thislabelistoolong")}},
-			out: out{err: ErrVfatLabelTooLong},
+			out: out{err: errors.ErrVfatLabelTooLong},
 		},
 	}
 

--- a/config/v2_3_experimental/types/ignition.go
+++ b/config/v2_3_experimental/types/ignition.go
@@ -15,17 +15,10 @@
 package types
 
 import (
-	"errors"
-
 	"github.com/coreos/go-semver/semver"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrOldVersion     = errors.New("incorrect config version (too old)")
-	ErrNewVersion     = errors.New("incorrect config version (too new)")
-	ErrInvalidVersion = errors.New("invalid config version (couldn't parse)")
 )
 
 func (c ConfigReference) ValidateSource() report.Report {
@@ -47,13 +40,13 @@ func (v Ignition) Semver() (*semver.Version, error) {
 func (v Ignition) Validate() report.Report {
 	tv, err := v.Semver()
 	if err != nil {
-		return report.ReportFromError(ErrInvalidVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrInvalidVersion, report.EntryError)
 	}
 	if MaxVersion.Major > tv.Major {
-		return report.ReportFromError(ErrOldVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrOldVersion, report.EntryError)
 	}
 	if MaxVersion.LessThan(*tv) {
-		return report.ReportFromError(ErrNewVersion, report.EntryError)
+		return report.ReportFromError(errors.ErrNewVersion, report.EntryError)
 	}
 	return report.Report{}
 }

--- a/config/v2_3_experimental/types/link.go
+++ b/config/v2_3_experimental/types/link.go
@@ -15,18 +15,16 @@
 package types
 
 import (
-	"fmt"
-
 	"github.com/coreos/ignition/config/validate/report"
 )
 
-func (s Link) Validate() report.Report {
+func (s LinkEmbedded1) ValidateTarget() report.Report {
 	r := report.Report{}
 	if !s.Hard {
 		err := validatePath(s.Target)
 		if err != nil {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("problem with target path %q: %v", s.Target, err),
+				Message: err.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_3_experimental/types/mode.go
+++ b/config/v2_3_experimental/types/mode.go
@@ -15,16 +15,12 @@
 package types
 
 import (
-	"errors"
-)
-
-var (
-	ErrFileIllegalMode = errors.New("illegal file mode")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validateMode(m *int) error {
 	if m != nil && (*m < 0 || *m > 07777) {
-		return ErrFileIllegalMode
+		return errors.ErrFileIllegalMode
 	}
 	return nil
 }

--- a/config/v2_3_experimental/types/mode_test.go
+++ b/config/v2_3_experimental/types/mode_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestModeValidate(t *testing.T) {
@@ -53,7 +55,7 @@ func TestModeValidate(t *testing.T) {
 		},
 		{
 			in:  in{mode: intToPtr(010000)},
-			out: out{ErrFileIllegalMode},
+			out: out{errors.ErrFileIllegalMode},
 		},
 	}
 

--- a/config/v2_3_experimental/types/node.go
+++ b/config/v2_3_experimental/types/node.go
@@ -15,22 +15,17 @@
 package types
 
 import (
-	"errors"
 	"path/filepath"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrNoFilesystem     = errors.New("no filesystem specified")
-	ErrBothIDAndNameSet = errors.New("cannot set both id and name")
 )
 
 func (n Node) ValidateFilesystem() report.Report {
 	r := report.Report{}
 	if n.Filesystem == "" {
 		r.Add(report.Entry{
-			Message: ErrNoFilesystem.Error(),
+			Message: errors.ErrNoFilesystem.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -60,7 +55,7 @@ func (nu NodeUser) Validate() report.Report {
 	r := report.Report{}
 	if nu.ID != nil && nu.Name != "" {
 		r.Add(report.Entry{
-			Message: ErrBothIDAndNameSet.Error(),
+			Message: errors.ErrBothIDAndNameSet.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -70,7 +65,7 @@ func (ng NodeGroup) Validate() report.Report {
 	r := report.Report{}
 	if ng.ID != nil && ng.Name != "" {
 		r.Add(report.Entry{
-			Message: ErrBothIDAndNameSet.Error(),
+			Message: errors.ErrBothIDAndNameSet.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_3_experimental/types/node_test.go
+++ b/config/v2_3_experimental/types/node_test.go
@@ -18,12 +18,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 func TestNodeValidatePath(t *testing.T) {
 	node := Node{Path: "not/absolute"}
-	rep := report.ReportFromError(ErrPathRelative, report.EntryError)
+	rep := report.ReportFromError(errors.ErrPathRelative, report.EntryError)
 	if receivedRep := node.ValidatePath(); !reflect.DeepEqual(rep, receivedRep) {
 		t.Errorf("bad error: want %v, got %v", rep, receivedRep)
 	}
@@ -40,7 +41,7 @@ func TestNodeValidateFilesystem(t *testing.T) {
 		},
 		{
 			node: Node{Path: "/"},
-			r:    report.ReportFromError(ErrNoFilesystem, report.EntryError),
+			r:    report.ReportFromError(errors.ErrNoFilesystem, report.EntryError),
 		},
 	}
 	for i, test := range tests {
@@ -73,7 +74,7 @@ func TestNodeValidateUser(t *testing.T) {
 		},
 		{
 			in:  NodeUser{intToPtr(1000), "core"},
-			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+			out: report.ReportFromError(errors.ErrBothIDAndNameSet, report.EntryError),
 		},
 	}
 
@@ -104,7 +105,7 @@ func TestNodeValidateGroup(t *testing.T) {
 		},
 		{
 			in:  NodeGroup{intToPtr(1000), "core"},
-			out: report.ReportFromError(ErrBothIDAndNameSet, report.EntryError),
+			out: report.ReportFromError(errors.ErrBothIDAndNameSet, report.EntryError),
 		},
 	}
 

--- a/config/v2_3_experimental/types/partition.go
+++ b/config/v2_3_experimental/types/partition.go
@@ -15,22 +15,16 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
 const (
 	guidRegexStr = "^(|[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12})$"
-)
-
-var (
-	ErrLabelTooLong         = errors.New("partition labels may not exceed 36 characters")
-	ErrDoesntMatchGUIDRegex = errors.New("doesn't match the form \"01234567-89AB-CDEF-EDCB-A98765432101\"")
-	ErrLabelContainsColon   = errors.New("partition label will be truncated to text before the colon")
 )
 
 func (p Partition) ValidateLabel() report.Report {
@@ -42,7 +36,7 @@ func (p Partition) ValidateLabel() report.Report {
 	// with udev naming /dev/disk/by-partlabel/*.
 	if len(p.Label) > 36 {
 		r.Add(report.Entry{
-			Message: ErrLabelTooLong.Error(),
+			Message: errors.ErrLabelTooLong.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -50,7 +44,7 @@ func (p Partition) ValidateLabel() report.Report {
 	// sgdisk uses colons for delimitting compound arguments and does not allow escaping them.
 	if strings.Contains(p.Label, ":") {
 		r.Add(report.Entry{
-			Message: ErrLabelContainsColon.Error(),
+			Message: errors.ErrLabelContainsColon.Error(),
 			Kind:    report.EntryWarning,
 		})
 	}
@@ -75,7 +69,7 @@ func validateGUID(guid string) report.Report {
 		})
 	} else if !ok {
 		r.Add(report.Entry{
-			Message: ErrDoesntMatchGUIDRegex.Error(),
+			Message: errors.ErrDoesntMatchGUIDRegex.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_3_experimental/types/partition_test.go
+++ b/config/v2_3_experimental/types/partition_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -46,11 +47,11 @@ func TestValidateLabel(t *testing.T) {
 		},
 		{
 			in{"1111111111111111111111111111111111111"},
-			out{report.ReportFromError(ErrLabelTooLong, report.EntryError)},
+			out{report.ReportFromError(errors.ErrLabelTooLong, report.EntryError)},
 		},
 		{
 			in{"test:"},
-			out{report.ReportFromError(ErrLabelContainsColon, report.EntryWarning)},
+			out{report.ReportFromError(errors.ErrLabelContainsColon, report.EntryWarning)},
 		},
 	}
 	for i, test := range tests {
@@ -82,7 +83,7 @@ func TestValidateTypeGUID(t *testing.T) {
 		},
 		{
 			in{"not-a-valid-typeguid"},
-			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+			out{report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)},
 		},
 	}
 	for i, test := range tests {
@@ -114,7 +115,7 @@ func TestValidateGUID(t *testing.T) {
 		},
 		{
 			in{"not-a-valid-typeguid"},
-			out{report.ReportFromError(ErrDoesntMatchGUIDRegex, report.EntryError)},
+			out{report.ReportFromError(errors.ErrDoesntMatchGUIDRegex, report.EntryError)},
 		},
 	}
 	for i, test := range tests {

--- a/config/v2_3_experimental/types/passwd.go
+++ b/config/v2_3_experimental/types/passwd.go
@@ -15,30 +15,15 @@
 package types
 
 import (
-	"errors"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrPasswdCreateDeprecated      = errors.New("the create object has been deprecated in favor of user-level options")
-	ErrPasswdCreateAndGecos        = errors.New("cannot use both the create object and the user-level gecos field")
-	ErrPasswdCreateAndGroups       = errors.New("cannot use both the create object and the user-level groups field")
-	ErrPasswdCreateAndHomeDir      = errors.New("cannot use both the create object and the user-level homeDir field")
-	ErrPasswdCreateAndNoCreateHome = errors.New("cannot use both the create object and the user-level noCreateHome field")
-	ErrPasswdCreateAndNoLogInit    = errors.New("cannot use both the create object and the user-level noLogInit field")
-	ErrPasswdCreateAndNoUserGroup  = errors.New("cannot use both the create object and the user-level noUserGroup field")
-	ErrPasswdCreateAndPrimaryGroup = errors.New("cannot use both the create object and the user-level primaryGroup field")
-	ErrPasswdCreateAndShell        = errors.New("cannot use both the create object and the user-level shell field")
-	ErrPasswdCreateAndSystem       = errors.New("cannot use both the create object and the user-level system field")
-	ErrPasswdCreateAndUID          = errors.New("cannot use both the create object and the user-level uid field")
 )
 
 func (p PasswdUser) Validate() report.Report {
 	r := report.Report{}
 	if p.Create != nil {
 		r.Add(report.Entry{
-			Message: ErrPasswdCreateDeprecated.Error(),
+			Message: errors.ErrPasswdCreateDeprecated.Error(),
 			Kind:    report.EntryWarning,
 		})
 		addErr := func(err error) {
@@ -48,34 +33,34 @@ func (p PasswdUser) Validate() report.Report {
 			})
 		}
 		if p.Gecos != "" {
-			addErr(ErrPasswdCreateAndGecos)
+			addErr(errors.ErrPasswdCreateAndGecos)
 		}
 		if len(p.Groups) > 0 {
-			addErr(ErrPasswdCreateAndGroups)
+			addErr(errors.ErrPasswdCreateAndGroups)
 		}
 		if p.HomeDir != "" {
-			addErr(ErrPasswdCreateAndHomeDir)
+			addErr(errors.ErrPasswdCreateAndHomeDir)
 		}
 		if p.NoCreateHome {
-			addErr(ErrPasswdCreateAndNoCreateHome)
+			addErr(errors.ErrPasswdCreateAndNoCreateHome)
 		}
 		if p.NoLogInit {
-			addErr(ErrPasswdCreateAndNoLogInit)
+			addErr(errors.ErrPasswdCreateAndNoLogInit)
 		}
 		if p.NoUserGroup {
-			addErr(ErrPasswdCreateAndNoUserGroup)
+			addErr(errors.ErrPasswdCreateAndNoUserGroup)
 		}
 		if p.PrimaryGroup != "" {
-			addErr(ErrPasswdCreateAndPrimaryGroup)
+			addErr(errors.ErrPasswdCreateAndPrimaryGroup)
 		}
 		if p.Shell != "" {
-			addErr(ErrPasswdCreateAndShell)
+			addErr(errors.ErrPasswdCreateAndShell)
 		}
 		if p.System {
-			addErr(ErrPasswdCreateAndSystem)
+			addErr(errors.ErrPasswdCreateAndSystem)
 		}
 		if p.UID != nil {
-			addErr(ErrPasswdCreateAndUID)
+			addErr(errors.ErrPasswdCreateAndUID)
 		}
 	}
 	return r

--- a/config/v2_3_experimental/types/path.go
+++ b/config/v2_3_experimental/types/path.go
@@ -15,17 +15,14 @@
 package types
 
 import (
-	"errors"
 	"path"
-)
 
-var (
-	ErrPathRelative = errors.New("path not absolute")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validatePath(p string) error {
 	if !path.IsAbs(p) {
-		return ErrPathRelative
+		return errors.ErrPathRelative
 	}
 	return nil
 }

--- a/config/v2_3_experimental/types/path_test.go
+++ b/config/v2_3_experimental/types/path_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestPathValidate(t *testing.T) {
@@ -49,7 +51,7 @@ func TestPathValidate(t *testing.T) {
 		},
 		{
 			in:  in{device: "relative/path"},
-			out: out{err: ErrPathRelative},
+			out: out{err: errors.ErrPathRelative},
 		},
 	}
 

--- a/config/v2_3_experimental/types/raid.go
+++ b/config/v2_3_experimental/types/raid.go
@@ -15,8 +15,7 @@
 package types
 
 import (
-	"fmt"
-
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -26,7 +25,7 @@ func (n Raid) ValidateLevel() report.Report {
 	case "linear", "raid0", "0", "stripe":
 		if n.Spares != 0 {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("spares unsupported for %q arrays", n.Level),
+				Message: errors.ErrSparesUnsupportedForLevel.Error(),
 				Kind:    report.EntryError,
 			})
 		}
@@ -37,7 +36,7 @@ func (n Raid) ValidateLevel() report.Report {
 	case "raid10", "10":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("unrecognized raid level: %q", n.Level),
+			Message: errors.ErrUnrecognizedRaidLevel.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -49,7 +48,7 @@ func (n Raid) ValidateDevices() report.Report {
 	for _, d := range n.Devices {
 		if err := validatePath(string(d)); err != nil {
 			r.Add(report.Entry{
-				Message: fmt.Sprintf("array %q: device path not absolute: %q", n.Name, d),
+				Message: errors.ErrPathRelative.Error(),
 				Kind:    report.EntryError,
 			})
 		}

--- a/config/v2_3_experimental/types/unit.go
+++ b/config/v2_3_experimental/types/unit.go
@@ -15,20 +15,15 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"path"
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/shared/validations"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrInvalidSystemdExt  = errors.New("invalid systemd unit extension")
-	ErrInvalidNetworkdExt = errors.New("invalid networkd unit extension")
 )
 
 func (u Unit) ValidateContents() report.Report {
@@ -53,7 +48,7 @@ func (u Unit) ValidateName() report.Report {
 	case ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice", ".scope":
 	default:
 		r.Add(report.Entry{
-			Message: ErrInvalidSystemdExt.Error(),
+			Message: errors.ErrInvalidSystemdExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -74,7 +69,7 @@ func (d SystemdDropin) Validate() report.Report {
 	case ".conf":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid systemd unit drop-in extension: %q", path.Ext(d.Name)),
+			Message: errors.ErrInvalidSystemdDropinExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -96,7 +91,7 @@ func (u Networkdunit) Validate() report.Report {
 	case ".link", ".netdev", ".network":
 	default:
 		r.Add(report.Entry{
-			Message: ErrInvalidNetworkdExt.Error(),
+			Message: errors.ErrInvalidNetworkdExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}
@@ -118,7 +113,7 @@ func (d NetworkdDropin) Validate() report.Report {
 	case ".conf":
 	default:
 		r.Add(report.Entry{
-			Message: fmt.Sprintf("invalid networkd unit drop-in extension: %q", path.Ext(d.Name)),
+			Message: errors.ErrInvalidNetworkdDropinExt.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_3_experimental/types/unit_test.go
+++ b/config/v2_3_experimental/types/unit_test.go
@@ -15,10 +15,11 @@
 package types
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -40,7 +41,7 @@ func TestSystemdUnitValidateContents(t *testing.T) {
 		},
 		{
 			in:  in{unit: Unit{Name: "test.service", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 		{
 			in:  in{unit: Unit{Name: "test.service", Contents: "", Dropins: []SystemdDropin{{}}}},
@@ -78,7 +79,7 @@ func TestSystemdUnitValidateName(t *testing.T) {
 		},
 		{
 			in:  in{unit: "test.blah"},
-			out: out{err: ErrInvalidSystemdExt},
+			out: out{err: errors.ErrInvalidSystemdExt},
 		},
 	}
 
@@ -108,7 +109,7 @@ func TestSystemdUnitDropInValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: SystemdDropin{Name: "test.conf", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 
@@ -146,7 +147,7 @@ func TestNetworkdUnitNameValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: "test.blah"},
-			out: out{err: ErrInvalidNetworkdExt},
+			out: out{err: errors.ErrInvalidNetworkdExt},
 		},
 	}
 
@@ -176,7 +177,7 @@ func TestNetworkdUnitValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: Networkdunit{Name: "test.network", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 
@@ -206,7 +207,7 @@ func TestNetworkdUnitDropInValidate(t *testing.T) {
 		},
 		{
 			in:  in{unit: NetworkdDropin{Name: "test.conf", Contents: "[Foo"}},
-			out: out{err: errors.New("invalid unit content: unable to find end of section")},
+			out: out{err: fmt.Errorf("invalid unit content: unable to find end of section")},
 		},
 	}
 

--- a/config/v2_3_experimental/types/url.go
+++ b/config/v2_3_experimental/types/url.go
@@ -15,14 +15,11 @@
 package types
 
 import (
-	"errors"
 	"net/url"
 
 	"github.com/vincent-petithory/dataurl"
-)
 
-var (
-	ErrInvalidScheme = errors.New("invalid url scheme")
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func validateURL(s string) error {
@@ -32,7 +29,7 @@ func validateURL(s string) error {
 	}
 	u, err := url.Parse(s)
 	if err != nil {
-		return err
+		return errors.ErrInvalidUrl
 	}
 
 	switch u.Scheme {
@@ -44,6 +41,6 @@ func validateURL(s string) error {
 		}
 		return nil
 	default:
-		return ErrInvalidScheme
+		return errors.ErrInvalidScheme
 	}
 }

--- a/config/v2_3_experimental/types/url_test.go
+++ b/config/v2_3_experimental/types/url_test.go
@@ -17,6 +17,8 @@ package types
 import (
 	"reflect"
 	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
 )
 
 func TestURLValidate(t *testing.T) {
@@ -57,7 +59,7 @@ func TestURLValidate(t *testing.T) {
 		},
 		{
 			in:  in{u: "bad://"},
-			out: out{err: ErrInvalidScheme},
+			out: out{err: errors.ErrInvalidScheme},
 		},
 	}
 

--- a/config/v2_3_experimental/types/verification.go
+++ b/config/v2_3_experimental/types/verification.go
@@ -17,16 +17,10 @@ package types
 import (
 	"crypto"
 	"encoding/hex"
-	"errors"
 	"strings"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
-)
-
-var (
-	ErrHashMalformed    = errors.New("malformed hash specifier")
-	ErrHashWrongSize    = errors.New("incorrect size for hash sum")
-	ErrHashUnrecognized = errors.New("unrecognized hash function")
 )
 
 // HashParts will return the sum and function (in that order) of the hash stored
@@ -38,7 +32,7 @@ func (v Verification) HashParts() (string, string, error) {
 	}
 	parts := strings.SplitN(*v.Hash, "-", 2)
 	if len(parts) != 2 {
-		return "", "", ErrHashMalformed
+		return "", "", errors.ErrHashMalformed
 	}
 
 	return parts[0], parts[1], nil
@@ -66,7 +60,7 @@ func (v Verification) Validate() report.Report {
 		hash = crypto.SHA512
 	default:
 		r.Add(report.Entry{
-			Message: ErrHashUnrecognized.Error(),
+			Message: errors.ErrHashUnrecognized.Error(),
 			Kind:    report.EntryError,
 		})
 		return r
@@ -74,7 +68,7 @@ func (v Verification) Validate() report.Report {
 
 	if len(sum) != hex.EncodedLen(hash.Size()) {
 		r.Add(report.Entry{
-			Message: ErrHashWrongSize.Error(),
+			Message: errors.ErrHashWrongSize.Error(),
 			Kind:    report.EntryError,
 		})
 	}

--- a/config/v2_3_experimental/types/verification_test.go
+++ b/config/v2_3_experimental/types/verification_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/validate/report"
 )
 
@@ -38,7 +39,7 @@ func TestHashParts(t *testing.T) {
 		},
 		{
 			in:  in{data: `"sha512:01234567"`},
-			out: out{err: ErrHashMalformed},
+			out: out{err: errors.ErrHashMalformed},
 		},
 	}
 
@@ -71,11 +72,11 @@ func TestHashValidate(t *testing.T) {
 	}{
 		{
 			in:  in{v: Verification{Hash: &h1}},
-			out: out{err: ErrHashUnrecognized},
+			out: out{err: errors.ErrHashUnrecognized},
 		},
 		{
 			in:  in{v: Verification{Hash: &h2}},
-			out: out{err: ErrHashWrongSize},
+			out: out{err: errors.ErrHashWrongSize},
 		},
 		{
 			in:  in{v: Verification{Hash: &h3}},

--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -16,7 +16,7 @@ package validate
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	json "github.com/ajeddeloh/go-json"
-	conferrs "github.com/coreos/ignition/config/shared/errors"
+	"github.com/coreos/ignition/config/shared/errors"
 	"github.com/coreos/ignition/config/util"
 	"github.com/coreos/ignition/config/validate/astjson"
 	"github.com/coreos/ignition/config/validate/report"
@@ -51,23 +51,23 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			in:  in{cfg: Config{}},
-			out: out{err: ErrInvalidVersion},
+			out: out{err: errors.ErrInvalidVersion},
 		},
 		{
 			in:  in{cfg: Config{Ignition: Ignition{Version: "invalid.version"}}},
-			out: out{err: ErrInvalidVersion},
+			out: out{err: errors.ErrInvalidVersion},
 		},
 		{
 			in:  in{cfg: Config{Ignition: Ignition{Version: "2.3.0"}}},
-			out: out{err: ErrNewVersion},
+			out: out{err: errors.ErrNewVersion},
 		},
 		{
 			in:  in{cfg: Config{Ignition: Ignition{Version: "3.0.0"}}},
-			out: out{err: ErrNewVersion},
+			out: out{err: errors.ErrNewVersion},
 		},
 		{
 			in:  in{cfg: Config{Ignition: Ignition{Version: "1.0.0"}}},
-			out: out{err: ErrOldVersion},
+			out: out{err: errors.ErrOldVersion},
 		},
 		{
 			in: in{cfg: Config{
@@ -82,7 +82,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			}},
-			out: out{err: errors.New("unrecognized hash function")},
+			out: out{err: fmt.Errorf("unrecognized hash function")},
 		},
 		{
 			in: in{cfg: Config{
@@ -120,14 +120,14 @@ func TestValidate(t *testing.T) {
 				Ignition: Ignition{Version: semver.Version{Major: 2}.String()},
 				Systemd:  Systemd{Units: []Unit{{Name: "foo.bar", Contents: "[Foo]\nfoo=qux"}}},
 			}},
-			out: out{err: errors.New("invalid systemd unit extension")},
+			out: out{err: fmt.Errorf("invalid systemd unit extension")},
 		},
 		{
 			in: in{cfg: Config{
 				Ignition: Ignition{Version: semver.Version{Major: 2}.String()},
 				Systemd:  Systemd{Units: []Unit{{Name: "enable-but-no-install.service", Enabled: util.BoolToPtr(true), Contents: "[Foo]\nlemon=lime"}}},
 			}},
-			out: out{warning: conferrs.NewNoInstallSectionError("enable-but-no-install.service")},
+			out: out{warning: errors.NewNoInstallSectionError("enable-but-no-install.service")},
 		},
 	}
 
@@ -145,7 +145,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-var dummyErr = errors.New("dummy error")
+var dummyErr = fmt.Errorf("dummy error")
 
 // These types need to be declared here to allow us to define Validate() methods on them
 // simple case, no embedding, no Validate<NAME> functions, just Validate() defined on a struct


### PR DESCRIPTION
Defines many more common error values in config/shared/errors and then modifies all config/v*/types packages to use the new values.

This change makes the set of errors that the config package can produce much more predictable (there's still a few `fmt.Errorf`s in there), and will make it easier to update the phrasing of error values.

At some level this is followup cleanup for https://github.com/coreos/bugs/issues/2346

Depends on: https://github.com/coreos/ignition/pull/525, will rebase once that merges.