### PR TITLE
tests: use distro specific paths in tests

### DIFF
--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -21,6 +21,9 @@ if [ "${HELPERS:-CL}" == "HOST" ]; then
 	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.swapMkfsCmd=$(sudo which mkswap) "
 	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.vfatMkfsCmd=$(sudo which mkfs.vfat) "
 	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.xfsMkfsCmd=$(sudo which mkfs.xfs) "
+
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.losetupCmd=$(sudo which losetup) "
+	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.mke2fsCmd=$(sudo which mke2fs) "
 fi
 
 . build
@@ -29,7 +32,7 @@ PKG=$(cd gopath/src/${REPO_PATH}; go list ./tests/...)
 
 echo "Compiling tests..."
 for p in ${PKG}; do
-	go test -c $p
+	go test -ldflags "${GLDFLAGS}" -c $p
 done
 
 for D in tests/stubs/*; do

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -51,6 +51,10 @@ var (
 	swapMkfsCmd  = "/usr/sbin/mkswap"
 	vfatMkfsCmd  = "/usr/sbin/mkfs.vfat"
 	xfsMkfsCmd   = "/usr/sbin/mkfs.xfs"
+
+	// Needed for blackbox tests
+	losetupCmd = "/sbin/losetup"
+	mke2fsCmd  = "/sbin/mke2fs"
 )
 
 func DiskByIDDir() string       { return diskByIDDir }
@@ -77,6 +81,9 @@ func Ext4MkfsCmd() string  { return ext4MkfsCmd }
 func SwapMkfsCmd() string  { return swapMkfsCmd }
 func VfatMkfsCmd() string  { return vfatMkfsCmd }
 func XfsMkfsCmd() string   { return xfsMkfsCmd }
+
+func LosetupCmd() string { return losetupCmd }
+func Mke2fsCmd() string { return mke2fsCmd }
 
 func fromEnv(nameSuffix, defaultValue string) string {
 	value := os.Getenv("IGNITION_" + nameSuffix)

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -176,7 +176,7 @@ func createVolume(t *testing.T, ctx context.Context, index int, imageFile string
 // and then will format each partition according to what's described in the
 // partitions argument.
 func setDevices(t *testing.T, ctx context.Context, imageFile string, partitions []*types.Partition) (string, error) {
-	out, err := run(t, ctx, "losetup", "-Pf", "--show", imageFile)
+	out, err := run(t, ctx, distro.LosetupCmd(), "-Pf", "--show", imageFile)
 	if err != nil {
 		return "", err
 	}
@@ -196,7 +196,7 @@ func setDevices(t *testing.T, ctx context.Context, imageFile string, partitions 
 }
 
 func destroyDevice(t *testing.T, loopDevice string) error {
-	_, err := runWithoutContext(t, "losetup", "-d", loopDevice)
+	_, err := runWithoutContext(t, distro.LosetupCmd(), "-d", loopDevice)
 	return err
 }
 
@@ -206,11 +206,11 @@ func formatPartition(t *testing.T, ctx context.Context, partition *types.Partiti
 
 	switch partition.FilesystemType {
 	case "vfat":
-		mkfs = "mkfs.vfat"
+		mkfs = distro.VfatMkfsCmd()
 		label = []string{"-n", partition.FilesystemLabel}
 		uuid = []string{"-i", partition.FilesystemUUID}
 	case "ext2", "ext4":
-		mkfs = "mke2fs"
+		mkfs = distro.Mke2fsCmd()
 		opts = []string{
 			"-t", partition.FilesystemType, "-b", "4096",
 			"-i", "4096", "-I", "128", "-e", "remount-ro",
@@ -218,15 +218,15 @@ func formatPartition(t *testing.T, ctx context.Context, partition *types.Partiti
 		label = []string{"-L", partition.FilesystemLabel}
 		uuid = []string{"-U", partition.FilesystemUUID}
 	case "btrfs":
-		mkfs = "mkfs.btrfs"
+		mkfs = distro.BtrfsMkfsCmd()
 		label = []string{"--label", partition.FilesystemLabel}
 		uuid = []string{"--uuid", partition.FilesystemUUID}
 	case "xfs":
-		mkfs = "mkfs.xfs"
+		mkfs = distro.XfsMkfsCmd()
 		label = []string{"-L", partition.FilesystemLabel}
 		uuid = []string{"-m", "uuid=" + partition.FilesystemUUID}
 	case "swap":
-		mkfs = "mkswap"
+		mkfs = distro.SwapMkfsCmd()
 		label = []string{"-L", partition.FilesystemLabel}
 		uuid = []string{"-U", partition.FilesystemUUID}
 	default:
@@ -294,7 +294,7 @@ func createPartitionTable(t *testing.T, ctx context.Context, imageFile string, p
 			opts = append(opts, fmt.Sprintf("-h=%s", intJoin(hybrids, ":")))
 		}
 	}
-	_, err := run(t, ctx, "sgdisk", opts...)
+	_, err := run(t, ctx, distro.SgdiskCmd(), opts...)
 	return err
 }
 

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/exec/util"
 	"github.com/coreos/ignition/tests/types"
 )
@@ -46,7 +47,7 @@ func validateDisk(t *testing.T, d types.Disk, imageFile string) error {
 			continue
 		}
 		sgdiskInfo, err := exec.Command(
-			"sgdisk", "-i", strconv.Itoa(e.Number),
+			distro.SgdiskCmd(), "-i", strconv.Itoa(e.Number),
 			imageFile).CombinedOutput()
 		if err != nil {
 			fmt.Printf("sgdisk -i %d %s died\n", e.Number, imageFile)


### PR DESCRIPTION
Use the internal/distro package to determine paths for things like losetup and mkfs.* when running blackbox tests.