### PR TITLE
stages/files: use stable sort for directories

### DIFF
--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -200,7 +200,7 @@ func (s stage) mapEntriesToFilesystems(config types.Config) (map[types.Filesyste
 
 	// Sort directories to ensure /a gets created before /a/b.
 	sortedDirs := config.Storage.Directories
-	sort.Sort(ByDirectorySegments(sortedDirs))
+	sort.Stable(ByDirectorySegments(sortedDirs))
 
 	// Add directories first to ensure they are created before files.
 	for _, d := range sortedDirs {


### PR DESCRIPTION
Use a stable sort so directories from appended configs are always
created after directories from the appendee.