### PR TITLE
exec/util/passwd: rename authorized_keys.d fragment to "ignition"

### DIFF
--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -189,7 +189,7 @@ func (u Util) AuthorizeSSHKeys(c types.PasswdUser) error {
 			ks = ks + "\n"
 		}
 
-		if err := akd.Add("coreos-ignition", []byte(ks), true, true); err != nil {
+		if err := akd.Add("ignition", []byte(ks), true, true); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Renames the written fragment in ~/.ssh/authorized_keys.d/ from
"coreos-ignition" to "ignition". This is to have a more
distro-independent identifier.

Fixes: #710 

---

Tested this change in FCOS, and confirmed the `ignition` fragment gets written with the keys given in the Ignition config `"sshAuthorizedKeys"`.

```
$ ls ~/.ssh/authorized_keys.d/ignition -l
-rw-------. 1 core core 424 Feb 26 19:48 /var/home/core/.ssh/authorized_keys.d/ignition
```