### PR TITLE
travis: bump min go version to 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: go
 go_import_path: github.com/coreos/ignition
 
 go:
-  - "1.8.7"
   - "1.10.4"
   - "1.11"
 


### PR DESCRIPTION
The previous min version was 1.8.x because we weren't sure what would be
available for use in building RHCOS. Turns out 1.10.x is fine, so lets
bump this.

see https://github.com/coreos/ignition/pull/626#discussion_r214266901 for old discussion