### PR TITLE
internal/*: Drop support for default.ign config files

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -78,12 +78,6 @@ func (e Engine) Run(stageName string) error {
 	cfg, err := e.acquireConfig()
 	if err == errors.ErrEmpty {
 		e.Logger.Info("%v: ignoring user-provided config", err)
-		cfg, r, err = system.FetchDefaultConfig(e.Logger)
-		e.logReport(r)
-		if err != nil && err != providers.ErrNoProvider {
-			e.Logger.Crit("failed to acquire default config: %v", err)
-			return err
-		}
 	} else if err != nil {
 		e.Logger.Crit("failed to acquire config: %v", err)
 		return err

--- a/internal/providers/system/system.go
+++ b/internal/providers/system/system.go
@@ -29,17 +29,12 @@ import (
 )
 
 const (
-	baseFilename    = "base.ign"
-	defaultFilename = "default.ign"
-	userFilename    = "user.ign"
+	baseFilename = "base.ign"
+	userFilename = "user.ign"
 )
 
 func FetchBaseConfig(logger *log.Logger) (types.Config, report.Report, error) {
 	return fetchConfig(logger, baseFilename)
-}
-
-func FetchDefaultConfig(logger *log.Logger) (types.Config, report.Report, error) {
-	return fetchConfig(logger, defaultFilename)
 }
 
 func FetchConfig(f resource.Fetcher) (types.Config, report.Report, error) {

--- a/tests/positive/general/preemption.go
+++ b/tests/positive/general/preemption.go
@@ -23,29 +23,21 @@ import (
 )
 
 func init() {
-	// Default config is applied
-	register.Register(register.PositiveTest, makePreemptTest("D"))
-	// Base and default configs are both applied
-	register.Register(register.PositiveTest, makePreemptTest("BD"))
 	// Base and provider configs are both applied
 	register.Register(register.PositiveTest, makePreemptTest("BP"))
-	// Provider config is applied; default config is ignored
-	register.Register(register.PositiveTest, makePreemptTest("dP"))
-	// Base and user configs are applied; provider and default
-	// configs are ignored
-	register.Register(register.PositiveTest, makePreemptTest("BdUp"))
+	// Base and user configs are applied; provider config is ignored
+	register.Register(register.PositiveTest, makePreemptTest("BUp"))
 	// No configs provided; Ignition should still run successfully
 	register.Register(register.PositiveTest, makePreemptTest(""))
 }
 
 // makePreemptTest returns a config preemption test that executes some
-// combination of "b"ase, "d"efault, "u"ser (user.ign), and "p"rovider
+// combination of "b"ase, "u"ser (user.ign), and "p"rovider
 // (IGNITION_CONFIG_FILE) configs. Capital letters indicate configs that
 // Ignition should apply.
 func makePreemptTest(components string) types.Test {
 	longnames := map[string]string{
 		"b": "base",
-		"d": "default",
 		"u": "user",
 		"p": "provider",
 	}
@@ -82,7 +74,7 @@ func makePreemptTest(components string) types.Test {
 	}
 
 	var systemFiles []types.File
-	for _, component := range []string{"b", "d", "u"} {
+	for _, component := range []string{"b", "u"} {
 		if enabled(component) {
 			systemFiles = append(systemFiles, types.File{
 				Node: types.Node{


### PR DESCRIPTION
Removes functionality that checks for a file at
/usr/lib/ignition/default.ign. This was used to enable coreos-cloudinit,
which is no longer supported with Ignition 3.0.0.

Closes: #668

---

Manually tested with a CL image on QEMU.  Running `journalctl --identifier=ignition --all` indicates `default.ign` is no longer looked for.

WIP - still updating blackbox tests that fail due to this change (`tests/positive/general/preemption.go`).