### PR TITLE
tests: fail when Ignition emits CRITICAL logs

### DIFF
--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -111,6 +111,9 @@ func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, app
 	if strings.Contains(string(out), "panic") {
 		return fmt.Errorf("ignition panicked")
 	}
+	if strings.Contains(string(out), "CRITICAL") {
+		return fmt.Errorf("found critical ignition log")
+	}
 	return err
 }
 


### PR DESCRIPTION
Adds detection for `CRITICAL` log messages emitted by Ignition.

Blocked by https://github.com/coreos/bugs/issues/2441