### PR TITLE
Minor fixes for blackbox tests

### DIFF
--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -116,6 +116,9 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 		// There may be more partitions created by Ignition, so look at the
 		// expected output instead of the input to determine image size
 		imageSize := test.Out[i].CalculateImageSize()
+		if inSize := disk.CalculateImageSize(); inSize > imageSize {
+			imageSize = inSize
+		}
 
 		// Finish data setup
 		for _, part := range disk.Partitions {

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -99,7 +99,8 @@ func getRootLocation(partitions []*types.Partition) string {
 
 // returns true if no error, false if error
 func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, appendEnv []string) error {
-	args := []string{"-clear-cache", "-oem", "file", "-stage", stage, "-root", root, "-log-to-stdout"}
+	args := []string{"-clear-cache", "-oem", "file", "-stage", stage,
+		"-root", root, "-log-to-stdout", "--config-cache", filepath.Join(cwd, "ignition.json")}
 	cmd := exec.CommandContext(ctx, "ignition", args...)
 	t.Log("ignition", args)
 	cmd.Dir = cwd

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -130,7 +130,7 @@ func (ps Partitions) AddRemovedNodes(label string, ns []Node) {
 func (d Disk) SetOffsets() {
 	offset := gptHeaderSize
 	for _, p := range d.Partitions {
-		if p.Length == 0 || p.TypeCode == "blank" {
+		if p.Length == 0 {
 			continue
 		}
 		offset = Align(offset, d.Alignment)
@@ -216,12 +216,6 @@ func GetBaseDisk() []Disk {
 					TypeCode: "coreos-rootfs",
 					Length:   2097152,
 				}, {
-					Number:   5,
-					Label:    "ROOT-C",
-					GUID:     "d82521b4-07ac-4f1c-8840-ddefedc332f3",
-					TypeCode: "blank",
-					Length:   0,
-				}, {
 					Number:         6,
 					Label:          "OEM",
 					TypeCode:       "data",
@@ -232,11 +226,6 @@ func GetBaseDisk() []Disk {
 					Label:    "OEM-CONFIG",
 					TypeCode: "coreos-reserved",
 					Length:   131072,
-				}, {
-					Number:   8,
-					Label:    "coreos-reserved",
-					TypeCode: "blank",
-					Length:   0,
 				}, {
 					Number:         9,
 					Label:          "ROOT",


### PR DESCRIPTION
Turns out parallel tests were all fighting over the same file.
Also turns out we only checked that the partitions we expected were there, but not that there were not any extras.