### PR TITLE
build: clean before building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ language: go
 go_import_path: github.com/coreos/ignition
 
 go:
-  - 1.8
-  - 1.9
+  - "1.8.7"
+  - "1.10.4"
+  - "1.11"
 
 env:
   matrix:

--- a/build
+++ b/build
@@ -29,6 +29,9 @@ export GOPATH=${PWD}/gopath
 export CGO_ENABLED=1
 
 echo "Building ${NAME}..."
+# clean the cache since cgo isn't correctly handled by gocache. Test to see if this version
+# of go supports caching before trying to clear the cache
+go clean -help 2>&1 | grep -F '[-cache]' >/dev/null && go clean -cache -testcache internal
 go build -buildmode=pie -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${NAME} ${REPO_PATH}/internal
 
 NAME="ignition-validate"

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -145,7 +145,7 @@ func (u Util) CheckIfUserExists(c types.PasswdUser) (bool, error) {
 			u.Info("checking if user \"%s\" exists: %s", c.Name, fmt.Errorf("[Attention] %v: Cmd: %s Stdout: %s", err, log.QuotedCmd(cmd), stdout))
 			return false, nil
 		}
-		u.Logger.Info("error encountered (%+T): %v", err, err)
+		u.Logger.Info("error encountered (%T): %v", err, err)
 		return false, err
 	}
 	return true, nil

--- a/internal/main.go
+++ b/internal/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	err = engine.Run(flags.stage.String())
 	if statusErr := engine.OEMConfig.Status(flags.stage.String(), *engine.Fetcher, err); statusErr != nil {
-		logger.Err("POST Status error: ", statusErr.Error())
+		logger.Err("POST Status error: %v", statusErr.Error())
 	}
 	if err != nil {
 		logger.Crit("Ignition failed: %v", err.Error())

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -289,7 +289,7 @@ func (f *Fetcher) FetchFromOEM(u url.URL, dest *os.File, opts FetchOptions) erro
 
 	oemMountPath, err := ioutil.TempDir("/mnt", "oem")
 	if err != nil {
-		f.Logger.Err("failed to create mount path for oem partition: %v")
+		f.Logger.Err("failed to create mount path for oem partition: %v", err)
 		return ErrFailed
 	}
 	// try oemMountPath, requires mounting it.


### PR DESCRIPTION
Go's caching (on by default with 1.11, enforced in 1.12) does not handle
cgo at all. Update build to always clean so it will always pick up
changes to cgo code.