### PR TITLE
tests: workaround umount issues

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -51,7 +51,7 @@ Build both the Ignition & test binaries inside of a docker container, for this e
 
 ```sh
 docker run --rm -e TARGET=amd64 -v "$PWD":/usr/src/myapp -w /usr/src/myapp quay.io/coreos/ignition-builder-1.8 ./build_blackbox_tests
-sudo -E PATH=$PWD/bin/amd64:$PATH ./tests.test -test.parallel 4
+sudo -E PATH=$PWD/bin/amd64:$PATH ./tests.test
 ```
 
 ## Runnning Blackbox Tests on platforms other than Container Linux
@@ -60,12 +60,8 @@ Build Ignition and the test binaries with HELPERS=HOST to use the paths of the b
 
 ```sh
 HELPERS=HOST ./build_blackbox_tests
-sudo sh -c 'PATH=$PWD/bin/amd64:$PATH ./tests.test -test.parallel 4'
+sudo sh -c 'PATH=$PWD/bin/amd64:$PATH ./tests.test'
 ```
-
-## Running Blackbox Tests in Parallel
-
-`test.parallel 4` is suggested due to the go test runner defaulting the parallelism level to the amount of cores on the host machine. The Ignition blackbox tests are still currently racey with higher parallelism and test validity / resource cleanup is not guaranteed on higher levels of parallelism.
 
 ## Test Host System Dependencies
 

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -40,7 +40,7 @@ import (
 var (
 	// testTimeout controls how long a given test is allowed to run before being
 	// cancelled.
-	testTimeout = time.Second * 30
+	testTimeout = time.Second * 60
 	// somewhat of an abuse of contexts but go's got our hands tied
 	killContext = context.TODO()
 )


### PR DESCRIPTION
umount sometimes returns exit status 32 even when successful. Detect and
work around this case.

Increase the timeout to 60 seconds since running in parallel can cause
the tests to slow down and time out.