### PR TITLE
oem: add metal oem

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -127,6 +127,10 @@ func init() {
 		name:  "file",
 		fetch: file.FetchConfig,
 	})
+	configs.Register(Config{
+		name:  "metal",
+		fetch: noop.FetchConfig,
+	})
 }
 
 func Get(name string) (config Config, ok bool) {


### PR DESCRIPTION
Add oem for use by bare metal. It does nothing. This allows setting the
oem-id to "metal" for other projects and having Ignition not fail.