### PR TITLE
tests/reuse-existing-fs: use xfs not btrfs

### DIFF
--- a/tests/positive/filesystems/reuse_filesystem.go
+++ b/tests/positive/filesystems/reuse_filesystem.go
@@ -41,7 +41,7 @@ func ReuseExistingFilesystem() types.Test {
 					"mount": {
 						"device": "$DEVICE",
 						"wipeFilesystem": false,
-						"format": "btrfs",
+						"format": "xfs",
 						"label": "data",
 						"uuid": "8A7A6E26-5E8F-4CCA-A654-46215D4696AC"
 					}
@@ -56,7 +56,7 @@ func ReuseExistingFilesystem() types.Test {
 				Label:           "important-data",
 				Number:          1,
 				Length:          2621440,
-				FilesystemType:  "btrfs",
+				FilesystemType:  "xfs",
 				FilesystemLabel: "data",
 				FilesystemUUID:  "8A7A6E26-5E8F-4CCA-A654-46215D4696AC",
 				Files: []types.File{
@@ -78,7 +78,7 @@ func ReuseExistingFilesystem() types.Test {
 				Label:           "important-data",
 				Number:          1,
 				Length:          2621440,
-				FilesystemType:  "btrfs",
+				FilesystemType:  "xfs",
 				FilesystemLabel: "data",
 				FilesystemUUID:  "8A7A6E26-5E8F-4CCA-A654-46215D4696AC",
 				Files: []types.File{


### PR DESCRIPTION
There appears to be some btrfs bug which causes this test to flake.
Ignition is doing the right thing in that case, so switch to xfs so we
still test the functionality but don't encounter the flake.