### PR TITLE
build: produce position independent executable for ignition

### DIFF
--- a/build
+++ b/build
@@ -29,7 +29,7 @@ export GOPATH=${PWD}/gopath
 export CGO_ENABLED=1
 
 echo "Building ${NAME}..."
-go build -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${NAME} ${REPO_PATH}/internal
+go build -buildmode=pie -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${NAME} ${REPO_PATH}/internal
 
 NAME="ignition-validate"
 


### PR DESCRIPTION
When building the Ignition binary, produce a position independent executable as per recommendations from the [Fedora packaging guidelines](https://fedoraproject.org/wiki/Packaging:Guidelines#PIE).

I also attempted to produce PIE binaries for the `ignition-validate` binary, but this caused [compilation issues](https://gist.github.com/dgonyeo/5e2bae336541446b8dc4b4f499a1eaf4) and as per the guidelines I believe PIE is only recommended for `ignition-validate`, not required.

cc @ashcrow and @dustymabe, since this relates to https://github.com/ashcrow/ignition-specs