### PR TITLE
Critical level logs

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -129,7 +129,7 @@ func (e *Engine) acquireConfig() (cfg types.Config, err error) {
 	// (Re)Fetch the config if the cache is unreadable.
 	cfg, err = e.fetchProviderConfig()
 	if err != nil {
-		e.Logger.Crit("failed to fetch config: %s", err)
+		e.Logger.Warning("failed to fetch config: %s", err)
 		return
 	}
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -121,8 +121,8 @@ func (l *Logger) PopPrefix() {
 	l.prefixStack = l.prefixStack[:len(l.prefixStack)-1]
 }
 
-// quotedCmd returns a concatenated, quoted form of cmd's cmdline
-func quotedCmd(cmd *exec.Cmd) string {
+// QuotedCmd returns a concatenated, quoted form of cmd's cmdline
+func QuotedCmd(cmd *exec.Cmd) string {
 	if len(cmd.Args) == 0 {
 		return fmt.Sprintf("%q", cmd.Path)
 	}
@@ -140,7 +140,7 @@ func quotedCmd(cmd *exec.Cmd) string {
 func (l *Logger) LogCmd(cmd *exec.Cmd, format string, a ...interface{}) (int, error) {
 	code := -1
 	f := func() error {
-		cmdLine := quotedCmd(cmd)
+		cmdLine := QuotedCmd(cmd)
 		l.Debug("executing: %s", cmdLine)
 
 		stdout := &bytes.Buffer{}


### PR DESCRIPTION
This resolves issue [#2441](https://github.com/coreos/bugs/issues/2441):

For tests `Preemption_with_default_config` and `Empty_Userdata`: 
`Crit()` was changed to `Warning()` in `engine.go`

As for the `Adding_users` test:
Please look at commit [6820...](https://github.com/coreos/ignition/pull/558/commits/68204430d9125bb87fb023327a182e4969210264) and do let me know how I can improve this statement.

