### PR TITLE
tests/timeouts: fix concurrency panic

### DIFF
--- a/tests/positive/timeouts/timeouts.go
+++ b/tests/positive/timeouts/timeouts.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"time"
 
 	"github.com/coreos/ignition/tests/register"
@@ -37,16 +38,21 @@ var (
 	}))
 
 	lastResponses          = map[string]time.Time{}
+	lastResponsesLock      = sync.Mutex{}
 	respondThrottledServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var status int
+		lastResponsesLock.Lock()
 		lastResponse, ok := lastResponses[r.RequestURI]
 		if ok && time.Since(lastResponse) > time.Second*4 {
 			// Only respond successfully if it's been more than 4 seconds since
 			// the last attempt
-			w.WriteHeader(http.StatusOK)
-			return
+			status = http.StatusOK
+		} else {
+			status = http.StatusInternalServerError
+			lastResponses[r.RequestURI] = time.Now()
 		}
-		lastResponses[r.RequestURI] = time.Now()
-		w.WriteHeader(http.StatusInternalServerError)
+		lastResponsesLock.Unlock()
+		w.WriteHeader(status)
 	}))
 )
 


### PR DESCRIPTION
Fixes error:

    fatal error: concurrent map writes

    goroutine 17546 [running]:
    runtime.throw(0x98c3c4, 0x15)
        /usr/local/go/src/runtime/panic.go:608 +0x72 fp=0xc001222c60 sp=0xc001222c30 pc=0x42eee2
    runtime.mapassign_faststr(0x8f0540, 0xc0001e91d0, 0xc000df6584, 0x13, 0xfc3800)
        /usr/local/go/src/runtime/map_faststr.go:199 +0x3da fp=0xc001222cc8 sp=0xc001222c60 pc=0x41550a
    github.com/coreos/ignition/tests/positive/timeouts.glob..func2(0xa3c820, 0xc0005da0e0, 0xc000334200)
        /usr/src/myapp/gopath/src/github.com/coreos/ignition/tests/positive/timeouts/timeouts.go:48 +0xd3 fp=0xc001222d20 sp=0xc001222cc8 pc=0x873713
    net/http.HandlerFunc.ServeHTTP(0x9af250, 0xa3c820, 0xc0005da0e0, 0xc000334200)
        /usr/local/go/src/net/http/server.go:1964 +0x44 fp=0xc001222d48 sp=0xc001222d20 pc=0x6d78e4
    [...]