### PR TITLE
stages/files: relabel files for SELinux after boot

### DIFF
--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -8,6 +8,7 @@ set -eu
 # system
 GLDFLAGS="-X github.com/coreos/ignition/internal/distro.useraddCmd=useradd-stub "
 GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.usermodCmd=usermod-stub "
+GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.blackboxTesting=true "
 
 if [ "${HELPERS:-CL}" == "HOST" ]; then
 	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.mdadmCmd=$(sudo which mdadm) "

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -55,7 +55,8 @@ var (
 	xfsMkfsCmd   = "/usr/sbin/mkfs.xfs"
 
 	// Flags
-	selinuxRelabel = "false"
+	selinuxRelabel  = "false"
+	blackboxTesting = "false"
 )
 
 func DiskByIDDir() string       { return diskByIDDir }
@@ -84,7 +85,8 @@ func SwapMkfsCmd() string  { return swapMkfsCmd }
 func VfatMkfsCmd() string  { return vfatMkfsCmd }
 func XfsMkfsCmd() string   { return xfsMkfsCmd }
 
-func SelinuxRelabel() bool { return bakedStringToBool(selinuxRelabel) }
+func SelinuxRelabel() bool  { return bakedStringToBool(selinuxRelabel) }
+func BlackboxTesting() bool { return bakedStringToBool(blackboxTesting) }
 
 func fromEnv(nameSuffix, defaultValue string) string {
 	value := os.Getenv("IGNITION_" + nameSuffix)

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -15,6 +15,7 @@
 package distro
 
 import (
+	"fmt"
 	"os"
 )
 
@@ -35,15 +36,16 @@ var (
 	oemLookasideDir = "/usr/share/oem"
 
 	// Helper programs
-	chrootCmd   = "/usr/bin/chroot"
-	groupaddCmd = "/usr/sbin/groupadd"
-	idCmd       = "/usr/bin/id"
-	mdadmCmd    = "/usr/sbin/mdadm"
-	mountCmd    = "/usr/bin/mount"
-	sgdiskCmd   = "/usr/sbin/sgdisk"
-	udevadmCmd  = "/usr/bin/udevadm"
-	usermodCmd  = "/usr/sbin/usermod"
-	useraddCmd  = "/usr/sbin/useradd"
+	chrootCmd     = "/usr/bin/chroot"
+	groupaddCmd   = "/usr/sbin/groupadd"
+	idCmd         = "/usr/bin/id"
+	mdadmCmd      = "/usr/sbin/mdadm"
+	mountCmd      = "/usr/bin/mount"
+	sgdiskCmd     = "/usr/sbin/sgdisk"
+	udevadmCmd    = "/usr/bin/udevadm"
+	usermodCmd    = "/usr/sbin/usermod"
+	useraddCmd    = "/usr/sbin/useradd"
+	restoreconCmd = "/usr/sbin/restorecon"
 
 	// Filesystem tools
 	btrfsMkfsCmd = "/usr/sbin/mkfs.btrfs"
@@ -51,6 +53,9 @@ var (
 	swapMkfsCmd  = "/usr/sbin/mkswap"
 	vfatMkfsCmd  = "/usr/sbin/mkfs.vfat"
 	xfsMkfsCmd   = "/usr/sbin/mkfs.xfs"
+
+	// Flags
+	selinuxRelabel = "false"
 )
 
 func DiskByIDDir() string       { return diskByIDDir }
@@ -62,15 +67,16 @@ func KernelCmdlinePath() string { return kernelCmdlinePath }
 func SystemConfigDir() string   { return fromEnv("SYSTEM_CONFIG_DIR", systemConfigDir) }
 func OEMLookasideDir() string   { return fromEnv("OEM_LOOKASIDE_DIR", oemLookasideDir) }
 
-func ChrootCmd() string   { return chrootCmd }
-func GroupaddCmd() string { return groupaddCmd }
-func IdCmd() string       { return idCmd }
-func MdadmCmd() string    { return mdadmCmd }
-func MountCmd() string    { return mountCmd }
-func SgdiskCmd() string   { return sgdiskCmd }
-func UdevadmCmd() string  { return udevadmCmd }
-func UsermodCmd() string  { return usermodCmd }
-func UseraddCmd() string  { return useraddCmd }
+func ChrootCmd() string     { return chrootCmd }
+func GroupaddCmd() string   { return groupaddCmd }
+func IdCmd() string         { return idCmd }
+func MdadmCmd() string      { return mdadmCmd }
+func MountCmd() string      { return mountCmd }
+func SgdiskCmd() string     { return sgdiskCmd }
+func UdevadmCmd() string    { return udevadmCmd }
+func UsermodCmd() string    { return usermodCmd }
+func UseraddCmd() string    { return useraddCmd }
+func RestoreconCmd() string { return restoreconCmd }
 
 func BtrfsMkfsCmd() string { return btrfsMkfsCmd }
 func Ext4MkfsCmd() string  { return ext4MkfsCmd }
@@ -78,10 +84,24 @@ func SwapMkfsCmd() string  { return swapMkfsCmd }
 func VfatMkfsCmd() string  { return vfatMkfsCmd }
 func XfsMkfsCmd() string   { return xfsMkfsCmd }
 
+func SelinuxRelabel() bool { return bakedStringToBool(selinuxRelabel) }
+
 func fromEnv(nameSuffix, defaultValue string) string {
 	value := os.Getenv("IGNITION_" + nameSuffix)
 	if value != "" {
 		return value
 	}
 	return defaultValue
+}
+
+func bakedStringToBool(s string) bool {
+	// the linker only supports string args, so do some basic bool sensing
+	if s == "true" || s == "1" {
+		return true
+	} else if s == "false" || s == "0" {
+		return false
+	} else {
+		// if we got a bad compile flag, just crash and burn rather than assume
+		panic(fmt.Sprintf("value '%s' cannot be interpreted as a boolean", s))
+	}
 }

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -17,8 +17,11 @@ package files
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/exec/stages"
 	"github.com/coreos/ignition/internal/exec/util"
 	"github.com/coreos/ignition/internal/log"
@@ -55,6 +58,7 @@ func (creator) Name() string {
 
 type stage struct {
 	util.Util
+	toRelabel []string
 }
 
 func (stage) Name() string {
@@ -62,6 +66,10 @@ func (stage) Name() string {
 }
 
 func (s stage) Run(config types.Config) error {
+	if err := s.checkRelabeling(); err != nil {
+		return fmt.Errorf("failed to check if SELinux labeling required: %v", err)
+	}
+
 	if err := s.createPasswd(config); err != nil {
 		return fmt.Errorf("failed to create users/groups: %v", err)
 	}
@@ -74,5 +82,91 @@ func (s stage) Run(config types.Config) error {
 		return fmt.Errorf("failed to create units: %v", err)
 	}
 
+	// add systemd unit to relabel files
+	if err := s.addRelabelUnit(config); err != nil {
+		return fmt.Errorf("failed to add relabel unit: %v", err)
+	}
+
 	return nil
+}
+
+// checkRelabeling determines whether relabeling is supported/requested so that
+// we only collect filenames if we need to.
+func (s *stage) checkRelabeling() error {
+	if !distro.SelinuxRelabel() || distro.RestoreconCmd() == "" {
+		s.Logger.Debug("compiled without relabeling support, skipping")
+		return nil
+	}
+
+	exists, err := s.PathExists(distro.RestoreconCmd())
+	if err != nil {
+		return err
+	} else if !exists {
+		s.Logger.Debug("targeting root without %s, skipping relabel", distro.RestoreconCmd())
+		return nil
+	}
+
+	// initialize to non-nil (whereas a nil slice means not to append, even
+	// though they're functionally equivalent)
+	s.toRelabel = []string{}
+	return nil
+}
+
+// relabeling returns true if we are relabeling, false otherwise.
+func (s *stage) relabeling() bool {
+	return s.toRelabel != nil
+}
+
+// relabel adds one or more paths to the list of paths that need relabeling.
+func (s *stage) relabel(paths ...string) {
+	if s.toRelabel != nil {
+		s.toRelabel = append(s.toRelabel, paths...)
+	}
+}
+
+// addRelabelUnit creates and enables a runtime systemd unit to run restorecon
+// if there are files that need to be relabeled.
+func (s *stage) addRelabelUnit(config types.Config) error {
+	if s.toRelabel == nil || len(s.toRelabel) == 0 {
+		return nil
+	}
+
+	// create the unit file itself
+	unit := types.Unit{
+		Name: "ignition-relabel.service",
+		Contents: `[Unit]
+Description=Relabel files created by Ignition
+DefaultDependencies=no
+After=local-fs.target
+Before=sysinit.target
+ConditionSecurity=selinux
+ConditionPathExists=/etc/selinux/ignition.relabel
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
+
+[Service]
+Type=oneshot
+ExecStart=` + distro.RestoreconCmd() + ` -0vRf /etc/selinux/ignition.relabel
+ExecStart=/usr/bin/rm /etc/selinux/ignition.relabel
+RemainAfterExit=yes`,
+	}
+
+	if err := s.writeSystemdUnit(unit, true); err != nil {
+		return err
+	}
+
+	if err := s.EnableRuntimeUnit(unit, "sysinit.target"); err != nil {
+		return err
+	}
+
+	// and now create the list of files to relabel
+	f, err := os.Create(s.JoinPath("etc/selinux/ignition.relabel"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// yes, apparently the final \0 is needed
+	_, err = f.WriteString(strings.Join(s.toRelabel, "\000") + "\000")
+	return err
 }

--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -21,13 +21,26 @@ import (
 )
 
 // createPasswd creates the users and groups as described in config.Passwd.
-func (s stage) createPasswd(config types.Config) error {
+func (s *stage) createPasswd(config types.Config) error {
 	if err := s.createGroups(config); err != nil {
 		return fmt.Errorf("failed to create groups: %v", err)
 	}
 
 	if err := s.createUsers(config); err != nil {
 		return fmt.Errorf("failed to create users: %v", err)
+	}
+
+	// to be safe, just blanket mark all passwd-related files rather than
+	// trying to make it more granular based on which executables we ran
+	if len(config.Passwd.Groups) != 0 || len(config.Passwd.Users) != 0 {
+		s.relabel(
+			"/etc/passwd*",
+			"/etc/group*",
+			"/etc/shadow*",
+			"/etc/gshadow*",
+			"/etc/.pwd.lock",
+			"/home",
+		)
 	}
 
 	return nil

--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/internal/exec/util"
 )
 
@@ -81,9 +82,10 @@ func (s *stage) createUnits(config types.Config) error {
 // If the contents of the unit or are empty, the unit is not created. The same
 // applies to the unit's dropins.
 func (s *stage) writeSystemdUnit(unit types.Unit, runtime bool) error {
-	// use a different DestDir if it's runtime so it affects our /run
+	// use a different DestDir if it's runtime so it affects our /run (but not
+	// if we're running locally through blackbox tests)
 	u := s.Util
-	if runtime {
+	if runtime && !distro.BlackboxTesting() {
 		u.DestDir = "/"
 	}
 

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -267,6 +267,20 @@ func MkdirForFile(path string) error {
 	return os.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions)
 }
 
+// PathExists returns true if a node exists within DestDir, false otherwise. Any
+// error other than ENOENT is treated as fatal.
+func (u Util) PathExists(path string) (bool, error) {
+	_, err := os.Stat(u.JoinPath(path))
+	switch {
+	case os.IsNotExist(err):
+		return false, nil
+	case err != nil:
+		return false, err
+	default:
+		return true, nil
+	}
+}
+
 // getFileOwner will return the uid and gid for the file at a given path. If the
 // file doesn't exist, or some other error is encountered when running stat on
 // the path, 0, 0, and 0 will be returned.

--- a/internal/exec/util/path.go
+++ b/internal/exec/util/path.go
@@ -22,12 +22,24 @@ func SystemdUnitsPath() string {
 	return filepath.Join("etc", "systemd", "system")
 }
 
+func SystemdRuntimeUnitsPath() string {
+	return filepath.Join("run", "systemd", "system")
+}
+
+func SystemdRuntimeUnitWantsPath(unitName string) string {
+	return filepath.Join("run", "systemd", "system", unitName+".wants")
+}
+
 func NetworkdUnitsPath() string {
 	return filepath.Join("etc", "systemd", "network")
 }
 
 func SystemdDropinsPath(unitName string) string {
 	return filepath.Join("etc", "systemd", "system", unitName+".d")
+}
+
+func SystemdRuntimeDropinsPath(unitName string) string {
+	return filepath.Join("run", "systemd", "system", unitName+".d")
 }
 
 func NetworkdDropinsPath(unitName string) string {

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -22,6 +22,7 @@ import (
 
 	configUtil "github.com/coreos/ignition/config/util"
 	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/distro"
 
 	"github.com/vincent-petithory/dataurl"
 )
@@ -113,9 +114,11 @@ func (u Util) EnableUnit(unit types.Unit) error {
 // presets link in /etc, which doesn't make sense for runtime units
 // Related: https://github.com/coreos/ignition/issues/588
 func (u Util) EnableRuntimeUnit(unit types.Unit, target string) error {
-	// we want to affect /run, which will be carried into the pivot,
-	// not a directory named /$DestDir/run
-	u.DestDir = "/"
+	// unless we're running tests locally, we want to affect /run, which will
+	// be carried into the pivot, not a directory named /$DestDir/run
+	if !distro.BlackboxTesting() {
+		u.DestDir = "/"
+	}
 
 	link := types.Link{
 		Node: types.Node{

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -31,13 +31,21 @@ const (
 	DefaultPresetPermissions os.FileMode = 0644
 )
 
-func FileFromSystemdUnit(unit types.Unit) (*FetchOp, error) {
+func FileFromSystemdUnit(unit types.Unit, runtime bool) (*FetchOp, error) {
 	u, err := url.Parse(dataurl.EncodeBytes([]byte(unit.Contents)))
 	if err != nil {
 		return nil, err
 	}
+
+	var path string
+	if runtime {
+		path = SystemdRuntimeUnitsPath()
+	} else {
+		path = SystemdUnitsPath()
+	}
+
 	return &FetchOp{
-		Path: filepath.Join(SystemdUnitsPath(), string(unit.Name)),
+		Path: filepath.Join(path, string(unit.Name)),
 		Url:  *u,
 		Mode: configUtil.IntToPtr(int(DefaultFilePermissions)),
 	}, nil
@@ -55,13 +63,21 @@ func FileFromNetworkdUnit(unit types.Networkdunit) (*FetchOp, error) {
 	}, nil
 }
 
-func FileFromSystemdUnitDropin(unit types.Unit, dropin types.SystemdDropin) (*FetchOp, error) {
+func FileFromSystemdUnitDropin(unit types.Unit, dropin types.SystemdDropin, runtime bool) (*FetchOp, error) {
 	u, err := url.Parse(dataurl.EncodeBytes([]byte(dropin.Contents)))
 	if err != nil {
 		return nil, err
 	}
+
+	var path string
+	if runtime {
+		path = SystemdRuntimeDropinsPath(string(unit.Name))
+	} else {
+		path = SystemdDropinsPath(string(unit.Name))
+	}
+
 	return &FetchOp{
-		Path: filepath.Join(SystemdDropinsPath(string(unit.Name)), string(dropin.Name)),
+		Path: filepath.Join(path, string(dropin.Name)),
 		Url:  *u,
 		Mode: configUtil.IntToPtr(int(DefaultFilePermissions)),
 	}, nil
@@ -92,6 +108,27 @@ func (u Util) MaskUnit(unit types.Unit) error {
 
 func (u Util) EnableUnit(unit types.Unit) error {
 	return u.appendLineToPreset(fmt.Sprintf("enable %s", unit.Name))
+}
+
+// presets link in /etc, which doesn't make sense for runtime units
+// Related: https://github.com/coreos/ignition/issues/588
+func (u Util) EnableRuntimeUnit(unit types.Unit, target string) error {
+	// we want to affect /run, which will be carried into the pivot,
+	// not a directory named /$DestDir/run
+	u.DestDir = "/"
+
+	link := types.Link{
+		Node: types.Node{
+			Filesystem: "root",
+			// XXX(jl): make Wants/Required a parameter
+			Path: filepath.Join(SystemdRuntimeUnitWantsPath(target), string(unit.Name)),
+		},
+		LinkEmbedded1: types.LinkEmbedded1{
+			Target: filepath.Join("/", SystemdRuntimeUnitsPath(), string(unit.Name)),
+		},
+	}
+
+	return u.WriteLink(link)
 }
 
 func (u Util) DisableUnit(unit types.Unit) error {

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	presetPath               string      = "/etc/systemd/system-preset/20-ignition.preset"
+	PresetPath               string      = "/etc/systemd/system-preset/20-ignition.preset"
 	DefaultPresetPermissions os.FileMode = 0644
 )
 
@@ -136,7 +136,7 @@ func (u Util) DisableUnit(unit types.Unit) error {
 }
 
 func (u Util) appendLineToPreset(data string) error {
-	path := u.JoinPath(presetPath)
+	path := u.JoinPath(PresetPath)
 	if err := MkdirForFile(path); err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes the files stage immediately load the SELinux policy from the
target sysroot to ensure that files it creates will be properly labeled.

(Marking as WIP because this is untested on CL). Would be nice if someone already set up could try this (without [the workaround](https://github.com/coreos/ignition/blob/a611d96e5c1179e7b93b93afe53548ae7d1d1b87/doc/operator-notes.md#selinux)) and confirm that files are labeled correctly.