### PR TITLE
internal/exec: increase default config fetch timeout

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	DefaultFetchTimeout = time.Minute
+	DefaultFetchTimeout = 2 * time.Minute
 )
 
 // Engine represents the entity that fetches and executes a configuration.


### PR DESCRIPTION
This bumps default config timeout to 2 minutes in order to be more
resilient in environments where network stabilization may take a long
time.

Ref: https://github.com/coreos/bugs/issues/2527
Ref: https://github.com/coreos/bugs/issues/2532