### PR TITLE
test: skip backward compat tests with -test.short

### DIFF
--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -80,7 +80,7 @@ func TestIgnitionBlackBox(t *testing.T) {
 	for _, test := range register.Tests[register.PositiveTest] {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
-			if killContext.Err() != nil {
+			if killContext.Err() != nil || (testing.Short() && test.ConfigMinVersion != test.ConfigVersion) {
 				t.SkipNow()
 			}
 			if listSubtests {
@@ -100,7 +100,7 @@ func TestIgnitionBlackBoxNegative(t *testing.T) {
 	for _, test := range register.Tests[register.NegativeTest] {
 		test := test
 		t.Run(test.Name, func(t *testing.T) {
-			if killContext.Err() != nil {
+			if killContext.Err() != nil || (testing.Short() && test.ConfigMinVersion != test.ConfigVersion) {
 				t.SkipNow()
 			}
 			if listSubtests {

--- a/tests/register/register.go
+++ b/tests/register/register.go
@@ -55,6 +55,7 @@ func Register(tType TestType, t types.Test) {
 	test := types.DeepCopy(t)
 	version, semverErr := semver.NewVersion(test.ConfigMinVersion)
 	test.ReplaceAllVersionVars(test.ConfigMinVersion)
+	test.ConfigVersion = test.ConfigMinVersion
 	register(tType, test) // some tests purposefully don't have config version
 
 	if semverErr == nil && version != nil && t.ConfigMinVersion != "" {
@@ -62,6 +63,7 @@ func Register(tType TestType, t types.Test) {
 			if version.LessThan(v) {
 				test = types.DeepCopy(t)
 				test.ReplaceAllVersionVars(v.String())
+				test.ConfigVersion = v.String()
 				register(tType, test)
 			}
 		}

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -99,6 +99,7 @@ type Test struct {
 	SystemDirFiles    []File
 	Config            string
 	ConfigMinVersion  string
+	ConfigVersion     string
 	ConfigShouldBeBad bool
 }
 


### PR DESCRIPTION
Don't replace version numbers when running with -test.short. This cuts
the test case down from 505 -> 137 as of this commit.