### PR TITLE
Parallel filesystem creation

### DIFF
--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -405,7 +405,7 @@ func removeEmpty(strings []string) []string {
 
 func createFilesForPartitions(ctx context.Context, partitions []*types.Partition) error {
 	for _, partition := range partitions {
-		if partition.FilesystemType == "swap" || partition.FilesystemType == "" {
+		if partition.FilesystemType == "swap" || partition.FilesystemType == "" || partition.FilesystemType == "blank" {
 			continue
 		}
 		if err := mountPartition(ctx, partition); err != nil {


### PR DESCRIPTION
Fixes #681. It caps the concurrency at GOMAXPROCS.

There are a couple smaller changes in here too, one necessary and one useful:
* I added a flag to allow passing a pattern specifying which blackbox tests will be run, since `test.run` only sees the overall single test method.
* I ensured that In partitions always have a Device and MountPath set, even if they're blank. That way you can take a blank partition and format it.