### PR TITLE
glide: switch to tags where we can

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,5 @@ all:
 
 .PHONY: vendor
 vendor:
-	@glide update --strip-vendor
-	# TODO: Need --keep because update-ssh-keys uses symlinks within its package
-	@glide-vc --use-lock-file --no-tests --only-code --keep '**/authorized_keys_d*'
+	@glide --quiet update --strip-vendor
+	@glide-vc --use-lock-file --no-tests --only-code

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7ac5073f3dddddf1f82ba6039fa082cd177b3c58bbdd13ac909b1e75c21e2609
-updated: 2018-09-05T15:27:05.905996183-07:00
+hash: 45ef0dd196a7294a2c1926416e22a2d031531d12302e680dc55999706ded86a7
+updated: 2018-09-17T14:38:31.888054059-07:00
 imports:
 - name: github.com/ajeddeloh/go-json
   version: 73d058cf8437a1989030afe571eeab9f90eebbbd
@@ -43,7 +43,7 @@ imports:
   - dbus
   - unit
 - name: github.com/go-ini/ini
-  version: c787282c39ac1fc618827141a1f762240def08a3
+  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
 - name: github.com/godbus/dbus
   version: a389bdde4dd695d414e47b755e95e72b7826432c
 - name: github.com/inconshreveable/mousetrap

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,11 +3,11 @@ import:
 - package: github.com/ajeddeloh/go-json
   version: 73d058cf8437a1989030afe571eeab9f90eebbbd
 - package: github.com/coreos/go-semver
-  version: 294930c1e79c64e7dbe360054274fdad492c8cf5
+  version: 0.1.0
 - package: github.com/coreos/go-systemd
   version: v17
 - package: github.com/pin/tftp
-  version: 9ea92f6b1029bc1bf3072bba195c84bb9b0370e3
+  version: 2.1.0
 - package: github.com/vmware/vmw-ovflib
   version: 1f217b9dc714d5f340d0a3cc3e9d49255c536f68
 - package: github.com/sigma/vmw-guestinfo
@@ -23,9 +23,7 @@ import:
 - package: github.com/spf13/pflag
   version: 1.0.0
 - package: github.com/godbus/dbus
-  version: a389bdde4dd695d414e47b755e95e72b7826432c
-- package: github.com/go-ini/ini
-  version: c787282c39ac1fc618827141a1f762240def08a3
+  version: 4.1.0
 # see https://github.com/Masterminds/glide/issues/564 on why this is not
 # in testImport
 - package: github.com/pborman/uuid


### PR DESCRIPTION
Switch from using raw commit hashes to tags. This makes it much more
human readable. Also drop a transient dep that did not need to be in the
glide.yaml file. This does not update any of the dependencies.