### PR TITLE
Cleanup tests and make them killable

### DIFF
--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -26,12 +26,10 @@ fi
 
 . build
 
-PKG=$(cd gopath/src/${REPO_PATH}; go list ./tests/...)
+PKG=$(cd gopath/src/${REPO_PATH}; go list ./tests/)
 
 echo "Compiling tests..."
-for p in ${PKG}; do
-	go test -c $p
-done
+go test -c $PKG
 
 for D in tests/stubs/*; do
 	if [ -d "${D}" ]; then

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -29,7 +29,7 @@ import (
 	"github.com/coreos/ignition/tests/types"
 )
 
-func run(t *testing.T, ctx context.Context, command string, args ...string) ([]byte, error) {
+func run(ctx context.Context, command string, args ...string) ([]byte, error) {
 	out, err := exec.CommandContext(ctx, command, args...).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed: %q: %v\n%s", command, err, out)
@@ -39,7 +39,7 @@ func run(t *testing.T, ctx context.Context, command string, args ...string) ([]b
 
 // Runs the command even if the context has exired. Should be used for cleanup
 // operations
-func runWithoutContext(t *testing.T, command string, args ...string) ([]byte, error) {
+func runWithoutContext(command string, args ...string) ([]byte, error) {
 	out, err := exec.Command(command, args...).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed: %q: %v\n%s", command, err, out)
@@ -47,7 +47,7 @@ func runWithoutContext(t *testing.T, command string, args ...string) ([]byte, er
 	return out, nil
 }
 
-func prepareRootPartitionForPasswd(t *testing.T, ctx context.Context, partitions []*types.Partition) error {
+func prepareRootPartitionForPasswd(ctx context.Context, partitions []*types.Partition) error {
 	mountPath := getRootLocation(partitions)
 	if mountPath == "" {
 		// Guess there's no root partition
@@ -78,12 +78,12 @@ func prepareRootPartitionForPasswd(t *testing.T, ctx context.Context, partitions
 	}
 
 	// TODO: use the architecture, not hardcode amd64
-	_, err := run(t, ctx, "cp", "bin/amd64/id-stub", filepath.Join(mountPath, distro.IdCmd()))
+	_, err := run(ctx, "cp", "bin/amd64/id-stub", filepath.Join(mountPath, distro.IdCmd()))
 	if err != nil {
 		return err
 	}
 	// TODO: needed for user_group_lookup.c
-	_, err = run(t, ctx, "cp", "/lib64/libnss_files.so.2", filepath.Join(mountPath, "usr", "lib64"))
+	_, err = run(ctx, "cp", "/lib64/libnss_files.so.2", filepath.Join(mountPath, "usr", "lib64"))
 	return err
 }
 
@@ -118,7 +118,7 @@ func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, app
 
 // pickPartition will return the partition device corresponding to a
 // partition with a given label on the given loop device
-func pickPartition(t *testing.T, device string, partitions []*types.Partition, label string) string {
+func pickPartition(device string, partitions []*types.Partition, label string) string {
 	for _, p := range partitions {
 		if p.Label == label {
 			return fmt.Sprintf("%sp%d", device, p.Number)
@@ -129,7 +129,7 @@ func pickPartition(t *testing.T, device string, partitions []*types.Partition, l
 
 // setupDisk creates a backing file then loop mounts it. It sets up the partitions and filesystems on that loop device.
 // It returns any error it encounters, but cleans up after itself if it errors out.
-func setupDisk(t *testing.T, ctx context.Context, disk *types.Disk, diskIndex int, imageSize int64, tmpDirectory string) (err error) {
+func setupDisk(ctx context.Context, disk *types.Disk, diskIndex int, imageSize int64, tmpDirectory string) (err error) {
 	// attempt to create the file, will leave already existing files alone.
 	// os.Truncate requires the file to already exist
 	var (
@@ -153,7 +153,7 @@ func setupDisk(t *testing.T, ctx context.Context, disk *types.Disk, diskIndex in
 	}
 
 	// Attach the file to a loopback device
-	tmp, err = run(t, ctx, "losetup", "-Pf", "--show", disk.ImageFile)
+	tmp, err = run(ctx, "losetup", "-Pf", "--show", disk.ImageFile)
 	if err != nil {
 		return err
 	}
@@ -161,16 +161,16 @@ func setupDisk(t *testing.T, ctx context.Context, disk *types.Disk, diskIndex in
 	loopdev := disk.Device
 	defer func() {
 		if err != nil {
-			destroyDevice(t, loopdev)
+			destroyDevice(loopdev)
 		}
 	}()
 
 	// Avoid race with kernel by waiting for loopDevice creation to complete
-	if _, err = run(t, ctx, "udevadm", "settle"); err != nil {
+	if _, err = run(ctx, "udevadm", "settle"); err != nil {
 		return fmt.Errorf("Settling devices: %v", err)
 	}
 
-	if err = createPartitionTable(t, ctx, disk.Device, disk.Partitions); err != nil {
+	if err = createPartitionTable(ctx, disk.Device, disk.Partitions); err != nil {
 		return err
 	}
 
@@ -192,19 +192,19 @@ func setupDisk(t *testing.T, ctx context.Context, disk *types.Disk, diskIndex in
 		}()
 
 		partition.Device = fmt.Sprintf("%sp%d", disk.Device, partition.Number)
-		if err = formatPartition(t, ctx, partition); err != nil {
+		if err = formatPartition(ctx, partition); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func destroyDevice(t *testing.T, loopDevice string) error {
-	_, err := runWithoutContext(t, "losetup", "-d", loopDevice)
+func destroyDevice(loopDevice string) error {
+	_, err := runWithoutContext("losetup", "-d", loopDevice)
 	return err
 }
 
-func formatPartition(t *testing.T, ctx context.Context, partition *types.Partition) error {
+func formatPartition(ctx context.Context, partition *types.Partition) error {
 	var mkfs string
 	var opts, label, uuid []string
 
@@ -249,7 +249,7 @@ func formatPartition(t *testing.T, ctx context.Context, partition *types.Partiti
 	}
 	opts = append(opts, partition.Device)
 
-	_, err := run(t, ctx, mkfs, opts...)
+	_, err := run(ctx, mkfs, opts...)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func formatPartition(t *testing.T, ctx context.Context, partition *types.Partiti
 			"-U", "clear", "-T", "20091119110000", "-c", "0", "-i", "0",
 			"-m", "0", "-r", "0", "-e", "remount-ro", partition.Device,
 		}
-		_, err = run(t, ctx, "tune2fs", opts...)
+		_, err = run(ctx, "tune2fs", opts...)
 		if err != nil {
 			return err
 		}
@@ -268,7 +268,7 @@ func formatPartition(t *testing.T, ctx context.Context, partition *types.Partiti
 	return nil
 }
 
-func createPartitionTable(t *testing.T, ctx context.Context, imageFile string, partitions []*types.Partition) error {
+func createPartitionTable(ctx context.Context, imageFile string, partitions []*types.Partition) error {
 	opts := []string{imageFile}
 	hybrids := []int{}
 	for _, p := range partitions {
@@ -298,16 +298,16 @@ func createPartitionTable(t *testing.T, ctx context.Context, imageFile string, p
 			opts = append(opts, fmt.Sprintf("-h=%s", intJoin(hybrids, ":")))
 		}
 	}
-	_, err := run(t, ctx, "sgdisk", opts...)
+	_, err := run(ctx, "sgdisk", opts...)
 	return err
 }
 
-func mountRootPartition(t *testing.T, ctx context.Context, partitions []*types.Partition) (bool, error) {
+func mountRootPartition(ctx context.Context, partitions []*types.Partition) (bool, error) {
 	for _, partition := range partitions {
 		if partition.Label != "ROOT" {
 			continue
 		}
-		if _, err := run(t, ctx, "mount", partition.Device, partition.MountPath); err != nil {
+		if _, err := run(ctx, "mount", partition.Device, partition.MountPath); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -315,13 +315,13 @@ func mountRootPartition(t *testing.T, ctx context.Context, partitions []*types.P
 	return false, nil
 }
 
-func mountPartitions(t *testing.T, ctx context.Context, partitions []*types.Partition) error {
+func mountPartitions(ctx context.Context, partitions []*types.Partition) error {
 	for _, partition := range partitions {
 		if partition.FilesystemType == "" || partition.FilesystemType == "swap" || partition.Label == "ROOT" {
 			continue
 		}
 
-		if _, err := run(t, ctx, "mount", partition.Device, partition.MountPath); err != nil {
+		if _, err := run(ctx, "mount", partition.Device, partition.MountPath); err != nil {
 			return err
 		}
 	}
@@ -367,17 +367,17 @@ func removeEmpty(strings []string) []string {
 	return r
 }
 
-func createFilesForPartitions(t *testing.T, partitions []*types.Partition) error {
+func createFilesForPartitions(partitions []*types.Partition) error {
 	for _, partition := range partitions {
-		err := createDirectoriesFromSlice(t, partition.MountPath, partition.Directories)
+		err := createDirectoriesFromSlice(partition.MountPath, partition.Directories)
 		if err != nil {
 			return err
 		}
-		createFilesFromSlice(t, partition.MountPath, partition.Files)
+		createFilesFromSlice(partition.MountPath, partition.Files)
 		if err != nil {
 			return err
 		}
-		createLinksFromSlice(t, partition.MountPath, partition.Links)
+		createLinksFromSlice(partition.MountPath, partition.Links)
 		if err != nil {
 			return err
 		}
@@ -385,7 +385,7 @@ func createFilesForPartitions(t *testing.T, partitions []*types.Partition) error
 	return nil
 }
 
-func createFilesFromSlice(t *testing.T, basedir string, files []types.File) error {
+func createFilesFromSlice(basedir string, files []types.File) error {
 	for _, file := range files {
 		err := os.MkdirAll(filepath.Join(
 			basedir, file.Directory), 0755)
@@ -410,7 +410,7 @@ func createFilesFromSlice(t *testing.T, basedir string, files []types.File) erro
 	return nil
 }
 
-func createDirectoriesFromSlice(t *testing.T, basedir string, dirs []types.Directory) error {
+func createDirectoriesFromSlice(basedir string, dirs []types.Directory) error {
 	for _, dir := range dirs {
 		err := os.MkdirAll(filepath.Join(
 			basedir, dir.Directory), 0755)
@@ -426,7 +426,7 @@ func createDirectoriesFromSlice(t *testing.T, basedir string, dirs []types.Direc
 	return nil
 }
 
-func createLinksFromSlice(t *testing.T, basedir string, links []types.Link) error {
+func createLinksFromSlice(basedir string, links []types.Link) error {
 	for _, link := range links {
 		err := os.MkdirAll(filepath.Join(
 			basedir, link.Directory), 0755)
@@ -445,13 +445,13 @@ func createLinksFromSlice(t *testing.T, basedir string, links []types.Link) erro
 	return nil
 }
 
-func unmountRootPartition(t *testing.T, partitions []*types.Partition) error {
+func unmountRootPartition(partitions []*types.Partition) error {
 	for _, partition := range partitions {
 		if partition.Label != "ROOT" {
 			continue
 		}
 
-		_, err := runWithoutContext(t, "umount", partition.Device)
+		_, err := runWithoutContext("umount", partition.Device)
 		if err != nil {
 			return err
 		}
@@ -459,13 +459,13 @@ func unmountRootPartition(t *testing.T, partitions []*types.Partition) error {
 	return nil
 }
 
-func unmountPartitions(t *testing.T, partitions []*types.Partition) error {
+func unmountPartitions(partitions []*types.Partition) error {
 	for _, partition := range partitions {
 		if partition.FilesystemType == "" || partition.FilesystemType == "swap" || partition.Label == "ROOT" {
 			continue
 		}
 
-		_, err := runWithoutContext(t, "umount", partition.Device)
+		_, err := runWithoutContext("umount", partition.Device)
 		if err != nil {
 			return err
 		}

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -173,11 +173,11 @@ func validatePartitionNodes(t *testing.T, partition *types.Partition) {
 	device, mountPath := partition.Device, partition.MountPath
 	if partition.Label != "ROOT" {
 		// TODO unmount root before doing validation so this is not a special case
-		if _, err := runWithoutContext(t, "mount", device, mountPath); err != nil {
+		if _, err := runWithoutContext("mount", device, mountPath); err != nil {
 			t.Errorf("failed to mount %s: %v", device, err)
 		}
 		defer func() {
-			if _, err := runWithoutContext(t, "umount", mountPath); err != nil {
+			if _, err := runWithoutContext("umount", mountPath); err != nil {
 				// failing to unmount is not a validation failure
 				t.Logf("Failed to unmount %s: %v", mountPath, err)
 			}


### PR DESCRIPTION
This uses a global context as the root of all the individual test contexts that gets canceled on ^C. All Ignition processes and setup processes use this context. All cleanup code does not. This means cleanup code still runs when you ^C the tests.