### PR TITLE
Default file.overwrite config option to false 

### DIFF
--- a/doc/configuration-v3_0-experimental.md
+++ b/doc/configuration-v3_0-experimental.md
@@ -55,7 +55,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
   * **_files_** (list of objects): the list of files to be written.
     * **path** (string): the absolute path to the file.
-    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to true.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to false.
     * **_append_** (boolean): whether to append to the specified file. Creates a new file if nothing exists at the path. Cannot be set if overwrite is set to true.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
@@ -71,7 +71,7 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_name_** (string): the group name of the owner.
   * **_directories_** (list of objects): the list of directories to be created.
     * **path** (string): the absolute path to the directory.
-    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to false.
     * **_mode_** (integer): the directory's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0755 -> 493). If not specified, the permission mode for directories defaults to 0755.
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
@@ -81,7 +81,7 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_name_** (string): the group name of the owner.
   * **_links_** (list of objects): the list of links to be created
     * **path** (string): the absolute path to the link
-    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.

--- a/tests/negative/files/preexisting_nodes.go
+++ b/tests/negative/files/preexisting_nodes.go
@@ -21,6 +21,7 @@ import (
 
 func init() {
 	register.Register(register.NegativeTest, ForceFileCreation())
+	register.Register(register.NegativeTest, ForceFileCreationNoOverwrite())
 	register.Register(register.NegativeTest, ForceDirCreation())
 	register.Register(register.NegativeTest, ForceLinkCreation())
 	register.Register(register.NegativeTest, ForceHardLinkCreation())
@@ -53,6 +54,41 @@ func ForceFileCreation() types.Test {
 			},
 		},
 	})
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+func ForceFileCreationNoOverwrite() types.Test {
+	name := "Force File Creation No Overwrite"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "$version" },
+	  "storage": {
+	    "files": [{
+	      "path": "/foo/bar",
+	      "contents": {
+	        "source": "http://127.0.0.1:8080/contents"
+	      }
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Directory: "foo",
+				Name:      "bar",
+			},
+			Contents: "hello, world",
+		},
+	})
+	configMinVersion := "3.0.0-experimental"
 
 	return types.Test{
 		Name:             name,

--- a/tests/positive/files/file.go
+++ b/tests/positive/files/file.go
@@ -23,7 +23,6 @@ func init() {
 	register.Register(register.PositiveTest, CreateFileOnRoot())
 	register.Register(register.PositiveTest, UserGroupByID())
 	register.Register(register.PositiveTest, ForceFileCreation())
-	register.Register(register.PositiveTest, ForceFileCreationNoOverwrite())
 	register.Register(register.PositiveTest, AppendToAFile())
 	register.Register(register.PositiveTest, AppendToNonexistentFile())
 	register.Register(register.PositiveTest, ApplyDefaultFilePermissions())
@@ -151,50 +150,6 @@ func ForceFileCreation() types.Test {
 	        "source": "http://127.0.0.1:8080/contents"
 	      },
 		  "overwrite": true
-	    }]
-	  }
-	}`
-	in[0].Partitions.AddFiles("ROOT", []types.File{
-		{
-			Node: types.Node{
-				Directory: "foo",
-				Name:      "bar",
-			},
-			Contents: "hello, world",
-		},
-	})
-	out[0].Partitions.AddFiles("ROOT", []types.File{
-		{
-			Node: types.Node{
-				Directory: "foo",
-				Name:      "bar",
-			},
-			Contents: "asdf\nfdsa",
-		},
-	})
-	configMinVersion := "3.0.0-experimental"
-
-	return types.Test{
-		Name:             name,
-		In:               in,
-		Out:              out,
-		Config:           config,
-		ConfigMinVersion: configMinVersion,
-	}
-}
-
-func ForceFileCreationNoOverwrite() types.Test {
-	name := "Force File Creation No Overwrite"
-	in := types.GetBaseDisk()
-	out := types.GetBaseDisk()
-	config := `{
-	  "ignition": { "version": "$version" },
-	  "storage": {
-	    "files": [{
-	      "path": "/foo/bar",
-	      "contents": {
-	        "source": "http://127.0.0.1:8080/contents"
-	      }
 	    }]
 	  }
 	}`

--- a/tests/positive/files/link.go
+++ b/tests/positive/files/link.go
@@ -250,7 +250,8 @@ func WriteOverSymlink() types.Test {
 	  "storage": {
 	    "files": [{
 	      "path": "/etc/file",
-	      "mode": 420
+	      "mode": 420,
+	      "overwrite": true
 	    }]
 	  }
 	}`
@@ -313,7 +314,8 @@ func WriteOverBrokenSymlink() types.Test {
 	  "storage": {
 	    "files": [{
 	      "path": "/etc/file",
-	      "mode": 420
+	      "mode": 420,
+	      "overwrite": true
 	    }]
 	  }
 	}`

--- a/tests/positive/general/preemption.go
+++ b/tests/positive/general/preemption.go
@@ -47,7 +47,8 @@ func makePreemptTest(components string) types.Test {
 			"storage": {
 				"files": [{
 					"path": "/ignition/%s",
-					"contents": {"source": "data:,%s"}
+					"contents": {"source": "data:,%s"},
+					"overwrite": true
 				}]}
 		}`, longnames[component], component)
 	}


### PR DESCRIPTION
Need to verify the changes after passing the Ignition config to an OS image. Blackbox tests should work.

Code should be ready for a look - the main change was making `Node.Overwrite` a `bool` instead of `*bool` to use the zero Go value as the `false` default. An alternative could be allocating/setting `*n.Overwrite = false` when `n.Overwrite == nil`, but it doesn't seem like the "unset" case where `n.Overwrite == nil` needs handling now.

Resolves: #604 