### PR TITLE
exec/util: handle 4k sectors correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,24 @@ addons:
 install:
   # since libblkid-dev:arm64 cannot be installed, spoof it
   -     if [ "${TARGET}" == "arm64" ]; then
-                echo "void blkid_new_probe_from_filename(void) {}"   >> stub.c;
-                echo "void blkid_do_probe(void) {}"                  >> stub.c;
-                echo "void blkid_probe_has_value(void) {}"           >> stub.c;
-                echo "void blkid_probe_lookup_value(void) {}"        >> stub.c;
-                echo "void blkid_free_probe(void) {}"                >> stub.c;
-                echo "void blkid_probe_get_partitions(void) {}"      >> stub.c;
-                echo "void blkid_partlist_get_table(void) {}"        >> stub.c;
-                echo "void blkid_partlist_get_partition(void) {}"    >> stub.c;
-                echo "void blkid_partlist_numof_partitions(void) {}" >> stub.c;
-                echo "void blkid_partition_get_name(void) {}"        >> stub.c;
-                echo "void blkid_partition_get_uuid(void) {}"        >> stub.c;
-                echo "void blkid_partition_get_type_string(void) {}" >> stub.c;
-                echo "void blkid_partition_get_start(void) {}"       >> stub.c;
-                echo "void blkid_partition_get_size(void) {}"        >> stub.c;
-                echo "void blkid_partition_get_partno(void) {}"      >> stub.c;
-                echo "void blkid_parttable_get_type(void) {}"        >> stub.c;
+                echo "void blkid_new_probe_from_filename(void) {}"          >> stub.c;
+                echo "void blkid_do_probe(void) {}"                         >> stub.c;
+                echo "void blkid_probe_has_value(void) {}"                  >> stub.c;
+                echo "void blkid_probe_lookup_value(void) {}"               >> stub.c;
+                echo "void blkid_free_probe(void) {}"                       >> stub.c;
+                echo "void blkid_probe_get_partitions(void) {}"             >> stub.c;
+                echo "void blkid_partlist_get_table(void) {}"               >> stub.c;
+                echo "void blkid_partlist_get_partition(void) {}"           >> stub.c;
+                echo "void blkid_partlist_numof_partitions(void) {}"        >> stub.c;
+                echo "void blkid_partition_get_name(void) {}"               >> stub.c;
+                echo "void blkid_partition_get_uuid(void) {}"               >> stub.c;
+                echo "void blkid_partition_get_type_string(void) {}"        >> stub.c;
+                echo "void blkid_partition_get_start(void) {}"              >> stub.c;
+                echo "void blkid_partition_get_size(void) {}"               >> stub.c;
+                echo "void blkid_partition_get_partno(void) {}"             >> stub.c;
+                echo "void blkid_parttable_get_type(void) {}"               >> stub.c;
+                echo "void blkid_probe_get_topology (void) {}"              >> stub.c;
+                echo "void blkid_topology_get_logical_sector_size(void) {}" >> stub.c;
                 aarch64-linux-gnu-gcc-4.8 -c -o stub.o stub.c;
                 aarch64-linux-gnu-gcc-ar-4.8 cq libblkid.a stub.o;
         fi

--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -75,6 +75,12 @@ func cResultToErr(res C.result_t, device string) error {
 		return fmt.Errorf("internal error. bad params passed while handling %q", device)
 	case C.RESULT_OVERFLOW:
 		return fmt.Errorf("internal error. libblkid returned impossibly large value when handling %q", device)
+	case C.RESULT_NO_TOPO:
+		return fmt.Errorf("failed to get topology information for %q", device)
+	case C.RESULT_NO_SECTOR_SIZE:
+		return fmt.Errorf("failed to get logical sector size for %q", device)
+	case C.RESULT_BAD_SECTOR_SIZE:
+		return fmt.Errorf("logical sector size for %q was not a multiple of 512", device)
 	default:
 		return fmt.Errorf("Unknown error while handling %q. err code: %d", device, res)
 	}

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -29,6 +29,9 @@ typedef enum {
 	RESULT_DISK_NOT_GPT,
 	RESULT_BAD_PARAMS,
 	RESULT_OVERFLOW,
+	RESULT_NO_TOPO,
+	RESULT_NO_SECTOR_SIZE,
+	RESULT_BAD_SECTOR_SIZE,
 } result_t;
 
 // really this shouldn't need to be larger than 145, but extra doesn't hurt


### PR DESCRIPTION
libblkid always assumes sectors are 512 bytes, regardless of actual
size. Add detection for otherly sized sectors (e.g. 4k) and translate
the 512 byte values to logical-sector-sized values.