### PR TITLE
tests/types: add comments on some members of Test

### DIFF
--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -92,15 +92,15 @@ type MntDevice struct {
 
 type Test struct {
 	Name              string
-	In                []Disk
-	Out               []Disk
+	In                []Disk // Disk state before running Ignition
+	Out               []Disk // Expected disk state after running Ignition
 	MntDevices        []MntDevice
 	OEMLookasideFiles []File
 	SystemDirFiles    []File
 	Config            string
 	ConfigMinVersion  string
 	ConfigVersion     string
-	ConfigShouldBeBad bool
+	ConfigShouldBeBad bool // Set to true to skip config validation step
 }
 
 func (ps Partitions) GetPartition(label string) *Partition {


### PR DESCRIPTION
Initially, it took some time to understand these (was clear after
reading `tests/blackbox_tests.go`). Adding a few comments as hints,
which may be useful when first reading the code.