### PR TITLE
user-group: Add chdir("/") after chroot()

### DIFF
--- a/internal/exec/util/user_group_lookup.c
+++ b/internal/exec/util/user_group_lookup.c
@@ -58,6 +58,10 @@ static int user_lookup_fn(lookup_ctxt_t *ctxt) {
 		goto out_err;
 	}
 
+	if (chdir("/") == -1) {
+		goto out_err;
+	}
+
 	if(getpwnam_r(ctxt->name, &p, buf, sizeof(buf), &pptr) != 0 || !pptr) {
 		goto out_err;
 	}
@@ -87,6 +91,10 @@ static int group_lookup_fn(lookup_ctxt_t *ctxt) {
 	struct group g, *gptr;
 
 	if(chroot(ctxt->root) == -1) {
+		goto out_err;
+	}
+
+	if (chdir("/") == -1) {
 		goto out_err;
 	}
 


### PR DESCRIPTION
rpmlint finds this: `E: missing-call-to-chdir-with-chroot /usr/bin/ignition`
and in our case I don't think it'll matter as nothing is reading from the
current working directory, but it's definitely best practice.

(Although I would say this code should be replaced by forking a container
 process off in the target (e.g. via bwrap) and talking to it over IPC)