### PR TITLE
internal/providers/packet: don't send success to packet from Ignition

### DIFF
--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -112,7 +112,7 @@ func postMessage(stageName string, e error, url string) error {
 		}
 	} else {
 		m = mStruct{
-			State:   "succeeded",
+			State:   "running",
 			Message: stageName + " Ignition status: finished successfully",
 		}
 	}


### PR DESCRIPTION
Right now we're reporting successful provisioning in Ignition after each
stage. This can cause issues where the disks stage might pass sending a
successful configuration followed by the files stage failing. Instead
send a running status and allow the [phone-home service](https://github.com/coreos/coreos-overlay/blob/master/coreos-base/oem-packet/files/units/packet-phone-home.service) to report
success.

Closes #651 