### PR TITLE
 resource: add os-release headers when fetching config 

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -105,7 +105,7 @@ When an experimental version of the Ignition config spec (e.g.: `2.3.0-experimen
 - Any configs with a `version` field set to the previously experimental version will no longer pass validation. For example, if `2.3.0-experimental` is being marked as stable, any configs written for `2.3.0-experimental` should have their version fields changed to `2.3.0`, for Ignition will no longer accept them.
 - A new experimental spec version will be created. For example, if `2.3.0-experimental` is being marked as stable, a new version of `2.4.0-experimental` will now be accepted, and start to accumulate new changes to the spec.
 - The new stable spec and the new experimental spec will be identical. The new experimental spec is a direct copy of the old experimental spec, and no new changes to the spec have been made yet, so initially the two specs will have the same fields and semantics.
-- The HTTP `user-agent` header that Ignition uses whenever fetching an object and the HTTP `accept` header that Ignition uses whenever fetching a config will be updated to advertise the new stable spec.
+- The HTTP `user-agent` header that Ignition uses whenever fetching an object and the HTTP `Accept`, `Ignition-Initramfs-ID`, `Ignition-Initramfs-Version_ID` (if present), and `Ignition-Initramfs-Variant_ID` (if present) headers that Ignition uses whenever fetching a config will be updated to advertise the new stable spec.
 - New features will be documented in the [migrating configs](doc/migrating-configs.md) documentation.
 
 The code changes that are required to achieve these effects are typically the following:

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 1de154fd59f1a5e02d4a9a15815f7328fb7cb8ef232ded755432f2d3b1120419
-updated: 2018-06-14T16:10:53.870195521-07:00
+hash: 4c7ec3e76d79976c7be97f2232d865c01b3a9d3b94b147672d119bf5d67c1274
+updated: 2018-07-01T20:06:33.283505893-07:00
 imports:
 - name: github.com/ajeddeloh/go-json
   version: 73d058cf8437a1989030afe571eeab9f90eebbbd
+- name: github.com/ashcrow/osrelease
+  version: 9b292693c55c791c79825cdce5b7e0b3b6da6e88
 - name: github.com/aws/aws-sdk-go
   version: c861d27d0304a79f727e9a8a4e2ac1e74602fdc0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,6 +36,8 @@ import:
   version: a389bdde4dd695d414e47b755e95e72b7826432c
 - package: github.com/go-ini/ini
   version: c787282c39ac1fc618827141a1f762240def08a3
+- package: github.com/ashcrow/osrelease
+  version: v1
 testImport:
 - package: github.com/stretchr/testify
   version: 4d4bfba8f1d1027c4fdbe371823030df51419987

--- a/vendor/github.com/ashcrow/osrelease/LICENSE
+++ b/vendor/github.com/ashcrow/osrelease/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/ashcrow/osrelease/osrelease.go
+++ b/vendor/github.com/ashcrow/osrelease/osrelease.go
@@ -1,0 +1,143 @@
+// Package osrelease package provides access to parsed os-release information
+package osrelease
+
+import (
+	"errors"
+	"io/ioutil"
+	"reflect"
+	"strings"
+)
+
+// etcPath is the default path to os-release in etc
+var etcPath = "/etc/os-release"
+
+// usrPath is the default path to os-release in usr
+var usrPath = "/usr/lib/os-release"
+
+// OSRelease implements the format noted at
+// https://www.freedesktop.org/software/systemd/man/os-release.html
+type OSRelease struct {
+	NAME               string            // OS Identifier
+	VERSION            string            // Full OS Version
+	ID                 string            // Lowercase OS identifier
+	ID_LIKE            string            // Coma seperated list of closely related OSes
+	VERSION_ID         string            // Lowercase OS version
+	VERSION_CODENAME   string            // Lowercase OS release codename
+	PRETTY_NAME        string            // Human presented OS/Release name
+	ANSI_COLOR         string            // Suggested color for showing OS name
+	CPE_NAME           string            // See http://scap.nist.gov/specifications/cpe/
+	HOME_URL           string            // Main link for the OS
+	BUG_REPORT_URL     string            // Bug report link for the OS
+	PRIVACY_POLICY_URL string            // Privacy policy link for the OS
+	VARIANT            string            // Human presnted OS Variant
+	VARIANT_ID         string            // Lowercase OS Variant identifier
+	ADDITIONAL_FIELDS  map[string]string // Custom/unsupported fields
+	supportedFields    []string          // List of supported fields
+}
+
+// getFields denerates a list of fields which are supported by
+// the os-release spec.
+func (o *OSRelease) getFields() []string {
+	t := reflect.ValueOf(OSRelease{}).Type()
+	var fields []string
+	for x := 0; x < t.NumField(); x++ {
+		fields = append(fields, t.Field(x).Name)
+	}
+	return fields
+}
+
+// SetField sets a field on an instance of OSRelease.
+// If the field is not a supported field it will be
+// added to ADDITIONAL_FIELDS.
+func (o *OSRelease) SetField(key, value string) {
+	supported := false
+	for _, supportedKey := range o.supportedFields {
+		if key == supportedKey {
+			supported = true
+			break
+		}
+	}
+	if supported == true {
+		field := reflect.ValueOf(o).Elem()
+		field.FieldByName(key).SetString(value)
+	} else {
+		o.ADDITIONAL_FIELDS[key] = value
+	}
+}
+
+// GetField returns a field from the instance. If the
+// field is not present then an error us returned.
+func (o *OSRelease) GetField(key string) (string, error) {
+	supported := false
+	for _, supportedKey := range o.supportedFields {
+		if key == supportedKey {
+			supported = true
+			break
+		}
+	}
+
+	if supported == true {
+		return reflect.ValueOf(*o).FieldByName(key).String(), nil
+	}
+	for additionalKey := range o.ADDITIONAL_FIELDS {
+		if key == additionalKey {
+			return o.ADDITIONAL_FIELDS[additionalKey], nil
+		}
+	}
+	// Fail case
+	return "", errors.New("Field does not exist")
+}
+
+// Populate reads the os-release file, parses it, and
+// sets fields for use.
+func (o *OSRelease) Populate(paths []string) error {
+	o.supportedFields = o.getFields()
+	o.ADDITIONAL_FIELDS = make(map[string]string)
+
+	// Iterate over our known file paths
+	var rawContent []byte
+	var err error
+	for _, path := range paths {
+		rawContent, err = ioutil.ReadFile(path)
+		if err == nil {
+			break
+		}
+	}
+	// Error if we were unable to get any content
+	if len(rawContent) == 0 {
+		return errors.New("No content available from os-release files")
+	}
+
+	for _, line := range strings.Split(string(rawContent), "\n") {
+		if strings.Contains(line, "=") {
+			item := strings.Split(string(line), "=")
+			// Remove prefix/suffix quotes from values
+			item[1] = strings.TrimPrefix(item[1], "\"")
+			item[1] = strings.TrimSuffix(item[1], "\"")
+			// Set the field
+			o.SetField(item[0], item[1])
+		}
+	}
+	return nil
+}
+
+// New creates and returns a new insance of OSRelease.
+// Generally New should be used to create a new instance.
+func New() (OSRelease, error) {
+	o, err := NewWithOverrides(etcPath, usrPath)
+	if err != nil {
+		return o, err
+	}
+	return o, nil
+}
+
+// NewWithOverrides creates and returns a new instance of OSRelease
+// using the paths passed in.
+func NewWithOverrides(etcOverridePath, usrOverridePath string) (OSRelease, error) {
+	o := OSRelease{}
+	err := o.Populate([]string{etcOverridePath, usrOverridePath})
+	if err != nil {
+		return o, err
+	}
+	return o, nil
+}


### PR DESCRIPTION
ID, Version_ID (if present), and Variant_ID (if present) headers are added to GET requests when fetching configuration files. This provides the server side with more information on the type of system requesting an ignition config.

Jira card: https://projects.engineering.redhat.com/browse/COREOS-184