### PR TITLE
doc: Mention spec v2.2 as the latest stable version

### DIFF
--- a/doc/configuration-v2_0.md
+++ b/doc/configuration-v2_0.md
@@ -1,6 +1,6 @@
 # Configuration Specification v2.0.0 #
 
-*NOTE*: The [configuration specification 2.1.0][v2_1] is currently the latest stable version of the spec, and it's advised to use that over version 2.0.0.
+*NOTE*: The [configuration specification 2.2.0][v2_2] is currently the latest stable version of the spec, and it's advised to use that over version 2.0.0.
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
@@ -87,6 +87,6 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_passwordHash_** (string): the encrypted password of the new group.
     * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
 
-[v2_1]: configuration-v2_1.md
+[v2_2]: configuration-v2_2.md
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/doc/configuration-v2_1.md
+++ b/doc/configuration-v2_1.md
@@ -1,5 +1,7 @@
 # Configuration Specification v2.1.0 #
 
+*NOTE*: The [configuration specification 2.2.0][v2_2] is currently the latest stable version of the spec, and it's advised to use that over version 2.1.0.
+
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **ignition** (object): metadata about the configuration itself.
@@ -127,5 +129,6 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_passwordHash_** (string): the encrypted password of the new group.
     * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
 
+[v2_2]: configuration-v2_2.md
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397


### PR DESCRIPTION
The previous note in the v2.0 spec pointed at v2.1.  That made sense when it landed in 94d4a60f (#400).  But since 4e88b931 (#510) cut v2.2, we should be pointing at v2.2 instead.