### PR TITLE
internal/exec: use nonzero default file permissions 

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -34,7 +34,8 @@ var (
 	ErrInvalidVersion = errors.New("invalid config version (couldn't parse)")
 
 	// Storage section errors
-	ErrPermissionsUnset            = errors.New("permissions unset, defaulting to 0000")
+	ErrFilePermissionsUnset        = errors.New("permissions unset, defaulting to 0644")
+	ErrDirectoryPermissionsUnset   = errors.New("permissions unset, defaulting to 0755")
 	ErrDiskDeviceRequired          = errors.New("disk device is required")
 	ErrPartitionNumbersCollide     = errors.New("partition numbers collide")
 	ErrPartitionsOverlap           = errors.New("partitions overlap")

--- a/config/v3_0_experimental/types/directory.go
+++ b/config/v3_0_experimental/types/directory.go
@@ -28,10 +28,7 @@ func (d Directory) ValidateMode() report.Report {
 		})
 	}
 	if d.Mode == nil {
-		r.Add(report.Entry{
-			Message: errors.ErrPermissionsUnset.Error(),
-			Kind:    report.EntryWarning,
-		})
+		r.AddOnWarning(errors.ErrDirectoryPermissionsUnset)
 	}
 	return r
 }

--- a/config/v3_0_experimental/types/file.go
+++ b/config/v3_0_experimental/types/file.go
@@ -37,10 +37,7 @@ func (f File) ValidateMode() report.Report {
 		})
 	}
 	if f.Mode == nil {
-		r.Add(report.Entry{
-			Message: errors.ErrPermissionsUnset.Error(),
-			Kind:    report.EntryWarning,
-		})
+		r.AddOnWarning(errors.ErrFilePermissionsUnset)
 	}
 	return r
 }

--- a/doc/configuration-v3_0-experimental.md
+++ b/doc/configuration-v3_0-experimental.md
@@ -62,7 +62,7 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
-    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).
+    * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). If not specified, the permission mode for files defaults to 0644.
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
@@ -72,7 +72,7 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_directories_** (list of objects): the list of directories to be created.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path.
-    * **_mode_** (integer): the directory's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0755 -> 493).
+    * **_mode_** (integer): the directory's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0755 -> 493). If not specified, the permission mode for directories defaults to 0755.
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -121,7 +121,7 @@ func (tmp dirEntry) create(l *log.Logger, u util.Util) error {
 		}
 
 		if d.Mode == nil {
-			d.Mode = configUtil.IntToPtr(0)
+			d.Mode = configUtil.IntToPtr(int(util.DefaultDirectoryPermissions))
 		}
 
 		if err := os.MkdirAll(path, os.FileMode(*d.Mode)); err != nil {

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -243,7 +243,7 @@ func (u Util) PerformFetch(f *FetchOp) error {
 
 		// Ensure the ownership and mode are as requested (since WriteFile can be affected by sticky bit)
 
-		mode := os.FileMode(0)
+		mode := DefaultFilePermissions
 		if f.Mode != nil {
 			mode = os.FileMode(*f.Mode)
 		}

--- a/tests/positive/files/directory.go
+++ b/tests/positive/files/directory.go
@@ -15,6 +15,8 @@
 package files
 
 import (
+	"os"
+
 	"github.com/coreos/ignition/tests/register"
 	"github.com/coreos/ignition/tests/types"
 )
@@ -23,6 +25,7 @@ func init() {
 	register.Register(register.PositiveTest, CreateDirectoryOnRoot())
 	register.Register(register.PositiveTest, ForceDirCreation())
 	register.Register(register.PositiveTest, ForceDirCreationOverNonemptyDir())
+	register.Register(register.PositiveTest, ApplyDefaultDirectoryPermissions())
 }
 
 func CreateDirectoryOnRoot() types.Test {
@@ -65,7 +68,7 @@ func ForceDirCreation() types.Test {
 	  "storage": {
 	    "directories": [{
 	      "path": "/foo/bar",
-		  "overwrite": true
+	      "overwrite": true
 	    }]
 	  }
 	}`
@@ -106,7 +109,7 @@ func ForceDirCreationOverNonemptyDir() types.Test {
 	  "storage": {
 	    "directories": [{
 	      "path": "/foo/bar",
-		  "overwrite": true
+	      "overwrite": true
 	    }]
 	  }
 	}`
@@ -129,6 +132,39 @@ func ForceDirCreationOverNonemptyDir() types.Test {
 	})
 	configMinVersion := "3.0.0-experimental"
 	// TODO: add ability to ensure that foo/bar/baz doesn't exist here.
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+func ApplyDefaultDirectoryPermissions() types.Test {
+	name := "Apply Default Directory Permissions"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "$version" },
+	  "storage": {
+	    "directories": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar"
+	    }]
+	  }
+	}`
+	out[0].Partitions.AddDirectories("ROOT", []types.Directory{
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "foo",
+			},
+			Mode: 0755 | int(os.ModeDir),
+		},
+	})
+	configMinVersion := "3.0.0-experimental"
 
 	return types.Test{
 		Name:             name,

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -26,6 +26,7 @@ func init() {
 	register.Register(register.PositiveTest, ForceFileCreationNoOverwrite())
 	register.Register(register.PositiveTest, AppendToAFile())
 	register.Register(register.PositiveTest, AppendToNonexistentFile())
+	register.Register(register.PositiveTest, ApplyDefaultFilePermissions())
 	// TODO: Investigate why ignition's C code hates our environment
 	// register.Register(register.PositiveTest, UserGroupByName())
 }
@@ -291,6 +292,41 @@ func AppendToNonexistentFile() types.Test {
 				Group:     500,
 			},
 			Contents: "hello world\n",
+		},
+	})
+	configMinVersion := "3.0.0-experimental"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+func ApplyDefaultFilePermissions() types.Test {
+	name := "Apply Default File Permissions"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "$version" },
+	  "storage": {
+	    "files": [{
+	      "filesystem": "root",
+	      "path": "/foo/bar",
+	      "contents": { "source": "data:,hello%20world%0A" }
+	    }]
+	  }
+	}`
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+			Contents: "hello world\n",
+			Mode:     0644,
 		},
 	})
 	configMinVersion := "3.0.0-experimental"

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -305,7 +305,7 @@ func validateMode(t *testing.T, path string, mode int) {
 		}
 
 		if fileInfo.Mode() != os.FileMode(mode) {
-			t.Error("Node Mode does not match", path, mode, fileInfo.Mode())
+			t.Error("Node Mode does not match", path, os.FileMode(mode), fileInfo.Mode())
 		}
 	}
 }


### PR DESCRIPTION
Creates files and directories with default permissions 0644 and 0755
respectively, when "mode" is not specified in the Ignition config for
the file/directory. This also updates the warning message printed when
the default permissions are applied.

Closes: #582

---

Blackbox tests should work. Did not get to verifying with a full `kola run` with this yet.

When trying to verify the changes, I was having problems running `./coreos_production_qemu.sh -i cfg.ign -- -nographic` (Ignition logs showed the error `not a config(empty)`). This was before I rebased onto a more recent master, so I need to check if the same problem occurs on this branch.