### PR TITLE
release-checklist: move to .github and drop front matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -1,8 +1,3 @@
----
-name: Release checklist
-about: Checklist for releasing a new version of Ignition
----
-
 Release checklist:
  - [ ] Write release notes in NEWS. Get them reviewed and merged
      - [ ] If doing a branched release, also include a PR to merge the NEWS changes into master


### PR DESCRIPTION
Avoid the extra top-level directory by moving the release checklist into `.github/ISSUE_TEMPLATE/`.  Drop YAML front matter so the checklist won't show up in the issue template chooser.