### PR TITLE
stages/files: also relabel /root home dir

### DIFF
--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -40,6 +40,7 @@ func (s *stage) createPasswd(config types.Config) error {
 			"/etc/gshadow*",
 			"/etc/.pwd.lock",
 			"/home",
+			"/root",
 		)
 	}
 


### PR DESCRIPTION
For the same reasons that `/home` is in that list. The difference is
that the "root" user will always exist, but we might be touching and
creating files there. For example, we might be adding an
`.ssh/authorized_keys`, which will need to be relabeled.

---

Marking as WIP for now until I sanity check this solves all issues we've been seeing.