### PR TITLE
config: have Parse return ErrUnknownVersion if version is bad

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -28,7 +28,6 @@ var (
 	ErrUnknownVersion     = errors.New("unsupported config version")
 	ErrScript             = errors.New("not a config (found coreos-cloudinit script)")
 	ErrDeprecated         = errors.New("config format deprecated")
-	ErrVersion            = errors.New("incorrect config version")
 	ErrCompressionInvalid = errors.New("invalid compression method")
 
 	// Ignition section errors

--- a/config/v1/config.go
+++ b/config/v1/config.go
@@ -44,7 +44,7 @@ func Parse(rawConfig []byte) (types.Config, report.Report, error) {
 	}
 
 	if config.Version != types.Version {
-		return types.Config{}, report.Report{}, errors.ErrInvalid
+		return types.Config{}, report.Report{}, errors.ErrUnknownVersion
 	}
 
 	rpt := validate.ValidateConfig(rawConfig, config)

--- a/config/v1/config_test.go
+++ b/config/v1/config_test.go
@@ -61,7 +61,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte{}},

--- a/config/v2_0/config_test.go
+++ b/config/v2_0/config_test.go
@@ -41,7 +41,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "1.0.0"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.0.0"}}`)},
@@ -53,7 +53,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte{}},

--- a/config/v2_1/config_test.go
+++ b/config/v2_1/config_test.go
@@ -42,7 +42,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "1.0.0"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.0.0"}}`)},
@@ -58,11 +58,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "invalid.semver"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte{}},

--- a/config/v2_2/config_test.go
+++ b/config/v2_2/config_test.go
@@ -42,7 +42,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "1.0.0"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.0.0"}}`)},
@@ -70,11 +70,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "invalid.semver"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte{}},

--- a/config/v2_3_experimental/config_test.go
+++ b/config/v2_3_experimental/config_test.go
@@ -42,7 +42,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "1.0.0"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "2.0.0"}}`)},
@@ -74,11 +74,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			in:  in{config: []byte(`{"ignition": {"version": "invalid.semver"}}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte(`{}`)},
-			out: out{err: errors.ErrInvalid},
+			out: out{err: errors.ErrUnknownVersion},
 		},
 		{
 			in:  in{config: []byte{}},


### PR DESCRIPTION
It returned `ErrVersion` until 530602f, when it started returning `ErrInvalid`.  The latter makes it impossible to distinguish unrecognized versions from other errors, which is important when trying to locate the oldest parser that can read a config.  Switch to `ErrUnknownVersion` for consistency with the other parsers.