### PR TITLE
stages/disks: fix extraneous udevadm settle

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -68,10 +68,12 @@ func (stage) Name() string {
 func (s stage) Run(config types.Config) error {
 	// Interacting with disks/partitions/raids/filesystems in general can cause
 	// udev races. If we do not need to  do anything, we also do not need to
-	// do the udevadm settle and can just return here.
+	// do the udevadm settle and can just return here. There is always an implicit
+	// root filesystem defined in the base config, so the lowest number of
+	// filesystems is 1.
 	if len(config.Storage.Disks) == 0 &&
 		len(config.Storage.Raid) == 0 &&
-		len(config.Storage.Filesystems) == 0 {
+		len(config.Storage.Filesystems) == 1 {
 		return nil
 	}
 


### PR DESCRIPTION
There is no need to settle when there was nothing in the disks stage.
The old check did not take into account that the disks stage has an
implicit filesystem in the base config so there is at minimum 1
filesystem.