### PR TITLE
stages/files: relabel files before systemd-sysctl

### DIFF
--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -138,7 +138,7 @@ func (s *stage) addRelabelUnit(config types.Config) error {
 Description=Relabel files created by Ignition
 DefaultDependencies=no
 After=local-fs.target
-Before=sysinit.target
+Before=sysinit.target systemd-sysctl.service
 ConditionSecurity=selinux
 ConditionPathExists=/etc/selinux/ignition.relabel
 OnFailure=emergency.target


### PR DESCRIPTION
This is a workaround for an inherent issue with the current relabeling
approach (see #635). `systemd-sysctl.service` is definitely one of those
early services that have a high probability of reading files from `/etc`
before it's relabeled.

They're both pulled in by `sysinit.target`, but
`ignition-relabel.service` has an additional `After=local-fs.target`
which makes it likelier to run later (also see #635 about that). So for
now, let's just hack around this by making sure `systemd-sysctl` runs
after us.