### PR TITLE
providers: add initial hetzner cloud support

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -11,6 +11,7 @@ Ignition is currently only supported for the following platforms:
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [QEMU] - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device.
 * [DigitalOcean] - Ignition will read its configuration from the droplet userdata. SSH keys and network configuration are handled by coreos-metadata.
+* [Hetzner Cloud] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 
 Ignition is under active development so expect this list to expand in the coming months.
 

--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -24,3 +24,4 @@ Ignition is under active development so expect this list to expand in the coming
 [Packet]: https://github.com/coreos/docs/blob/master/os/booting-on-packet.md
 [QEMU]: https://github.com/qemu/qemu/blob/d75aa4372f0414c9960534026a562b0302fcff29/docs/specs/fw_cfg.txt
 [DigitalOcean]: https://github.com/coreos/docs/blob/master/os/booting-on-digitalocean.md
+[Hetzner Cloud]: https://www.hetzner.com/cloud

--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/ignition/internal/providers/ec2"
 	"github.com/coreos/ignition/internal/providers/file"
 	"github.com/coreos/ignition/internal/providers/gce"
+	"github.com/coreos/ignition/internal/providers/hcloud"
 	"github.com/coreos/ignition/internal/providers/noop"
 	"github.com/coreos/ignition/internal/providers/openstack"
 	"github.com/coreos/ignition/internal/providers/packet"
@@ -109,6 +110,10 @@ func init() {
 	configs.Register(Config{
 		name:  "gce",
 		fetch: gce.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "hcloud",
+		fetch: hcloud.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "hyperv",

--- a/internal/providers/hcloud/hcloud.go
+++ b/internal/providers/hcloud/hcloud.go
@@ -1,0 +1,46 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The hcloud provider fetches a remote configuration from the Hetzner Cloud user-data
+// metadata service URL.
+
+package hcloud
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/providers/util"
+	"github.com/coreos/ignition/internal/resource"
+)
+
+var (
+	userdataUrl = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "2009-04-04/user-data",
+	}
+)
+
+func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
+		Headers: resource.ConfigHeaders,
+	})
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}


### PR DESCRIPTION
Along with:
- https://github.com/coreos/coreos-metadata/pull/125
- https://github.com/coreos/coreos-overlay/pull/3490
- https://github.com/coreos/scripts/pull/859
- https://github.com/coreos/container-linux-config-transpiler/pull/164
- https://github.com/coreos/bootengine/pull/150

This will greatly enhance working with CoreOS on the Hetzner Cloud.