### PR TITLE
Disallow mounting filesystem entries via symlinks

### DIFF
--- a/internal/exec/util/util.go
+++ b/internal/exec/util/util.go
@@ -34,16 +34,16 @@ type Util struct {
 	*log.Logger
 }
 
-// splitPath splits /a/b/c/d into [a, b, c, d]
+// SplitPath splits /a/b/c/d into [a, b, c, d]
 // golang-- for making me write this
 
-func splitPath(p string) []string {
+func SplitPath(p string) []string {
 	dir, file := filepath.Split(p)
 	if dir == "" || dir == "/" {
 		return []string{file}
 	}
 	dir = filepath.Clean(dir)
-	return append(splitPath(dir), file)
+	return append(SplitPath(dir), file)
 }
 
 func wantsToEscape(p string) bool {
@@ -57,7 +57,7 @@ func wantsToEscape(p string) bool {
 func (u Util) JoinPath(path ...string) (string, error) {
 	components := []string{}
 	for _, tmp := range path {
-		components = append(components, splitPath(tmp)...)
+		components = append(components, SplitPath(tmp)...)
 	}
 	last := components[len(components)-1]
 	components = components[:len(components)-1]

--- a/tests/negative/filesystems/symlinks.go
+++ b/tests/negative/filesystems/symlinks.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystems
+
+import (
+	"github.com/coreos/ignition/tests/register"
+	"github.com/coreos/ignition/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, UsesSymlinks())
+}
+
+func UsesSymlinks() types.Test {
+	name := "No Device"
+	in := types.GetBaseDisk()
+	in[0].Partitions.AddLinks("ROOT", []types.Link{
+		{
+			Node: types.Node{
+				Name:      "tmp0",
+				Directory: "/",
+			},
+			Hard:   false,
+			Target: "/",
+		},
+	})
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "OEM",
+			Substitution: "$DEVICE",
+		},
+	}
+	out := in
+	config := `{
+		"ignition": {"version": "$version"},
+		"storage": {
+			"filesystems": [{
+				"format": "ext4",
+				"path": "/tmp0",
+				"device": "$DEVICE"
+			}]
+		}
+	}`
+	configMinVersion := "3.0.0-experimental"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		MntDevices:       mntDevices,
+		ConfigMinVersion: configMinVersion,
+	}
+}


### PR DESCRIPTION
We can't determine the correct order to mount if we allow this. Also systemd mount units also disallow this, so there's some precedent.