### PR TITLE
Status Report for Packet Instance

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -85,11 +85,12 @@ var (
 	ErrInvalidNetworkdDropinExt = errors.New("invalid networkd drop-in extension")
 
 	// Misc errors
-	ErrInvalidScheme    = errors.New("invalid url scheme")
-	ErrInvalidUrl       = errors.New("unable to parse url")
-	ErrHashMalformed    = errors.New("malformed hash specifier")
-	ErrHashWrongSize    = errors.New("incorrect size for hash sum")
-	ErrHashUnrecognized = errors.New("unrecognized hash function")
+	ErrInvalidScheme       = errors.New("invalid url scheme")
+	ErrInvalidUrl          = errors.New("unable to parse url")
+	ErrHashMalformed       = errors.New("malformed hash specifier")
+	ErrHashWrongSize       = errors.New("incorrect size for hash sum")
+	ErrHashUnrecognized    = errors.New("unrecognized hash function")
+	ErrEngineConfiguration = errors.New("engine incorrectly configured")
 )
 
 // NewNoInstallSectionError produces an error indicating the given unit, named

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -16,6 +16,7 @@ package files
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/coreos/ignition/internal/config/types"
 	"github.com/coreos/ignition/internal/exec/stages"
@@ -60,21 +61,18 @@ func (stage) Name() string {
 	return name
 }
 
-func (s stage) Run(config types.Config) bool {
+func (s stage) Run(config types.Config) error {
 	if err := s.createPasswd(config); err != nil {
-		s.Logger.Crit("failed to create users/groups: %v", err)
-		return false
+		return fmt.Errorf("failed to create users/groups: %v", err)
 	}
 
 	if err := s.createFilesystemsEntries(config); err != nil {
-		s.Logger.Crit("failed to create files: %v", err)
-		return false
+		return fmt.Errorf("failed to create files: %v", err)
 	}
 
 	if err := s.createUnits(config); err != nil {
-		s.Logger.Crit("failed to create units: %v", err)
-		return false
+		return fmt.Errorf("failed to create units: %v", err)
 	}
 
-	return true
+	return nil
 }

--- a/internal/exec/stages/stages.go
+++ b/internal/exec/stages/stages.go
@@ -23,7 +23,7 @@ import (
 
 // Stage is responsible for actually executing a stage of the configuration.
 type Stage interface {
-	Run(config types.Config) bool
+	Run(config types.Config) error
 	Name() string
 }
 

--- a/internal/main.go
+++ b/internal/main.go
@@ -93,7 +93,7 @@ func main() {
 		Fetcher:      &fetcher,
 	}
 
-	if !engine.Run(flags.stage.String()) {
+	if engine.Run(flags.stage.String()) != nil {
 		os.Exit(1)
 	}
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -93,7 +93,13 @@ func main() {
 		Fetcher:      &fetcher,
 	}
 
-	if engine.Run(flags.stage.String()) != nil {
+	err = engine.Run(flags.stage.String())
+	if statusErr := engine.OEMConfig.Status(flags.stage.String(), *engine.Fetcher, err); statusErr != nil {
+		logger.Err("POST Status error: ", statusErr.Error())
+	}
+	if err != nil {
+		logger.Crit("Ignition failed: %v", err.Error())
 		os.Exit(1)
 	}
+	logger.Info("Ignition finished successfully")
 }

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -119,8 +119,9 @@ func init() {
 		fetch: noop.FetchConfig,
 	})
 	configs.Register(Config{
-		name:  "packet",
-		fetch: packet.FetchConfig,
+		name:   "packet",
+		fetch:  packet.FetchConfig,
+		status: packet.PostStatus,
 	})
 	configs.Register(Config{
 		name:  "pxe",

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -40,6 +40,7 @@ type Config struct {
 	name       string
 	fetch      providers.FuncFetchConfig
 	newFetcher providers.FuncNewFetcher
+	status     providers.FuncPostStatus
 }
 
 func (c Config) Name() string {
@@ -59,6 +60,14 @@ func (c Config) NewFetcherFunc() providers.FuncNewFetcher {
 			Logger: l,
 		}, nil
 	}
+}
+
+// Status takes a Fetcher and the error from Run (from engine)
+func (c Config) Status(stageName string, f resource.Fetcher, statusErr error) error {
+	if c.status != nil {
+		return c.status(stageName, f, statusErr)
+	}
+	return nil
 }
 
 var configs = registry.Create("oem configs")

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -29,3 +29,4 @@ var (
 
 type FuncFetchConfig func(f resource.Fetcher) (types.Config, report.Report, error)
 type FuncNewFetcher func(logger *log.Logger) (resource.Fetcher, error)
+type FuncPostStatus func(stageName string, f resource.Fetcher, e error) error

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -219,9 +219,14 @@ func (f *Fetcher) FetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) err
 // FetchFromHTTP fetches a resource from u via HTTP(S) into dest, returning an
 // error if one is encountered.
 func (f *Fetcher) FetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) error {
+	// for the case when "config is not valid"
+	// this if necessary if not spawned through kola (e.g. Packet Dashboard)
 	if f.client == nil {
+		logger := log.New(true)
+		f.Logger = &logger
 		f.newHttpClient()
 	}
+
 	dataReader, status, ctxCancel, err := f.client.getReaderWithHeader(u.String(), opts.Headers)
 	if ctxCancel != nil {
 		// whatever context getReaderWithHeader created for the request should


### PR DESCRIPTION
This references issue [#2444](https://github.com/coreos/bugs/issues/2444).

The ./ignition build works when it is sent to a Packet instance. 

However, has trouble logging via ssh when an image with the changes in igntion is booted onto an instance. I roughly know what is causing this problem. 

The commits in the PR are numerous but I will eventually squash it into one commit after removing the debug prints some from logger.Info() and fmt.Println(). So I'm ignoring the tailor check for now, until I 
have one squashed commit. 