### PR TITLE
stages/files: Also relabel subuid/subgid files

### DIFF
--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -38,6 +38,8 @@ func (s *stage) createPasswd(config types.Config) error {
 			"/etc/group*",
 			"/etc/shadow*",
 			"/etc/gshadow*",
+			"/etc/subuid*",
+			"/etc/subgid*",
 			"/etc/.pwd.lock",
 			"/home",
 			"/root",


### PR DESCRIPTION
Those get touched by `useradd` and so we need relabeling if we added any
users or groups.

Closes: #762