### PR TITLE
tests/bb: update configMinVersion to reflect lowest compatible config version

### DIFF
--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -41,7 +41,7 @@ func MissingRemoteContentsHTTP() types.Test {
 	    }]
 	  }
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,
@@ -95,7 +95,7 @@ func MissingRemoteContentsOEM() types.Test {
 	    }]
 	  }
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/negative/files/preexisting_nodes.go
+++ b/tests/negative/files/preexisting_nodes.go
@@ -77,7 +77,7 @@ func ForceDirCreation() types.Test {
 	    }]
 	  }
 	}`
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.1.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -118,7 +118,7 @@ func ForceLinkCreation() types.Test {
 	    }]
 	  }
 	}`
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.1.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -160,7 +160,7 @@ func ForceHardLinkCreation() types.Test {
 	    }]
 	  }
 	}`
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.1.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -238,7 +238,7 @@ func ForceLinkCreationOverNonemptyDir() types.Test {
 	    }]
 	  }
 	}`
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.1.0"
 	in[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/negative/filesystems/no_device.go
+++ b/tests/negative/filesystems/no_device.go
@@ -41,7 +41,7 @@ func NoDevice() types.Test {
 			}]
 		}
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:              name,

--- a/tests/negative/filesystems/no_filesystem_type.go
+++ b/tests/negative/filesystems/no_filesystem_type.go
@@ -46,7 +46,7 @@ func NoFilesystemType() types.Test {
 			}]
 		}
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:              name,

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -120,7 +120,7 @@ func ReplaceConfigWithMissingFileHTTP() types.Test {
 	    }
 	  }
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,
@@ -170,7 +170,7 @@ func ReplaceConfigWithMissingFileOEM() types.Test {
 	    }
 	  }
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,
@@ -195,7 +195,7 @@ func AppendConfigWithMissingFileHTTP() types.Test {
 	    }
 	  }
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,
@@ -245,7 +245,7 @@ func AppendConfigWithMissingFileOEM() types.Test {
 	    }
 	  }
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/negative/partitions/simple.go
+++ b/tests/negative/partitions/simple.go
@@ -78,7 +78,7 @@ func DoesNotMatchNoWipeEntry() types.Test {
 			]
 		}
 	}`
-	configMinVersion := "2.3.0-experimental"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,
@@ -112,7 +112,7 @@ func ValidAndDoesNotMatchNoWipeEntry() types.Test {
 			]
 		}
 	}`
-	configMinVersion := "2.3.0-experimental"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/negative/partitions/zeroes.go
+++ b/tests/negative/partitions/zeroes.go
@@ -49,7 +49,7 @@ func Partition9DoesNotFillDisk() types.Test {
 			]
 		}
 	}`
-	configMinVersion := "2.3.0-experimental"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,
@@ -87,7 +87,7 @@ func Partition9DoesNotStartCorrectly() types.Test {
 			]
 		}
 	}`
-	configMinVersion := "2.3.0-experimental"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/negative/security/tls.go
+++ b/tests/negative/security/tls.go
@@ -75,7 +75,7 @@ AKbyaAqbChEy9CvDgyv6qxTYU+eeBImLKS3PH2uW5etc/69V/sDojqpH3hEffsOt
 -----END CERTIFICATE-----`)
 
 	customCAServerFile = []byte(`{
-			"ignition": { "version": "2.1.0" },
+			"ignition": { "version": "2.0.0" },
 			"storage": {
 				"files": [{
 					"filesystem": "root",
@@ -107,7 +107,7 @@ func AppendConfigCustomCert() types.Test {
 			}
 		}
 	}`, customCAServer.URL)
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:             name,
@@ -139,7 +139,7 @@ func FetchFileCustomCert() types.Test {
 			}]
 		}
 	}`, customCAServer.URL)
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.1.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -220,7 +220,7 @@ func ForceFileCreationNoOverwrite() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
-	configMinVersion := "2.2.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -130,7 +130,7 @@ func CreateFileFromRemoteContentsOEM() types.Test {
 			Contents: "asdf\nfdsa",
 		},
 	})
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -169,7 +169,7 @@ func ReplaceConfigWithRemoteConfigOEM() types.Test {
             }
           }
         }`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	in[0].Partitions.AddFiles("OEM", []types.File{
 		{
 			Node: types.Node{
@@ -326,7 +326,7 @@ func AppendConfigWithRemoteConfigOEM() types.Test {
         }]
       }
         }`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	in[0].Partitions.AddFiles("OEM", []types.File{
 		{
 			Node: types.Node{
@@ -384,7 +384,7 @@ func ReplaceConfigWithRemoteConfigData() types.Test {
             }
           }
         }`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{
@@ -418,7 +418,7 @@ func AppendConfigWithRemoteConfigData() types.Test {
             }
           }
         }`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/networkd/create_unit.go
+++ b/tests/positive/networkd/create_unit.go
@@ -36,7 +36,7 @@ func CreateNetworkdUnit() types.Test {
 			}]
 		}
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/oem/oem.go
+++ b/tests/positive/oem/oem.go
@@ -43,7 +43,7 @@ func OEMSearchPath() types.Test {
 				}
 			]}
 	}`
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	lookasideFiles := []types.File{
 		{
 			Node: types.Node{

--- a/tests/positive/partitions/zeros.go
+++ b/tests/positive/partitions/zeros.go
@@ -210,7 +210,7 @@ func VerifyRootFillsDisk() types.Test {
 			}]
 		}
 	}`
-	configMinVersion := "2.3.0-experimental"
+	configMinVersion := "2.0.0"
 
 	return types.Test{
 		Name:             name,

--- a/tests/positive/security/tls.go
+++ b/tests/positive/security/tls.go
@@ -74,7 +74,7 @@ AKbyaAqbChEy9CvDgyv6qxTYU+eeBImLKS3PH2uW5etc/69V/sDojqpH3hEffsOt
 -----END CERTIFICATE-----`)
 
 	customCAServerFile = []byte(`{
-			"ignition": { "version": "2.1.0" },
+			"ignition": { "version": "2.0.0" },
 			"storage": {
 				"files": [{
 					"filesystem": "root",

--- a/tests/positive/timeouts/timeouts.go
+++ b/tests/positive/timeouts/timeouts.go
@@ -112,7 +112,7 @@ func ConfirmHTTPBackoffWorks() types.Test {
 			]
 		}
 	}`, respondThrottledServer.URL)
-	configMinVersion := "2.1.0"
+	configMinVersion := "2.0.0"
 	out[0].Partitions.AddFiles("ROOT", []types.File{
 		{
 			Node: types.Node{


### PR DESCRIPTION
Updates the configMinVersion to reflect the lowest compatible config version.

** Opened this PR so I can run the BB test on jenkins since my system has mounting/unmounting issues