### PR TITLE
internal: don't leave a temporary file when appending

### DIFF
--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -175,12 +175,10 @@ func (u Util) PerformFetch(f *FetchOp) error {
 		return err
 	}
 
-	defer func() {
-		tmp.Close()
-		if err != nil {
-			os.Remove(tmp.Name())
-		}
-	}()
+	defer tmp.Close()
+	// sometimes the following line will fail (the file might be renamed),
+	// but that's ok (we wanted to keep the file in that case).
+	defer os.Remove(tmp.Name())
 
 	err = u.Fetcher.Fetch(f.Url, tmp, f.FetchOptions)
 	if err != nil {

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -130,6 +130,11 @@ func (f *Fetcher) FetchToBuffer(u url.URL, opts FetchOptions) ([]byte, error) {
 // and written into dest. If opts.Hash is set the data stream will also be
 // hashed and compared against opts.ExpectedSum, and any match failures will
 // result in an error being returned.
+//
+// Fetch expects dest to be an empty file and for the cursor in the file to be
+// at the beginning. Since some url schemes (ex: s3) use chunked downloads and
+// fetch chunks out of order, Fetch's behavior when dest is not an empty file is
+// undefined.
 func (f *Fetcher) Fetch(u url.URL, dest *os.File, opts FetchOptions) error {
 	switch u.Scheme {
 	case "http", "https":


### PR DESCRIPTION
A programming error resulted in an extraneous temporary file being left
on disk when a file is appended to.

Also add a comment in internal/resource which hopefully justifies why a
temporary file is used during file appending.

Fixes https://github.com/coreos/bugs/issues/2420

I manually tested this, the bb tests aren't currently expressive enough to write a test for "there shouldn't be extra files with unknown names here".