### PR TITLE
tests: refactor uuid replacement code

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -66,7 +66,7 @@ func (stage) Name() string {
 }
 
 func (s stage) Run(config types.Config) bool {
-	// Interacting with disks/paritions/raids/filesystems in general can cause
+	// Interacting with disks/partitions/raids/filesystems in general can cause
 	// udev races. If we do not need to  do anything, we also do not need to
 	// do the udevadm settle and can just return here.
 	if len(config.Storage.Disks) == 0 &&

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -80,8 +79,10 @@ func TestIgnitionBlackBoxNegative(t *testing.T) {
 func outer(t *testing.T, test types.Test, negativeTests bool) error {
 	t.Log(test.Name)
 
-	// Maps $uuid<num> such that two variables with the same <num> have identical UUID
-	UUIDmap := make(map[string]string)
+	err := test.ReplaceAllUUIDVars()
+	if err != nil {
+		return err
+	}
 
 	ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(testTimeout))
 	defer cancelFunc()
@@ -149,46 +150,6 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 			}
 		}
 		test.Out[i].SetOffsets()
-
-		// Replace all UUID variables (format $uuid<num>) in configs and partitions with an UUID
-		test.Config, err = replaceUUIDVars(t, test.Config, UUIDmap)
-		if err != nil {
-			return err
-		}
-
-		for _, disk := range test.In {
-			for _, partition := range disk.Partitions {
-				partition.TypeGUID, err = replaceUUIDVars(t, partition.TypeGUID, UUIDmap)
-				if err != nil {
-					return err
-				}
-				partition.GUID, err = replaceUUIDVars(t, partition.GUID, UUIDmap)
-				if err != nil {
-					return err
-				}
-				partition.FilesystemUUID, err = replaceUUIDVars(t, partition.FilesystemUUID, UUIDmap)
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		for _, disk := range test.Out {
-			for _, partition := range disk.Partitions {
-				partition.TypeGUID, err = replaceUUIDVars(t, partition.TypeGUID, UUIDmap)
-				if err != nil {
-					return err
-				}
-				partition.GUID, err = replaceUUIDVars(t, partition.GUID, UUIDmap)
-				if err != nil {
-					return err
-				}
-				partition.FilesystemUUID, err = replaceUUIDVars(t, partition.FilesystemUUID, UUIDmap)
-				if err != nil {
-					return err
-				}
-			}
-		}
 
 		// Creation
 		err = createVolume(t, ctx, tmpDirectory, i, disk.ImageFile, imageSize, disk.Partitions)
@@ -357,29 +318,4 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 		}
 	}
 	return nil
-}
-
-// Identify and replace $uuid<num> with correct UUID
-// Variables with matching <num> should have identical UUIDs
-func replaceUUIDVars(t *testing.T, str string, UUIDmap map[string]string) (string, error) {
-	finalStr := str
-
-	pattern := regexp.MustCompile("\\$uuid([0-9]+)")
-	for _, match := range pattern.FindAllStringSubmatch(str, -1) {
-		if len(match) != 2 {
-			return str, fmt.Errorf("find all string submatch error: want length of 2, got length of %d", len(match))
-		}
-
-		finalStr = strings.Replace(finalStr, match[0], getUUID(match[0], UUIDmap), 1)
-	}
-	return finalStr, nil
-}
-
-// Format: $uuid<num> where the uuid variable (uuid<num>) is the key
-// value is the UUID for this uuid variable
-func getUUID(key string, UUIDmap map[string]string) string {
-	if _, ok := UUIDmap[key]; !ok {
-		UUIDmap[key] = uuid.New()
-	}
-	return UUIDmap[key]
 }


### PR DESCRIPTION
Refactored the code that identifies and replaces UUID variables so that:
	1) It is not unnecessarily ran on each loop of test.In in outer()
	2) outer() is not as long

Jira card: https://projects.engineering.redhat.com/browse/COREOS-253