### PR TITLE
tests: drop OEMLookaside type

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -100,8 +100,6 @@ Out: `[]Disk` object, which describes the Disks that should be present after Ign
 
 MntDevices: `MntDevice` object, which describes any disk related variable replacements that need to be done to the Ignition config before Ignition is run. This is done so that disks which are created during the test run can be referenced inside of an Ignition config.
 
-OEMLookasideFiles: `[]File` object which describes the Files that should be written into the OEM lookaside directory before Ignition is run.
-
 SystemDirFiles: `[]File` object which describes the Files that should be written into Ignition's system config directory before Ignition is run.
 
 Config: `string` type where the specific config version should be replaced by `$version` and will be updated before Ignition is run.

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -95,7 +95,6 @@ type Test struct {
 	In                []Disk // Disk state before running Ignition
 	Out               []Disk // Expected disk state after running Ignition
 	MntDevices        []MntDevice
-	OEMLookasideFiles []File
 	SystemDirFiles    []File
 	Config            string
 	ConfigMinVersion  string
@@ -320,7 +319,7 @@ func (t *Test) ReplaceAllVersionVars(version string) {
 	t.Name += " " + version
 }
 
-// Deep copy Test struct fields In, Out, MntDevices, OEMLookasideFiles, SystemDirFiles
+// Deep copy Test struct fields In, Out, MntDevices, SystemDirFiles
 // so each BB test with identical Test structs have their own independent Test copies
 func DeepCopy(t Test) Test {
 	In_diskArr := make([]Disk, len(t.In))
@@ -334,10 +333,6 @@ func DeepCopy(t Test) Test {
 	mntdevice := make([]MntDevice, len(t.MntDevices))
 	copy(mntdevice, t.MntDevices)
 	t.MntDevices = mntdevice
-
-	OEMLookasideFiles := make([]File, len(t.OEMLookasideFiles))
-	copy(OEMLookasideFiles, t.OEMLookasideFiles)
-	t.OEMLookasideFiles = OEMLookasideFiles
 
 	SystemDirFiles := make([]File, len(t.SystemDirFiles))
 	copy(SystemDirFiles, t.SystemDirFiles)


### PR DESCRIPTION
This functionality was removed in #734 but the type definition itself
was missed.