### PR TITLE
tests/register: Run BB test on all compatible config versions

### DIFF
--- a/config/v1/types/config.go
+++ b/config/v1/types/config.go
@@ -14,8 +14,16 @@
 
 package types
 
+import "github.com/coreos/go-semver/semver"
+
 const (
 	Version = 1
+)
+
+var (
+	MaxVersion = semver.Version{
+		Major: Version,
+	}
 )
 
 type Config struct {

--- a/doc/development.md
+++ b/doc/development.md
@@ -92,7 +92,9 @@ OEMLookasideFiles: `[]File` object which describes the Files that should be writ
 
 SystemDirFiles: `[]File` object which describes the Files that should be written into Ignition's system config directory before Ignition is run.
 
-Config: `string`
+Config: `string` type where the specific config version should be replaced by `$version` and will be updated before Ignition is run.
+
+ConfigMinVersion: `string` type which describes the minimum config version the test should be run with. Copies of the test will be generated for every version, inside the same major version, that is equal to or greater than the specified ConfigMinVersion. If the test should run only once with a specfic config version, leave this field empty and replace $version in the `Config` field with the desired version.
 
 The test should be added to the init function inside of the test file. If the test module is being created then an `init` function should be created which registers the tests and the package must be imported inside of `tests/registry/registry.go` to allow for discovery.
 
@@ -134,6 +136,12 @@ Next, all places that imported `config/vX_Y_experimental` should be updated to `
 - `internal/config/types`
 - `tests`
 - `validate`
+
+Update `tests/register/register.go` in the following ways:
+
+- Update import `config/vX_Y_experimental` to `config/vX_Y`
+- Add import `config/vX_(Y+1)_experimental`
+- Add `config/vX_(Y+1)_experimental`'s identifier to `configVersions` in Register()
 
 ### Update the blackbox tests
 

--- a/tests/negative/files/append.go
+++ b/tests/negative/files/append.go
@@ -36,7 +36,7 @@ func AppendToDirectory() types.Test {
 	}
 
 	config := `{
-	    "ignition": {"version": "2.2.0"},
+	    "ignition": {"version": "$version" },
 	    "storage": {
 	      "files": [{
 	      "filesystem": "root",
@@ -54,13 +54,15 @@ func AppendToDirectory() types.Test {
 			},
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -76,7 +78,7 @@ func AppendAndOverwrite() types.Test {
 	}
 
 	config := `{
-		"ignition": {"version": "2.2.0"},
+		"ignition": {"version": "$version" },
 		"storage": {
 		  "files": [{
 	      "filesystem": "root",
@@ -87,6 +89,7 @@ func AppendAndOverwrite() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 
 	return types.Test{
 		Name:              name,
@@ -95,5 +98,6 @@ func AppendAndOverwrite() types.Test {
 		MntDevices:        mntDevices,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }

--- a/tests/negative/files/invalid_hash.go
+++ b/tests/negative/files/invalid_hash.go
@@ -36,7 +36,7 @@ func InvalidHash() types.Test {
 	}
 
 	config := `{
-		"ignition": {"version": "2.0.0"},
+		"ignition": {"version": "$version" },
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -53,13 +53,15 @@ func InvalidHash() types.Test {
 					"source": "data:,asdf", "verification": {"hash": "sha512-1a04c76c17079cd99e688ba4f1ba095b927d3fecf2b1e027af361dfeafb548f7f5f6fdd675aaa2563950db441d893ca77b0c3e965cdcb891784af96e330267d7"}}
 			}]}
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -68,7 +70,7 @@ func InvalidHashFromHTTPURL() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -80,6 +82,7 @@ func InvalidHashFromHTTPURL() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -91,9 +94,10 @@ func InvalidHashFromHTTPURL() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -30,7 +30,7 @@ func MissingRemoteContentsHTTP() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -41,11 +41,14 @@ func MissingRemoteContentsHTTP() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.1.0"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -54,7 +57,7 @@ func MissingRemoteContentsTFTP() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-          "ignition": { "version": "2.1.0" },
+          "ignition": { "version": "$version" },
           "storage": {
             "files": [{
               "filesystem": "root",
@@ -65,11 +68,14 @@ func MissingRemoteContentsTFTP() types.Test {
             }]
           }
         }`
+	configMinVersion := "2.1.0"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -78,7 +84,7 @@ func MissingRemoteContentsOEM() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -89,10 +95,13 @@ func MissingRemoteContentsOEM() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.1.0"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/files/preexisting_nodes.go
+++ b/tests/negative/files/preexisting_nodes.go
@@ -33,7 +33,7 @@ func ForceFileCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -45,6 +45,7 @@ func ForceFileCreation() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -55,10 +56,11 @@ func ForceFileCreation() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -67,7 +69,7 @@ func ForceDirCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "directories": [{
 	      "filesystem": "root",
@@ -75,6 +77,7 @@ func ForceDirCreation() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -86,10 +89,11 @@ func ForceDirCreation() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -98,7 +102,7 @@ func ForceLinkCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -114,6 +118,7 @@ func ForceLinkCreation() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -125,10 +130,11 @@ func ForceLinkCreation() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -137,7 +143,7 @@ func ForceHardLinkCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -154,6 +160,7 @@ func ForceHardLinkCreation() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -165,10 +172,11 @@ func ForceHardLinkCreation() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -177,7 +185,7 @@ func ForceFileCreationOverNonemptyDir() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -189,6 +197,7 @@ func ForceFileCreationOverNonemptyDir() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -200,10 +209,11 @@ func ForceFileCreationOverNonemptyDir() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -212,7 +222,7 @@ func ForceLinkCreationOverNonemptyDir() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -228,6 +238,7 @@ func ForceLinkCreationOverNonemptyDir() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.2.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -239,9 +250,10 @@ func ForceLinkCreationOverNonemptyDir() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/filesystems/invalid_filesystem.go
+++ b/tests/negative/filesystems/invalid_filesystem.go
@@ -28,7 +28,7 @@ func InvalidFilesystem() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.0.0"},
+		"ignition": {"version": "$version" },
 		"storage": {
 			"files": [{
 				"filesystem": "NotARealFilesystem",
@@ -36,11 +36,13 @@ func InvalidFilesystem() types.Test {
 				"contents": {"source": "data:,asdf"}
 			}]}
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/filesystems/no_device.go
+++ b/tests/negative/filesystems/no_device.go
@@ -31,7 +31,7 @@ func NoDevice() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -41,6 +41,7 @@ func NoDevice() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:              name,
@@ -48,6 +49,7 @@ func NoDevice() types.Test {
 		Out:               out,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }
 
@@ -56,7 +58,7 @@ func NoDeviceWithForce() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.0.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -69,6 +71,7 @@ func NoDeviceWithForce() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:              name,
@@ -76,6 +79,7 @@ func NoDeviceWithForce() types.Test {
 		Out:               out,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }
 
@@ -84,7 +88,7 @@ func NoDeviceWithWipeFilesystemTrue() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -95,6 +99,7 @@ func NoDeviceWithWipeFilesystemTrue() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:              name,
@@ -102,6 +107,7 @@ func NoDeviceWithWipeFilesystemTrue() types.Test {
 		Out:               out,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }
 
@@ -110,7 +116,7 @@ func NoDeviceWithWipeFilesystemFalse() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -121,6 +127,7 @@ func NoDeviceWithWipeFilesystemFalse() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:              name,
@@ -128,5 +135,6 @@ func NoDeviceWithWipeFilesystemFalse() types.Test {
 		Out:               out,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }

--- a/tests/negative/filesystems/no_filesystem_type.go
+++ b/tests/negative/filesystems/no_filesystem_type.go
@@ -36,7 +36,7 @@ func NoFilesystemType() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -46,6 +46,7 @@ func NoFilesystemType() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:              name,
@@ -54,6 +55,7 @@ func NoFilesystemType() types.Test {
 		MntDevices:        mntDevices,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }
 
@@ -68,7 +70,7 @@ func NoFilesystemTypeWithForce() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.0.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -81,6 +83,7 @@ func NoFilesystemTypeWithForce() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:              name,
@@ -89,6 +92,7 @@ func NoFilesystemTypeWithForce() types.Test {
 		MntDevices:        mntDevices,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }
 
@@ -103,7 +107,7 @@ func NoFilesystemTypeWithWipeFilesystem() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -114,6 +118,7 @@ func NoFilesystemTypeWithWipeFilesystem() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:              name,
@@ -122,5 +127,6 @@ func NoFilesystemTypeWithWipeFilesystem() types.Test {
 		MntDevices:        mntDevices,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -45,7 +45,7 @@ func ReplaceConfigWithInvalidHash() types.Test {
 	}
 	config := `{
 	  "ignition": {
-	    "version": "2.0.0",
+	    "version": "$version",
 	    "config": {
 	      "replace": {
 	        "source": "http://127.0.0.1:8080/config",
@@ -54,13 +54,15 @@ func ReplaceConfigWithInvalidHash() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -76,7 +78,7 @@ func AppendConfigWithInvalidHash() types.Test {
 	}
 	config := `{
 	  "ignition": {
-	    "version": "2.0.0",
+	    "version": "$version",
 	    "config": {
 	      "append": [{
 	        "source": "http://127.0.0.1:8080/config",
@@ -92,13 +94,15 @@ func AppendConfigWithInvalidHash() types.Test {
         }]
       }
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -108,7 +112,7 @@ func ReplaceConfigWithMissingFileHTTP() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.1.0",
+	    "version": "$version",
 	    "config": {
 	      "replace": {
 	        "source": "http://127.0.0.1:8080/asdf"
@@ -116,12 +120,14 @@ func ReplaceConfigWithMissingFileHTTP() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -131,7 +137,7 @@ func ReplaceConfigWithMissingFileTFTP() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.1.0",
+	    "version": "$version",
 	    "config": {
 	      "replace": {
 	        "source": "tftp://127.0.0.1:69/asdf"
@@ -139,12 +145,14 @@ func ReplaceConfigWithMissingFileTFTP() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -154,7 +162,7 @@ func ReplaceConfigWithMissingFileOEM() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.1.0",
+	    "version": "$version",
 	    "config": {
 	      "replace": {
 	        "source": "oem:///asdf"
@@ -162,12 +170,14 @@ func ReplaceConfigWithMissingFileOEM() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -177,7 +187,7 @@ func AppendConfigWithMissingFileHTTP() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.1.0",
+	    "version": "$version",
 	    "config": {
 	      "append": [{
 	        "source": "http://127.0.0.1:8080/asdf"
@@ -185,12 +195,14 @@ func AppendConfigWithMissingFileHTTP() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -200,7 +212,7 @@ func AppendConfigWithMissingFileTFTP() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.1.0",
+	    "version": "$version",
 	    "config": {
 	      "append": [{
 	        "source": "tftp://127.0.0.1:69/asdf"
@@ -208,12 +220,14 @@ func AppendConfigWithMissingFileTFTP() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -223,7 +237,7 @@ func AppendConfigWithMissingFileOEM() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.1.0",
+	    "version": "$version",
 	    "config": {
 	      "append": [{
 	        "source": "oem:///asdf"
@@ -231,12 +245,14 @@ func AppendConfigWithMissingFileOEM() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -246,7 +262,7 @@ func VersionOnlyConfig22() types.Test {
 	out := in
 	config := `{
 	  "ignition": {
-	    "version": "2.2.0-experimental"
+	    "version": $version"
 	  }
 	}`
 

--- a/tests/negative/general/invalid_version.go
+++ b/tests/negative/general/invalid_version.go
@@ -28,7 +28,7 @@ func InvalidVersion() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "4.0.0"},
+		"ignition": {"version": 4.0.0"},
 		"storage": {
 			"files": [{
 				"filesystem": "test",

--- a/tests/negative/networkd/dropins.go
+++ b/tests/negative/networkd/dropins.go
@@ -28,7 +28,7 @@ func NetworkdDropinInvalidExtension() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": { "version": "2.2.0" },
+		"ignition": { "version": "$version" },
 		"networkd": {
 			"units": [{
 				"name": "static.network",
@@ -39,6 +39,7 @@ func NetworkdDropinInvalidExtension() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.2.0"
 
 	return types.Test{
 		Name:              name,
@@ -46,5 +47,6 @@ func NetworkdDropinInvalidExtension() types.Test {
 		Out:               out,
 		Config:            config,
 		ConfigShouldBeBad: true,
+		ConfigMinVersion:  configMinVersion,
 	}
 }

--- a/tests/negative/partitions/simple.go
+++ b/tests/negative/partitions/simple.go
@@ -32,7 +32,7 @@ func ShouldNotExistNoWipeEntry() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.3.0-experimental"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"disks": [
 			{
@@ -47,12 +47,14 @@ func ShouldNotExistNoWipeEntry() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -61,7 +63,7 @@ func DoesNotMatchNoWipeEntry() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.3.0-experimental"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"disks": [
 			{
@@ -76,12 +78,14 @@ func DoesNotMatchNoWipeEntry() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -90,7 +94,7 @@ func ValidAndDoesNotMatchNoWipeEntry() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.3.0-experimental"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"disks": [
 			{
@@ -108,12 +112,14 @@ func ValidAndDoesNotMatchNoWipeEntry() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -122,7 +128,7 @@ func NotThereAndDoesNotMatchNoWipeEntry() types.Test {
 	in := types.GetBaseDisk()
 	out := in
 	config := `{
-		"ignition": {"version": "2.3.0-experimental"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"disks": [
 			{
@@ -141,11 +147,13 @@ func NotThereAndDoesNotMatchNoWipeEntry() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/partitions/zeroes.go
+++ b/tests/negative/partitions/zeroes.go
@@ -34,7 +34,7 @@ func Partition9DoesNotFillDisk() types.Test {
 	})
 	out := in
 	config := `{
-		"ignition": {"version": "2.3.0-experimental"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"disks": [
 			{
@@ -49,12 +49,14 @@ func Partition9DoesNotFillDisk() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -70,7 +72,7 @@ func Partition9DoesNotStartCorrectly() types.Test {
 	in[0].Partitions = append(in[0].Partitions, tmp)
 	out := in
 	config := `{
-		"ignition": {"version": "2.3.0-experimental"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"disks": [
 			{
@@ -85,11 +87,13 @@ func Partition9DoesNotStartCorrectly() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/regression/filesystem.go
+++ b/tests/negative/regression/filesystem.go
@@ -36,7 +36,7 @@ func VFATIgnoresWipeFilesystem() types.Test {
 		},
 	}
 	config := `{
-                "ignition": {"version": "2.1.0"},
+                "ignition": {"version": "$version"},
                 "storage": {
                         "filesystems": [{
                                 "mount": {
@@ -46,12 +46,14 @@ func VFATIgnoresWipeFilesystem() types.Test {
                                 }}]
                         }
         }`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/security/tls.go
+++ b/tests/negative/security/tls.go
@@ -96,7 +96,7 @@ func AppendConfigCustomCert() types.Test {
 	out := types.GetBaseDisk()
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.2.0",
+			"version": "$version",
 			"config": {
 			  "append": [{
 				"source": %q
@@ -107,12 +107,14 @@ func AppendConfigCustomCert() types.Test {
 			}
 		}
 	}`, customCAServer.URL)
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -122,7 +124,7 @@ func FetchFileCustomCert() types.Test {
 	out := types.GetBaseDisk()
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.2.0",
+			"version": "$version",
 			"timeouts": {
 				"httpTotal": 5
 			}
@@ -137,11 +139,13 @@ func FetchFileCustomCert() types.Test {
 			}]
 		}
 	}`, customCAServer.URL)
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/negative/timeouts/timeouts.go
+++ b/tests/negative/timeouts/timeouts.go
@@ -46,7 +46,7 @@ var (
 		// second (less than we wait!)
 		w.Write([]byte(fmt.Sprintf(`{
 			"ignition": {
-				"version": "2.1.0",
+				"version": "$version",
 				"config": {
 					"append": [{
 						"source": %q
@@ -67,7 +67,7 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 	out := in
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.1.0",
+			"version": "$version",
 			"timeouts": {
 				"httpResponseHeaders": 1,
 				"httpTotal": 10
@@ -85,12 +85,14 @@ func DecreaseHTTPResponseHeadersTimeout() types.Test {
 			]
 		}
 	}`, respondDelayServer.URL)
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -100,7 +102,7 @@ func AppendWithHTTPTimeouts() types.Test {
 	out := in
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.1.0",
+			"version": "$version",
 			"config": {
 				"append": [{
 					"source": %q
@@ -113,12 +115,14 @@ func AppendWithHTTPTimeouts() types.Test {
 		}
 	}`, configDelayServer.URL)
 	configDelayServerURL = configDelayServer.URL
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -128,7 +132,7 @@ func AppendLowerHTTPTimeouts() types.Test {
 	out := in
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.1.0",
+			"version": "$version",
 			"config": {
 				"append": [{
 					"source": %q
@@ -137,12 +141,14 @@ func AppendLowerHTTPTimeouts() types.Test {
 		}
 	}`, configDelayServer.URL)
 	configDelayServerURL = configDelayServer.URL
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -158,7 +164,7 @@ func AppendNoneThenLowerHTTPTimeouts() types.Test {
 			// second (less than we wait!)
 			w.Write([]byte(`{
 				"ignition": {
-					"version": "2.1.0"
+					"version": "$version"
 				}
 			}`))
 		}))
@@ -167,8 +173,8 @@ func AppendNoneThenLowerHTTPTimeouts() types.Test {
 			// Give a config that appends ourselves and sets the timeouts to 1
 			// second (less than we wait!)
 			w.Write([]byte(fmt.Sprintf(`{
-			"ignition": {
-				"version": "2.1.0",
+			"ignition": 
+				"version": "$version",
 				"config": {
 					"append": [{
 						"source": %q
@@ -184,7 +190,7 @@ func AppendNoneThenLowerHTTPTimeouts() types.Test {
 	out := in
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.1.0",
+			"version": "$version",
 			"config": {
 				"append": [{
 					"source": %q
@@ -196,11 +202,13 @@ func AppendNoneThenLowerHTTPTimeouts() types.Test {
 			}
 		}
 	}`, configNoDelayServer.URL)
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/files/directory.go
+++ b/tests/positive/files/directory.go
@@ -30,7 +30,7 @@ func CreateDirectoryOnRoot() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "directories": [{
 	      "filesystem": "root",
@@ -46,12 +46,14 @@ func CreateDirectoryOnRoot() types.Test {
 			},
 		},
 	})
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -60,7 +62,7 @@ func ForceDirCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "directories": [{
 	      "filesystem": "root",
@@ -86,12 +88,14 @@ func ForceDirCreation() types.Test {
 			},
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -100,7 +104,7 @@ func ForceDirCreationOverNonemptyDir() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "directories": [{
 	      "filesystem": "root",
@@ -126,12 +130,14 @@ func ForceDirCreationOverNonemptyDir() types.Test {
 			},
 		},
 	})
+	configMinVersion := "2.2.0"
 	// TODO: add ability to ensure that foo/bar/baz doesn't exist here.
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -21,14 +21,13 @@ import (
 
 func init() {
 	register.Register(register.PositiveTest, CreateFileOnRoot())
-	register.Register(register.PositiveTest, UserGroupByID_2_0_0())
-	register.Register(register.PositiveTest, UserGroupByID_2_1_0())
+	register.Register(register.PositiveTest, UserGroupByID())
 	register.Register(register.PositiveTest, ForceFileCreation())
 	register.Register(register.PositiveTest, ForceFileCreationNoOverwrite())
 	register.Register(register.PositiveTest, AppendToAFile())
 	register.Register(register.PositiveTest, AppendToNonexistentFile())
 	// TODO: Investigate why ignition's C code hates our environment
-	// register.Register(register.PositiveTest, UserGroupByName_2_1_0())
+	// register.Register(register.PositiveTest, UserGroupByName())
 }
 
 func CreateFileOnRoot() types.Test {
@@ -36,7 +35,7 @@ func CreateFileOnRoot() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -54,21 +53,23 @@ func CreateFileOnRoot() types.Test {
 			Contents: "example file\n",
 		},
 	})
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func UserGroupByID_2_0_0() types.Test {
-	name := "2.0.0 User/Group by id"
+func UserGroupByID() types.Test {
+	name := "User/Group by id"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -90,57 +91,23 @@ func UserGroupByID_2_0_0() types.Test {
 			Contents: "example file\n",
 		},
 	})
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func UserGroupByID_2_1_0() types.Test {
-	name := "2.1.0 User/Group by id"
+func UserGroupByName() types.Test {
+	name := "User/Group by name"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
-	  "storage": {
-	    "files": [{
-	      "filesystem": "root",
-	      "path": "/foo/bar",
-	      "contents": { "source": "data:,example%20file%0A" },
-		  "user": {"id": 500},
-		  "group": {"id": 500}
-	    }]
-	  }
-	}`
-	out[0].Partitions.AddFiles("ROOT", []types.File{
-		{
-			Node: types.Node{
-				Name:      "bar",
-				Directory: "foo",
-				User:      500,
-				Group:     500,
-			},
-			Contents: "example file\n",
-		},
-	})
-
-	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
-	}
-}
-
-func UserGroupByName_2_1_0() types.Test {
-	name := "2.1.0 User/Group by name"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -162,12 +129,14 @@ func UserGroupByName_2_1_0() types.Test {
 			Contents: "example file\n",
 		},
 	})
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -176,7 +145,7 @@ func ForceFileCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -206,12 +175,14 @@ func ForceFileCreation() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -220,7 +191,7 @@ func ForceFileCreationNoOverwrite() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -249,12 +220,14 @@ func ForceFileCreationNoOverwrite() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -263,7 +236,7 @@ func AppendToAFile() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -291,12 +264,14 @@ func AppendToAFile() types.Test {
 			Contents: "example file\nhello world\n",
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -305,7 +280,7 @@ func AppendToNonexistentFile() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -326,11 +301,13 @@ func AppendToNonexistentFile() types.Test {
 			Contents: "hello world\n",
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/files/hash.go
+++ b/tests/positive/files/hash.go
@@ -29,7 +29,7 @@ func ValidateFileHashFromDataURL() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -50,12 +50,14 @@ func ValidateFileHashFromDataURL() types.Test {
 			Contents: "example file\n",
 		},
 	})
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -64,7 +66,7 @@ func ValidateFileHashFromHTTPURL() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -85,11 +87,13 @@ func ValidateFileHashFromHTTPURL() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/files/link.go
+++ b/tests/positive/files/link.go
@@ -31,7 +31,7 @@ func CreateHardLinkOnRoot() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -67,12 +67,14 @@ func CreateHardLinkOnRoot() types.Test {
 			Hard:   true,
 		},
 	})
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -81,7 +83,7 @@ func CreateSymlinkOnRoot() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "links": [{
 	      "filesystem": "root",
@@ -109,12 +111,14 @@ func CreateSymlinkOnRoot() types.Test {
 			Hard:   false,
 		},
 	})
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -123,7 +127,7 @@ func ForceLinkCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -167,12 +171,14 @@ func ForceLinkCreation() types.Test {
 			Target: "/foo/target",
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -181,7 +187,7 @@ func ForceHardLinkCreation() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.2.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -227,11 +233,13 @@ func ForceHardLinkCreation() types.Test {
 			Hard:   true,
 		},
 	})
+	configMinVersion := "2.2.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -30,7 +30,7 @@ func CreateFileFromRemoteContentsHTTP() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -50,12 +50,14 @@ func CreateFileFromRemoteContentsHTTP() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -64,7 +66,7 @@ func CreateFileFromRemoteContentsTFTP() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-          "ignition": { "version": "2.1.0" },
+          "ignition": { "version": "$version" },
           "storage": {
             "files": [{
               "filesystem": "root",
@@ -84,12 +86,14 @@ func CreateFileFromRemoteContentsTFTP() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -98,7 +102,7 @@ func CreateFileFromRemoteContentsOEM() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "files": [{
 	      "filesystem": "root",
@@ -126,11 +130,13 @@ func CreateFileFromRemoteContentsOEM() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/filesystems/creation.go
+++ b/tests/positive/filesystems/creation.go
@@ -35,7 +35,7 @@ func ForceNewFilesystemOfSameType() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.0.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -47,6 +47,7 @@ func ForceNewFilesystemOfSameType() types.Test {
 				 }]
 			}
 	}`
+	configMinVersion := "2.0.0"
 
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
@@ -68,11 +69,12 @@ func ForceNewFilesystemOfSameType() types.Test {
 	})
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -87,7 +89,7 @@ func WipeFilesystemWithSameType() types.Test {
 		},
 	}
 	config := `{
-		"ignition": { "version": "2.1.0" },
+		"ignition": { "version": "$version" },
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -97,6 +99,7 @@ func WipeFilesystemWithSameType() types.Test {
 				}}]
 			}
 	}`
+	configMinVersion := "2.1.0"
 
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
@@ -118,10 +121,11 @@ func WipeFilesystemWithSameType() types.Test {
 	})
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/filesystems/reformat_filesystem.go
+++ b/tests/positive/filesystems/reformat_filesystem.go
@@ -20,18 +20,15 @@ import (
 )
 
 func init() {
-	register.Register(register.PositiveTest, ReformatToBTRFS_2_0_0())
-	register.Register(register.PositiveTest, ReformatToXFS_2_0_0())
-	register.Register(register.PositiveTest, ReformatToEXT4_2_0_0())
-	register.Register(register.PositiveTest, ReformatToBTRFS_2_1_0())
-	register.Register(register.PositiveTest, ReformatToXFS_2_1_0())
-	register.Register(register.PositiveTest, ReformatToVFAT_2_1_0())
-	register.Register(register.PositiveTest, ReformatToEXT4_2_1_0())
-	register.Register(register.PositiveTest, ReformatToSWAP_2_1_0())
+	register.Register(register.PositiveTest, ReformatToBTRFS())
+	register.Register(register.PositiveTest, ReformatToXFS())
+	register.Register(register.PositiveTest, ReformatToVFAT())
+	register.Register(register.PositiveTest, ReformatToEXT4())
+	register.Register(register.PositiveTest, ReformatToSWAP())
 }
 
-func ReformatToBTRFS_2_0_0() types.Test {
-	name := "Reformat a Filesystem to Btrfs - 2.0.0"
+func ReformatToBTRFS() types.Test {
+	name := "Reformat a Filesystem to Btrfs"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	mntDevices := []types.MntDevice{
@@ -41,7 +38,7 @@ func ReformatToBTRFS_2_0_0() types.Test {
 		},
 	}
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "filesystems": [{
 	      "mount": {
@@ -55,19 +52,21 @@ func ReformatToBTRFS_2_0_0() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func ReformatToXFS_2_0_0() types.Test {
-	name := "Reformat a Filesystem to XFS - 2.0.0"
+func ReformatToXFS() types.Test {
+	name := "Reformat a Filesystem to XFS"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	mntDevices := []types.MntDevice{
@@ -77,7 +76,7 @@ func ReformatToXFS_2_0_0() types.Test {
 		},
 	}
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "filesystems": [{
 	      "mount": {
@@ -91,19 +90,21 @@ func ReformatToXFS_2_0_0() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "xfs"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func ReformatToVFAT_2_0_0() types.Test {
-	name := "Reformat a Filesystem to VFAT - 2.0.0"
+func ReformatToVFAT() types.Test {
+	name := "Reformat a Filesystem to VFAT"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	mntDevices := []types.MntDevice{
@@ -113,34 +114,35 @@ func ReformatToVFAT_2_0_0() types.Test {
 		},
 	}
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "filesystems": [{
 	      "mount": {
 	        "device": "$DEVICE",
 	        "format": "vfat",
-	        "create": {
-	          "force": true,
-	          "options": [ "-n", "OEM", "-i", "$uuid0" ]
-	        }
+	        "label": "OEM",
+		"uuid": "2e24ec82",
+		"wipeFilesystem": true
 	      }
 	    }]
 	  }
 	}`
+	configMinVersion := "2.1.0"
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "vfat"
-	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "$uuid0"
+	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "2e24ec82"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func ReformatToEXT4_2_0_0() types.Test {
-	name := "Reformat a Filesystem to EXT4 - 2.0.0"
+func ReformatToEXT4() types.Test {
+	name := "Reformat a Filesystem to EXT4"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	mntDevices := []types.MntDevice{
@@ -150,7 +152,7 @@ func ReformatToEXT4_2_0_0() types.Test {
 		},
 	}
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "filesystems": [{
 	      "mount": {
@@ -164,21 +166,23 @@ func ReformatToEXT4_2_0_0() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	in[0].Partitions.GetPartition("OEM").FilesystemType = "ext2"
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "$uuid0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func ReformatToBTRFS_2_1_0() types.Test {
-	name := "Reformat a Filesystem to Btrfs - 2.1.0"
+func ReformatToSWAP() types.Test {
+	name := "Reformat a Filesystem to SWAP"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	mntDevices := []types.MntDevice{
@@ -188,152 +192,7 @@ func ReformatToBTRFS_2_1_0() types.Test {
 		},
 	}
 	config := `{
-	  "ignition": { "version": "2.1.0" },
-	  "storage": {
-	    "filesystems": [{
-	      "mount": {
-	        "device": "$DEVICE",
-	        "format": "btrfs",
-	        "label": "OEM",
-		"uuid": "$uuid0",
-		"wipeFilesystem": true
-	      }
-	    }]
-	  }
-	}`
-	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
-	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "$uuid0"
-
-	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
-	}
-}
-
-func ReformatToXFS_2_1_0() types.Test {
-	name := "Reformat a Filesystem to XFS - 2.1.0"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	mntDevices := []types.MntDevice{
-		{
-			Label:        "OEM",
-			Substitution: "$DEVICE",
-		},
-	}
-	config := `{
-	  "ignition": { "version": "2.1.0" },
-	  "storage": {
-	    "filesystems": [{
-	      "mount": {
-	        "device": "$DEVICE",
-	        "format": "xfs",
-	        "label": "OEM",
-		"uuid": "$uuid0",
-		"wipeFilesystem": true
-	      }
-	    }]
-	  }
-	}`
-	out[0].Partitions.GetPartition("OEM").FilesystemType = "xfs"
-	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "$uuid0"
-
-	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
-	}
-}
-
-func ReformatToVFAT_2_1_0() types.Test {
-	name := "Reformat a Filesystem to VFAT - 2.1.0"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	mntDevices := []types.MntDevice{
-		{
-			Label:        "OEM",
-			Substitution: "$DEVICE",
-		},
-	}
-	config := `{
-	  "ignition": { "version": "2.1.0" },
-	  "storage": {
-	    "filesystems": [{
-	      "mount": {
-	        "device": "$DEVICE",
-	        "format": "vfat",
-	        "label": "OEM",
-		"uuid": "2e24ec82",
-		"wipeFilesystem": true
-	      }
-	    }]
-	  }
-	}`
-	out[0].Partitions.GetPartition("OEM").FilesystemType = "vfat"
-	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "2e24ec82"
-
-	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
-	}
-}
-
-func ReformatToEXT4_2_1_0() types.Test {
-	name := "Reformat a Filesystem to EXT4 - 2.1.0"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	mntDevices := []types.MntDevice{
-		{
-			Label:        "OEM",
-			Substitution: "$DEVICE",
-		},
-	}
-	config := `{
-	  "ignition": { "version": "2.1.0" },
-	  "storage": {
-	    "filesystems": [{
-	      "mount": {
-	        "device": "$DEVICE",
-	        "format": "ext4",
-	        "label": "OEM",
-		"uuid": "$uuid0",
-		"wipeFilesystem": true
-	      }
-	    }]
-	  }
-	}`
-	in[0].Partitions.GetPartition("OEM").FilesystemType = "ext2"
-	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
-	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "$uuid0"
-
-	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
-	}
-}
-
-func ReformatToSWAP_2_1_0() types.Test {
-	name := "Reformat a Filesystem to SWAP - 2.1.0"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	mntDevices := []types.MntDevice{
-		{
-			Label:        "OEM",
-			Substitution: "$DEVICE",
-		},
-	}
-	config := `{
-	  "ignition": { "version": "2.1.0" },
+	  "ignition": { "version": "$version" },
 	  "storage": {
 	    "filesystems": [{
 	      "mount": {
@@ -346,15 +205,17 @@ func ReformatToSWAP_2_1_0() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.1.0"
 	in[0].Partitions.GetPartition("OEM").FilesystemType = "ext2"
 	out[0].Partitions.GetPartition("OEM").FilesystemType = "swap"
 	out[0].Partitions.GetPartition("OEM").FilesystemUUID = "$uuid0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/filesystems/reuse_filesystem.go
+++ b/tests/positive/filesystems/reuse_filesystem.go
@@ -34,7 +34,7 @@ func ReuseExistingFilesystem() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 		    "filesystems": [
 			    {
@@ -49,6 +49,7 @@ func ReuseExistingFilesystem() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.1.0"
 	in = append(in, types.Disk{
 		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
@@ -95,10 +96,11 @@ func ReuseExistingFilesystem() types.Test {
 	})
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -30,10 +30,7 @@ func init() {
 	register.Register(register.PositiveTest, AppendConfigWithRemoteConfigOEM())
 	register.Register(register.PositiveTest, ReplaceConfigWithRemoteConfigData())
 	register.Register(register.PositiveTest, AppendConfigWithRemoteConfigData())
-	register.Register(register.PositiveTest, VersionOnlyConfig20())
-	register.Register(register.PositiveTest, VersionOnlyConfig21())
-	register.Register(register.PositiveTest, VersionOnlyConfig22())
-	register.Register(register.PositiveTest, VersionOnlyConfig23())
+	register.Register(register.PositiveTest, VersionOnlyConfig())
 	register.Register(register.PositiveTest, EmptyUserdata())
 }
 
@@ -48,7 +45,7 @@ func ReformatFilesystemAndWriteFile() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.0.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"filesystems": [{
 				"mount": {
@@ -64,6 +61,7 @@ func ReformatFilesystemAndWriteFile() types.Test {
 				"contents": {"source": "data:,asdf"}
 			}]}
 	}`
+	configMinVersion := "2.0.0"
 
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").Files = []types.File{
@@ -77,11 +75,12 @@ func ReformatFilesystemAndWriteFile() types.Test {
 	}
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -91,7 +90,7 @@ func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 	  "ignition": {
-	    "version": "2.0.0",
+	    "version": "$version",
 	    "config": {
 	      "replace": {
 	        "source": "http://127.0.0.1:8080/config",
@@ -100,6 +99,7 @@ func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 	    }
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -111,10 +111,11 @@ func ReplaceConfigWithRemoteConfigHTTP() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -124,7 +125,7 @@ func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
           "ignition": {
-            "version": "2.1.0",
+            "version": "$version",
             "config": {
               "replace": {
                 "source": "tftp://127.0.0.1:69/config",
@@ -133,6 +134,7 @@ func ReplaceConfigWithRemoteConfigTFTP() types.Test {
             }
           }
         }`
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -144,10 +146,11 @@ func ReplaceConfigWithRemoteConfigTFTP() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -157,7 +160,7 @@ func ReplaceConfigWithRemoteConfigOEM() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
           "ignition": {
-            "version": "2.1.0",
+            "version": "$version",
             "config": {
               "replace": {
                 "source": "oem:///config",
@@ -166,6 +169,7 @@ func ReplaceConfigWithRemoteConfigOEM() types.Test {
             }
           }
         }`
+	configMinVersion := "2.1.0"
 	in[0].Partitions.AddFiles("OEM", []types.File{
 		{
 			Node: types.Node{
@@ -194,10 +198,11 @@ func ReplaceConfigWithRemoteConfigOEM() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -207,7 +212,7 @@ func AppendConfigWithRemoteConfigHTTP() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 	  "ignition": {
-	    "version": "2.0.0",
+	    "version": "$version",
 	    "config": {
 	      "append": [{
 	        "source": "http://127.0.0.1:8080/config",
@@ -223,6 +228,7 @@ func AppendConfigWithRemoteConfigHTTP() types.Test {
         }]
       }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -241,10 +247,11 @@ func AppendConfigWithRemoteConfigHTTP() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -254,7 +261,7 @@ func AppendConfigWithRemoteConfigTFTP() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
           "ignition": {
-            "version": "2.1.0",
+            "version": "$version",
             "config": {
               "append": [{
                 "source": "tftp://127.0.0.1:69/config",
@@ -270,6 +277,7 @@ func AppendConfigWithRemoteConfigTFTP() types.Test {
         }]
       }
         }`
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -288,10 +296,11 @@ func AppendConfigWithRemoteConfigTFTP() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -301,7 +310,7 @@ func AppendConfigWithRemoteConfigOEM() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
           "ignition": {
-            "version": "2.1.0",
+            "version": "$version",
             "config": {
               "append": [{
                 "source": "oem:///config",
@@ -317,6 +326,7 @@ func AppendConfigWithRemoteConfigOEM() types.Test {
         }]
       }
         }`
+	configMinVersion := "2.1.0"
 	in[0].Partitions.AddFiles("OEM", []types.File{
 		{
 			Node: types.Node{
@@ -352,10 +362,11 @@ func AppendConfigWithRemoteConfigOEM() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -365,7 +376,7 @@ func ReplaceConfigWithRemoteConfigData() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
           "ignition": {
-            "version": "2.1.0",
+            "version": "$version",
             "config": {
               "replace": {
 				  "source": "data:,%7B%22ignition%22%3A%7B%22version%22%3A%20%222.1.0%22%7D%2C%22storage%22%3A%20%7B%22files%22%3A%20%5B%7B%22filesystem%22%3A%20%22root%22%2C%22path%22%3A%20%22%2Ffoo%2Fbar%22%2C%22contents%22%3A%7B%22source%22%3A%22data%3A%2Canother%2520example%2520file%250A%22%7D%7D%5D%7D%7D%0A"
@@ -373,6 +384,7 @@ func ReplaceConfigWithRemoteConfigData() types.Test {
             }
           }
         }`
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -384,10 +396,11 @@ func ReplaceConfigWithRemoteConfigData() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -397,7 +410,7 @@ func AppendConfigWithRemoteConfigData() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
           "ignition": {
-            "version": "2.1.0",
+            "version": "$version",
             "config": {
               "append": [{
 				  "source": "data:,%7B%22ignition%22%3A%7B%22version%22%3A%20%222.1.0%22%7D%2C%22storage%22%3A%20%7B%22files%22%3A%20%5B%7B%22filesystem%22%3A%20%22root%22%2C%22path%22%3A%20%22%2Ffoo%2Fbar%22%2C%22contents%22%3A%7B%22source%22%3A%22data%3A%2Canother%2520example%2520file%250A%22%7D%7D%5D%7D%7D%0A"
@@ -405,6 +418,7 @@ func AppendConfigWithRemoteConfigData() types.Test {
             }
           }
         }`
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -416,74 +430,29 @@ func AppendConfigWithRemoteConfigData() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
-func VersionOnlyConfig20() types.Test {
-	name := "Version Only Config 2.0.0"
+func VersionOnlyConfig() types.Test {
+	name := "Version Only Config"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-		"ignition": {"version": "2.0.0"}
+		"ignition": {"version": "$version"}
 	}`
+	configMinVersion := "2.0.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
-	}
-}
-
-func VersionOnlyConfig21() types.Test {
-	name := "Version Only Config 2.1.0"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	config := `{
-		"ignition": {"version": "2.1.0"}
-	}`
-
-	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
-	}
-}
-
-func VersionOnlyConfig22() types.Test {
-	name := "Version Only Config 2.2.0"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	config := `{
-		"ignition": {"version": "2.2.0"}
-	}`
-
-	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
-	}
-}
-
-func VersionOnlyConfig23() types.Test {
-	name := "Version Only Config 2.3.0-experimental"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	config := `{
-		"ignition": {"version": "2.3.0-experimental"}
-	}`
-
-	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 

--- a/tests/positive/networkd/create_unit.go
+++ b/tests/positive/networkd/create_unit.go
@@ -28,7 +28,7 @@ func CreateNetworkdUnit() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-		"ignition": { "version": "2.1.0" },
+		"ignition": { "version": "$version" },
 		"networkd": {
 			"units": [{
 				"name": "static.network",
@@ -36,6 +36,7 @@ func CreateNetworkdUnit() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -47,9 +48,10 @@ func CreateNetworkdUnit() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/networkd/dropins.go
+++ b/tests/positive/networkd/dropins.go
@@ -28,7 +28,7 @@ func CreateNetworkdDropin() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-		"ignition": { "version": "2.2.0" },
+		"ignition": { "version": "$version" },
 		"networkd": {
 			"units": [{
 				"name": "static.network",
@@ -39,6 +39,7 @@ func CreateNetworkdDropin() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.2.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -50,9 +51,10 @@ func CreateNetworkdDropin() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/oem/oem.go
+++ b/tests/positive/oem/oem.go
@@ -28,7 +28,7 @@ func OEMSearchPath() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 			"files": [
 				{
@@ -43,6 +43,7 @@ func OEMSearchPath() types.Test {
 				}
 			]}
 	}`
+	configMinVersion := "2.1.0"
 	lookasideFiles := []types.File{
 		{
 			Node: types.Node{
@@ -82,5 +83,6 @@ func OEMSearchPath() types.Test {
 		Out:               out,
 		OEMLookasideFiles: lookasideFiles,
 		Config:            config,
+		ConfigMinVersion:  configMinVersion,
 	}
 }

--- a/tests/positive/partitions/complex.go
+++ b/tests/positive/partitions/complex.go
@@ -31,7 +31,7 @@ func KitchenSink() types.Test {
 	// Ignition should not clobber by default, so omit the partition 5 entry
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -74,6 +74,7 @@ func KitchenSink() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	in = append(in, types.Disk{
 		Alignment: types.IgnitionAlignment,
@@ -162,9 +163,10 @@ func KitchenSink() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/partitions/creation.go
+++ b/tests/positive/partitions/creation.go
@@ -44,7 +44,7 @@ func CreatePartition() types.Test {
 	})
 	config := `{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -63,11 +63,14 @@ func CreatePartition() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.1.0"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -77,7 +80,7 @@ func WipeAndCreateNewPartitions() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -104,6 +107,7 @@ func WipeAndCreateNewPartitions() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.1.0"
 	// Create dummy partitions. The UUIDs in the input partitions
 	// are intentionally different so if Ignition doesn't do the right thing the
 	// validation will fail.
@@ -147,10 +151,11 @@ func WipeAndCreateNewPartitions() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -160,7 +165,7 @@ func AppendPartitions() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -183,6 +188,7 @@ func AppendPartitions() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	in = append(in, types.Disk{
 		Alignment: types.IgnitionAlignment,
@@ -238,10 +244,11 @@ func AppendPartitions() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -252,7 +259,7 @@ func ResizeRoot() types.Test {
 	out[0].Partitions[9-2-1].Length = 12943360 + 65536
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -269,11 +276,13 @@ func ResizeRoot() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/partitions/deletion.go
+++ b/tests/positive/partitions/deletion.go
@@ -40,7 +40,7 @@ func DeleteOne() types.Test {
 	out := append(types.GetBaseDisk(), types.Disk{Alignment: types.IgnitionAlignment})
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -57,11 +57,14 @@ func DeleteOne() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -71,7 +74,7 @@ func DeleteAll() types.Test {
 	out := append(types.GetBaseDisk(), types.Disk{Alignment: types.IgnitionAlignment})
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -118,10 +121,13 @@ func DeleteAll() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/partitions/mixed.go
+++ b/tests/positive/partitions/mixed.go
@@ -76,7 +76,7 @@ func Match1Recreate1Delete1Create1() types.Test {
 	})
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -112,11 +112,14 @@ func Match1Recreate1Delete1Create1() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -171,7 +174,7 @@ func NothingMatches() types.Test {
 	})
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -206,10 +209,13 @@ func NothingMatches() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/partitions/no-op.go
+++ b/tests/positive/partitions/no-op.go
@@ -31,7 +31,7 @@ func DoNothing() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.0.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -41,11 +41,14 @@ func DoNothing() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.0.0"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -55,7 +58,7 @@ func SpecifiedNonexistent() types.Test {
 	out := append(types.GetBaseDisk(), types.Disk{Alignment: types.IgnitionAlignment})
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [
@@ -96,10 +99,13 @@ func SpecifiedNonexistent() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
+
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/partitions/verification.go
+++ b/tests/positive/partitions/verification.go
@@ -31,7 +31,7 @@ func VerifyBaseDisk() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -92,12 +92,14 @@ func VerifyBaseDisk() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -109,7 +111,7 @@ func VerifyBaseDiskWithWipe() types.Test {
 	// one and fail the test.
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -176,11 +178,13 @@ func VerifyBaseDiskWithWipe() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/partitions/zeros.go
+++ b/tests/positive/partitions/zeros.go
@@ -35,7 +35,7 @@ func PartitionSizeStart0() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -52,6 +52,7 @@ func PartitionSizeStart0() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	in = append(in, types.Disk{
 		Alignment: types.IgnitionAlignment,
@@ -70,10 +71,11 @@ func PartitionSizeStart0() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -83,7 +85,7 @@ func PartitionStartNumber0() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -110,6 +112,7 @@ func PartitionStartNumber0() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.1.0"
 
 	in = append(in, types.Disk{
 		Alignment: types.IgnitionAlignment,
@@ -142,10 +145,11 @@ func PartitionStartNumber0() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -156,7 +160,7 @@ func ResizeRootFillDisk() types.Test {
 	out[0].Partitions[9-2-1].Length = 12943360 + 65536
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -173,12 +177,14 @@ func ResizeRootFillDisk() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -188,7 +194,7 @@ func VerifyRootFillsDisk() types.Test {
 	out := in
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -204,12 +210,14 @@ func VerifyRootFillsDisk() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -223,7 +231,7 @@ func VerifyUnspecifiedIsDoNotCare() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -237,12 +245,14 @@ func VerifyUnspecifiedIsDoNotCare() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -279,7 +289,7 @@ func NumberZeroHappensLast() types.Test {
 	})
 	config := `{
 		"ignition": {
-			"version": "2.3.0-experimental"
+			"version": "$version"
 		},
 		"storage": {
 			"disks": [{
@@ -297,11 +307,13 @@ func NumberZeroHappensLast() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.3.0-experimental"
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/passwd/users.go
+++ b/tests/positive/passwd/users.go
@@ -29,7 +29,7 @@ func AddPasswdUsers() types.Test {
 	out := types.GetBaseDisk()
 	config := `{
 		"ignition": {
-			"version": "2.0.0"
+			"version": "$version"
 		},
 		"passwd": {
 			"users": [{
@@ -49,6 +49,7 @@ func AddPasswdUsers() types.Test {
 			]
 		}
 	}`
+	configMinVersion := "2.0.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -151,9 +152,10 @@ ENCRYPT_METHOD SHA512
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/regression/filesystem.go
+++ b/tests/positive/regression/filesystem.go
@@ -36,7 +36,7 @@ func EquivalentFilesystemUUIDsTreatedDistinctEXT4() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 		    "filesystems": [
 		      {
@@ -49,17 +49,19 @@ func EquivalentFilesystemUUIDsTreatedDistinctEXT4() types.Test {
 		    ]
 		  }
 		}`
+	configMinVersion := "2.1.0"
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "$uuid0"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "$uuid0"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -75,7 +77,7 @@ func EquivalentFilesystemUUIDsTreatedDistinctVFAT() types.Test {
 		},
 	}
 	config := `{
-		"ignition": {"version": "2.1.0"},
+		"ignition": {"version": "$version"},
 		"storage": {
 		    "filesystems": [
 		      {
@@ -88,15 +90,17 @@ func EquivalentFilesystemUUIDsTreatedDistinctVFAT() types.Test {
 		    ]
 		  }
 		}`
+	configMinVersion := "2.1.0"
 	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "2e24ec82"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemUUID = "2e24ec82"
 	out[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "vfat"
 
 	return types.Test{
-		Name:       name,
-		In:         in,
-		Out:        out,
-		MntDevices: mntDevices,
-		Config:     config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/security/tls.go
+++ b/tests/positive/security/tls.go
@@ -90,12 +90,12 @@ AKbyaAqbChEy9CvDgyv6qxTYU+eeBImLKS3PH2uW5etc/69V/sDojqpH3hEffsOt
 )
 
 func AppendConfigCustomCert() types.Test {
-	name := "Append config with custom tls cert"
+	name := "Append config with custom tls cert_positive"
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.2.0",
+			"version": "$version",
 			"config": {
 			  "append": [{
 				"source": %q
@@ -110,6 +110,7 @@ func AppendConfigCustomCert() types.Test {
 			}
 		}
 	}`, customCAServer.URL, dataurl.EncodeBytes(publicKey))
+	configMinVersion := "2.2.0"
 
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
@@ -122,10 +123,11 @@ func AppendConfigCustomCert() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -135,7 +137,7 @@ func FetchFileCustomCert() types.Test {
 	out := types.GetBaseDisk()
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.2.0",
+			"version": "$version",
 			"security": {
 				"tls": {
 					"certificateAuthorities": [{
@@ -154,6 +156,7 @@ func FetchFileCustomCert() types.Test {
 			}]
 		}
 	}`, dataurl.EncodeBytes(publicKey), customCAServer.URL)
+	configMinVersion := "2.2.0"
 
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
@@ -166,9 +169,10 @@ func FetchFileCustomCert() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/systemd/create_unit.go
+++ b/tests/positive/systemd/create_unit.go
@@ -28,7 +28,7 @@ func CreateSystemdService() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-		"ignition": { "version": "2.0.0" },
+		"ignition": { "version": "$version" },
 		"systemd": {
 			"units": [{
 				"name": "example.service",
@@ -37,6 +37,7 @@ func CreateSystemdService() types.Test {
 			}]
 		}
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -55,9 +56,10 @@ func CreateSystemdService() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/systemd/modify_service.go
+++ b/tests/positive/systemd/modify_service.go
@@ -29,7 +29,7 @@ func ModifySystemdService() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "systemd": {
 	    "units": [{
 	      "name": "systemd-networkd.service",
@@ -40,6 +40,7 @@ func ModifySystemdService() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -51,10 +52,11 @@ func ModifySystemdService() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -63,7 +65,7 @@ func MaskSystemdServices() types.Test {
 	in := types.GetBaseDisk()
 	out := types.GetBaseDisk()
 	config := `{
-	  "ignition": { "version": "2.0.0" },
+	  "ignition": { "version": "$version" },
 	  "systemd": {
 	    "units": [{
 	      "name": "systemd-networkd.service",
@@ -71,6 +73,7 @@ func MaskSystemdServices() types.Test {
 	    }]
 	  }
 	}`
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddLinks("ROOT", []types.Link{
 		{
 			Node: types.Node{
@@ -83,9 +86,10 @@ func MaskSystemdServices() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }

--- a/tests/positive/timeouts/timeouts.go
+++ b/tests/positive/timeouts/timeouts.go
@@ -55,7 +55,7 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 	out := types.GetBaseDisk()
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.1.0",
+			"version": "$version",
 			"timeouts": {
 				"httpResponseHeaders": 12
 			}
@@ -72,6 +72,7 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 			]
 		}
 	}`, respondDelayServer.URL)
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -83,10 +84,11 @@ func IncreaseHTTPResponseHeadersTimeout() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }
 
@@ -96,7 +98,7 @@ func ConfirmHTTPBackoffWorks() types.Test {
 	out := types.GetBaseDisk()
 	config := fmt.Sprintf(`{
 		"ignition": {
-			"version": "2.1.0"
+			"version": "$version"
 		},
 		"storage": {
 		    "files": [
@@ -110,6 +112,7 @@ func ConfirmHTTPBackoffWorks() types.Test {
 			]
 		}
 	}`, respondThrottledServer.URL)
+	configMinVersion := "2.1.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -121,9 +124,10 @@ func ConfirmHTTPBackoffWorks() types.Test {
 	})
 
 	return types.Test{
-		Name:   name,
-		In:     in,
-		Out:    out,
-		Config: config,
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
 	}
 }


### PR DESCRIPTION
The purpose of this PR is have blackbox tests to run all compatible versions. For example, a BB test with a 2.0.0 config should be registered and ran 4 different times; As a 2.0.0 config, a 2.1.0 config, a 2.2.0 config, and a 2.3.0-experimental config.

The jira card is: https://projects.engineering.redhat.com/browse/COREOS-76 && https://projects.engineering.redhat.com/browse/COREOS-362