### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -160,7 +160,7 @@ func translateV2_1PasswdUserGroupSliceToStringSlice(groups []types.Group) []stri
 	return newGroups
 }
 
-// Add the provided SSH public keys to the user's authorized keys.
+// AuthorizeSSHKeys adds the provided SSH public keys to the user's authorized keys.
 func (u Util) AuthorizeSSHKeys(c types.PasswdUser) error {
 	if len(c.SSHAuthorizedKeys) == 0 {
 		return nil

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -244,7 +244,7 @@ func GetBaseDisk() []Disk {
 	}
 }
 
-// Replace all UUID variables (format $uuid<num>) in configs and partitions with an UUID
+// ReplaceAllUUIDVars replaces all UUID variables (format $uuid<num>) in configs and partitions with an UUID
 func (test *Test) ReplaceAllUUIDVars() error {
 	var err error
 	UUIDmap := make(map[string]string)
@@ -311,7 +311,7 @@ func getUUID(key string, UUIDmap map[string]string) string {
 	return UUIDmap[key]
 }
 
-// Replace Version variable (format $version) in configs with ConfigMinVersion
+// ReplaceAllVersionVars replaces Version variable (format $version) in configs with ConfigMinVersion
 // Updates the old config version (oldVersion) with a new one (newVersion)
 func (t *Test) ReplaceAllVersionVars(version string) {
 	pattern := regexp.MustCompile("\\$version")


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?