### PR TITLE
internal: adjust http default timeouts

### DIFF
--- a/internal/resource/http.go
+++ b/internal/resource/http.go
@@ -39,8 +39,8 @@ const (
 	initialBackoff = 100 * time.Millisecond
 	maxBackoff     = 5 * time.Second
 
-	defaultHttpResponseHeaderTimeout = 10
-	defaultHttpTotalTimeout          = 0
+	defaultHttpResponseHeaderTimeout = 5
+	defaultHttpTotalTimeout          = 10
 )
 
 var (


### PR DESCRIPTION
This PR adjust the default timeouts so that an hung HTTP GET on the metadata server will retry.

Fixes #597