### PR TITLE
master: Rename `coreos.config.*` options to `ignition.config.*`

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -2,11 +2,11 @@
 
 Ignition is currently only supported for the following platforms:
 
-* [Bare Metal] - Use the `coreos.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
-* [PXE] - Use the `coreos.config.url` and `coreos.first_boot=1` (**in case of the very first PXE boot only**) kernel parameters to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
+* [Bare Metal] - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
+* [PXE] - Use the `ignition.config.url` and first boot kernel parameters to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config or the `oem://` scheme to specify a local config, rooted in `/usr/share/oem`.
 * [Amazon EC2] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
-* [VMware] - Use the VMware Guestinfo variables `coreos.config.data` and `coreos.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
+* [VMware] - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [QEMU] - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device.

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // The cmdline provider fetches a remote configuration from the URL specified
-// in the kernel boot option "coreos.config.url".
+// in the kernel boot option "ignition.config.url".
 
 package cmdline
 
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	cmdlineUrlFlag = "coreos.config.url"
+	cmdlineUrlFlag = "ignition.config.url"
 )
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {

--- a/internal/providers/vmware/vmware_amd64.go
+++ b/internal/providers/vmware/vmware_amd64.go
@@ -65,17 +65,17 @@ func fetchRawConfig(f resource.Fetcher) (config, error) {
 			f.Logger.Warning("failed to parse OVF environment: %v. Continuing...", err)
 		}
 
-		ovfData = env.Properties["guestinfo.coreos.config.data"]
-		ovfEncoding = env.Properties["guestinfo.coreos.config.data.encoding"]
+		ovfData = env.Properties["guestinfo.ignition.config.data"]
+		ovfEncoding = env.Properties["guestinfo.ignition.config.data.encoding"]
 	}
 
-	data, err := info.String("coreos.config.data", ovfData)
+	data, err := info.String("ignition.config.data", ovfData)
 	if err != nil {
 		f.Logger.Debug("failed to fetch config: %v", err)
 		return config{}, err
 	}
 
-	encoding, err := info.String("coreos.config.data.encoding", ovfEncoding)
+	encoding, err := info.String("ignition.config.data.encoding", ovfEncoding)
 	if err != nil {
 		f.Logger.Debug("failed to fetch config encoding: %v", err)
 		return config{}, err


### PR DESCRIPTION
to make options more distribution neutral

Resolves: #646