### PR TITLE
tests: return correct error value for failed files stage

### DIFF
--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -351,7 +351,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 	}
 	filesErr := runIgnition(t, ctx, "files", rootLocation, tmpDirectory, appendEnv)
 	if !negativeTests && filesErr != nil {
-		return err
+		return filesErr
 	}
 	if negativeTests && disksErr == nil && filesErr == nil {
 		return fmt.Errorf("Expected failure and ignition succeeded")


### PR DESCRIPTION
A programming error resulted in a value that was nil being returned
instead of the correct value when the files stage failed in a blackbox
test.