### PR TITLE
internal/distro: use relative paths

### DIFF
--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -10,20 +10,6 @@ GLDFLAGS="-X github.com/coreos/ignition/internal/distro.useraddCmd=useradd-stub 
 GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.usermodCmd=usermod-stub "
 GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.blackboxTesting=true "
 
-if [ "${HELPERS:-CL}" == "HOST" ]; then
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.mdadmCmd=$(sudo which mdadm) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.mountCmd=$(sudo which mount) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.sgdiskCmd=$(sudo which sgdisk) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.udevadmCmd=$(sudo which udevadm) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.chrootCmd=$(sudo which chroot) "
-
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.btrfsMkfsCmd=$(sudo which mkfs.btrfs) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.ext4MkfsCmd=$(sudo which mkfs.ext4) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.swapMkfsCmd=$(sudo which mkswap) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.vfatMkfsCmd=$(sudo which mkfs.vfat) "
-	GLDFLAGS+="-X github.com/coreos/ignition/internal/distro.xfsMkfsCmd=$(sudo which mkfs.xfs) "
-fi
-
 . build
 
 PKG=$(cd gopath/src/${REPO_PATH}; go list ./tests/)

--- a/doc/development.md
+++ b/doc/development.md
@@ -56,10 +56,8 @@ sudo -E PATH=$PWD/bin/amd64:$PATH ./tests.test
 
 ## Runnning Blackbox Tests on platforms other than Container Linux
 
-Build Ignition and the test binaries with HELPERS=HOST to use the paths of the binaries from your host system instead of those found in Container linux. Then run blackbox tests. The subshell ensures the root PATH is used instead of your user's.
-
 ```sh
-HELPERS=HOST ./build_blackbox_tests
+./build_blackbox_tests
 sudo sh -c 'PATH=$PWD/bin/amd64:$PATH ./tests.test'
 ```
 

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -33,23 +33,26 @@ var (
 	systemConfigDir = "/usr/lib/ignition"
 
 	// Helper programs
-	chrootCmd     = "/usr/bin/chroot"
-	groupaddCmd   = "/usr/sbin/groupadd"
-	idCmd         = "/usr/bin/id"
-	mdadmCmd      = "/usr/sbin/mdadm"
-	mountCmd      = "/usr/bin/mount"
-	sgdiskCmd     = "/usr/sbin/sgdisk"
-	udevadmCmd    = "/usr/bin/udevadm"
-	usermodCmd    = "/usr/sbin/usermod"
-	useraddCmd    = "/usr/sbin/useradd"
+	chrootCmd   = "chroot"
+	groupaddCmd = "groupadd"
+	idCmd       = "id"
+	mdadmCmd    = "mdadm"
+	mountCmd    = "mount"
+	sgdiskCmd   = "sgdisk"
+	udevadmCmd  = "udevadm"
+	usermodCmd  = "usermod"
+	useraddCmd  = "useradd"
+
+	// The restorecon tool is embedded inside of a systemd unit
+	// and as such requires the absolute path
 	restoreconCmd = "/usr/sbin/restorecon"
 
 	// Filesystem tools
-	btrfsMkfsCmd = "/usr/sbin/mkfs.btrfs"
-	ext4MkfsCmd  = "/usr/sbin/mkfs.ext4"
-	swapMkfsCmd  = "/usr/sbin/mkswap"
-	vfatMkfsCmd  = "/usr/sbin/mkfs.vfat"
-	xfsMkfsCmd   = "/usr/sbin/mkfs.xfs"
+	btrfsMkfsCmd = "mkfs.btrfs"
+	ext4MkfsCmd  = "mkfs.ext4"
+	swapMkfsCmd  = "mkswap"
+	vfatMkfsCmd  = "mkfs.vfat"
+	xfsMkfsCmd   = "mkfs.xfs"
 
 	// Flags
 	selinuxRelabel  = "false"

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/ignition/internal/distro"
 	"github.com/coreos/ignition/tests/types"
 )
 
@@ -81,7 +80,8 @@ func prepareRootPartitionForPasswd(ctx context.Context, root *types.Partition) e
 	}
 
 	// TODO: use the architecture, not hardcode amd64
-	_, err := run(ctx, "cp", "bin/amd64/id-stub", filepath.Join(mountPath, distro.IdCmd()))
+	// copy to mountPath/usr/bin/id as it's used by Ignition via a chroot to the mountPath
+	_, err := run(ctx, "cp", "bin/amd64/id-stub", filepath.Join(mountPath, "usr", "bin", "id"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Switch to relative paths for the binaries defined in the `distro`
package while still allowing them to be overridden via build flags.

Fixes #648