### PR TITLE
internal/exec: log hashes of configs not configs

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -15,6 +15,8 @@
 package exec
 
 import (
+	"crypto/sha512"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -261,7 +263,8 @@ func (e *Engine) fetchReferencedConfig(cfgRef types.ConfigReference) (types.Conf
 	if err != nil {
 		return types.Config{}, err
 	}
-	e.Logger.Debug("fetched referenced config: %s", string(rawCfg))
+	hash := sha512.Sum512(rawCfg)
+	e.Logger.Debug("fetched referenced config with SHA512: %s", hex.EncodeToString(hash[:]))
 
 	if err := util.AssertValid(cfgRef.Verification, rawCfg); err != nil {
 		return types.Config{}, err

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -281,6 +281,7 @@ func (e *Engine) fetchReferencedConfig(cfgRef types.ConfigReference) (types.Conf
 
 func (e Engine) logReport(r report.Report) {
 	for _, entry := range r.Entries {
+		entry.Highlight = "" // might contain secrets, don't log when Ignition runs
 		switch entry.Kind {
 		case report.EntryError:
 			e.Logger.Crit("%v", entry)

--- a/internal/providers/util/config.go
+++ b/internal/providers/util/config.go
@@ -15,6 +15,9 @@
 package util
 
 import (
+	"crypto/sha512"
+	"encoding/hex"
+
 	"github.com/coreos/ignition/config/validate/report"
 	"github.com/coreos/ignition/internal/config"
 	"github.com/coreos/ignition/internal/config/types"
@@ -22,7 +25,8 @@ import (
 )
 
 func ParseConfig(logger *log.Logger, rawConfig []byte) (types.Config, report.Report, error) {
-	logger.Debug("parsing config: %s", string(rawConfig))
+	hash := sha512.Sum512(rawConfig)
+	logger.Debug("parsing config with SHA512: %s", hex.EncodeToString(hash[:]))
 
 	return config.Parse(rawConfig)
 }


### PR DESCRIPTION
Do not log configs; instead log a hash of them. This ensures if a config
contains secrets, it does not log them to the journal.

Will PR a backport to `spec2x` after this merges