### PR TITLE
*: drop OEM terminology

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -30,7 +30,7 @@ import (
 	"github.com/coreos/ignition/internal/config/types"
 	"github.com/coreos/ignition/internal/exec/stages"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/oem"
+	"github.com/coreos/ignition/internal/platform"
 	"github.com/coreos/ignition/internal/providers"
 	"github.com/coreos/ignition/internal/providers/cmdline"
 	"github.com/coreos/ignition/internal/providers/system"
@@ -44,12 +44,12 @@ const (
 
 // Engine represents the entity that fetches and executes a configuration.
 type Engine struct {
-	ConfigCache  string
-	FetchTimeout time.Duration
-	Logger       *log.Logger
-	Root         string
-	OEMConfig    oem.Config
-	Fetcher      *resource.Fetcher
+	ConfigCache    string
+	FetchTimeout   time.Duration
+	Logger         *log.Logger
+	Root           string
+	PlatformConfig platform.Config
+	Fetcher        *resource.Fetcher
 }
 
 // Run executes the stage of the given name. It returns true if the stage
@@ -173,7 +173,7 @@ func (e *Engine) fetchProviderConfig() (types.Config, error) {
 	fetchers := []providers.FuncFetchConfig{
 		cmdline.FetchConfig,
 		system.FetchConfig,
-		e.OEMConfig.FetchFunc(),
+		e.PlatformConfig.FetchFunc(),
 	}
 
 	var cfg types.Config

--- a/internal/main.go
+++ b/internal/main.go
@@ -27,7 +27,7 @@ import (
 	_ "github.com/coreos/ignition/internal/exec/stages/mount"
 	_ "github.com/coreos/ignition/internal/exec/stages/umount"
 	"github.com/coreos/ignition/internal/log"
-	"github.com/coreos/ignition/internal/oem"
+	"github.com/coreos/ignition/internal/platform"
 	"github.com/coreos/ignition/internal/version"
 )
 
@@ -36,7 +36,7 @@ func main() {
 		clearCache   bool
 		configCache  string
 		fetchTimeout time.Duration
-		oem          oem.Name
+		platform     platform.Name
 		root         string
 		stage        stages.Name
 		version      bool
@@ -46,7 +46,7 @@ func main() {
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
 	flag.StringVar(&flags.configCache, "config-cache", "/run/ignition.json", "where to cache the config")
 	flag.DurationVar(&flags.fetchTimeout, "fetch-timeout", exec.DefaultFetchTimeout, "initial duration for which to wait for config")
-	flag.Var(&flags.oem, "oem", fmt.Sprintf("current oem. %v", oem.Names()))
+	flag.Var(&flags.platform, "platform", fmt.Sprintf("current platform. %v", platform.Names()))
 	flag.StringVar(&flags.root, "root", "/", "root of the filesystem")
 	flag.Var(&flags.stage, "stage", fmt.Sprintf("execution stage. %v", stages.Names()))
 	flag.BoolVar(&flags.version, "version", false, "print the version and exit")
@@ -59,8 +59,8 @@ func main() {
 		return
 	}
 
-	if flags.oem == "" {
-		fmt.Fprint(os.Stderr, "'--oem' must be provided\n")
+	if flags.platform == "" {
+		fmt.Fprint(os.Stderr, "'--platform' must be provided\n")
 		os.Exit(2)
 	}
 
@@ -80,23 +80,23 @@ func main() {
 		}
 	}
 
-	oemConfig := oem.MustGet(flags.oem.String())
-	fetcher, err := oemConfig.NewFetcherFunc()(&logger)
+	platformConfig := platform.MustGet(flags.platform.String())
+	fetcher, err := platformConfig.NewFetcherFunc()(&logger)
 	if err != nil {
 		logger.Crit("failed to generate fetcher: %s", err)
 		os.Exit(3)
 	}
 	engine := exec.Engine{
-		Root:         flags.root,
-		FetchTimeout: flags.fetchTimeout,
-		Logger:       &logger,
-		ConfigCache:  flags.configCache,
-		OEMConfig:    oemConfig,
-		Fetcher:      &fetcher,
+		Root:           flags.root,
+		FetchTimeout:   flags.fetchTimeout,
+		Logger:         &logger,
+		ConfigCache:    flags.configCache,
+		PlatformConfig: platformConfig,
+		Fetcher:        &fetcher,
 	}
 
 	err = engine.Run(flags.stage.String())
-	if statusErr := engine.OEMConfig.Status(flags.stage.String(), *engine.Fetcher, err); statusErr != nil {
+	if statusErr := engine.PlatformConfig.Status(flags.stage.String(), *engine.Fetcher, err); statusErr != nil {
 		logger.Err("POST Status error: %v", statusErr.Error())
 	}
 	if err != nil {

--- a/internal/platform/name.go
+++ b/internal/platform/name.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package oem
+package platform
 
 import (
 	"fmt"
 )
 
-// Name is used to identify an OEM. It must be in the set of registered OEMs.
+// Name is used to identify an platform. It must be in the set of registered platforms.
 type Name string
 
 func (s Name) String() string {
@@ -27,7 +27,7 @@ func (s Name) String() string {
 
 func (s *Name) Set(val string) error {
 	if _, ok := Get(val); !ok {
-		return fmt.Errorf("%s is not a valid oem", val)
+		return fmt.Errorf("%s is not a valid platform", val)
 	}
 
 	*s = Name(val)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package oem
+package platform
 
 import (
 	"fmt"
@@ -35,7 +35,7 @@ import (
 	"github.com/coreos/ignition/internal/resource"
 )
 
-// Config represents a set of options that map to a particular OEM.
+// Config represents a set of options that map to a particular platform.
 type Config struct {
 	name       string
 	fetch      providers.FuncFetchConfig
@@ -70,7 +70,7 @@ func (c Config) Status(stageName string, f resource.Fetcher, statusErr error) er
 	return nil
 }
 
-var configs = registry.Create("oem configs")
+var configs = registry.Create("platform configs")
 
 func init() {
 	configs.Register(Config{
@@ -138,7 +138,7 @@ func MustGet(name string) Config {
 	if config, ok := Get(name); ok {
 		return config
 	} else {
-		panic(fmt.Sprintf("invalid OEM name %q provided", name))
+		panic(fmt.Sprintf("invalid platform name %q provided", name))
 	}
 }
 

--- a/internal/providers/noop/noop.go
+++ b/internal/providers/noop/noop.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The noop provider does nothing, for use by unimplemented oems.
+// The noop provider does nothing, for use by unimplemented platforms.
 
 package noop
 

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -160,7 +160,7 @@ func umountPartition(p *types.Partition) error {
 
 // returns true if no error, false if error
 func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, appendEnv []string) error {
-	args := []string{"-clear-cache", "-oem", "file", "-stage", stage,
+	args := []string{"-clear-cache", "-platform", "file", "-stage", stage,
 		"-root", root, "-log-to-stdout", "--config-cache", filepath.Join(cwd, "ignition.json")}
 	cmd := exec.CommandContext(ctx, "ignition", args...)
 	t.Log("ignition", args)


### PR DESCRIPTION
Switches from using the OEM terminology (a remnant of ChromiumOS) to
platform.

Fixes #684