### PR TITLE
internal: don't cancel http contexts until the body has been read

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -219,11 +219,15 @@ func (f *Fetcher) FetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) err
 // FetchFromHTTP fetches a resource from u via HTTP(S) into dest, returning an
 // error if one is encountered.
 func (f *Fetcher) FetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) error {
-	ctx := context.Background()
 	if f.client == nil {
 		f.newHttpClient()
 	}
-	dataReader, status, err := f.client.getReaderWithHeader(ctx, u.String(), opts.Headers)
+	dataReader, status, ctxCancel, err := f.client.getReaderWithHeader(u.String(), opts.Headers)
+	if ctxCancel != nil {
+		// whatever context getReaderWithHeader created for the request should
+		// be cancelled once we're done reading the response
+		defer ctxCancel()
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Contexts for HTTP requests should not be cancelled until after the HTTP
body has been successfully read, or errors can be encountered.

Fixes https://github.com/coreos/bugs/issues/2435
I think