### PR TITLE
Fix blackbox tests

### DIFF
--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -35,13 +35,7 @@ done
 for D in tests/stubs/*; do
 	if [ -d "${D}" ]; then
 		echo "Building ${D}"
-		if [ "$GOHOSTARCH" == "$GOARCH" ]; then
-			go install ${REPO_PATH}/${D}
-		else
-			# Don't try to go install things when cross compiling because
-			# go install disallows it.
-			go build ${REPO_PATH}/${D}
-		fi
+		go build -o ${BIN_PATH}/$(basename ${D}) ${REPO_PATH}/${D}
 	fi
 done
 

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -78,12 +78,12 @@ func prepareRootPartitionForPasswd(t *testing.T, ctx context.Context, partitions
 	}
 
 	// TODO: use the architecture, not hardcode amd64
-	err := exec.CommandContext(ctx, "cp", "bin/amd64/id-stub", filepath.Join(mountPath, distro.IdCmd())).Run()
+	_, err := run(t, ctx, "cp", "bin/amd64/id-stub", filepath.Join(mountPath, distro.IdCmd()))
 	if err != nil {
 		return err
 	}
 	// TODO: needed for user_group_lookup.c
-	err = exec.CommandContext(ctx, "cp", "/lib64/libnss_files.so.2", filepath.Join(mountPath, "usr", "lib64")).Run()
+	_, err = run(t, ctx, "cp", "/lib64/libnss_files.so.2", filepath.Join(mountPath, "usr", "lib64"))
 	return err
 }
 


### PR DESCRIPTION
The `build_blackbox_tests` script started failing to put the helper stubs in `bin/${ARCH}` (it would put them in `./gopath/bin/id-stub`), which would cause the blackbox tests to fail if run on a machine they hadn't run on before. This PR fixes that, and changes a thing in the tests to emit more useful errors.

Based on some non-exhaustive investigation this regression may have been introduced in [this commit](https://github.com/coreos/ignition/commit/ff6985977ab14565e715a4cb33d3cbc866061083), but I didn't figure out why that commit caused this.