### PR TITLE
*: rename ec2 -> aws and gce -> gcp

### DIFF
--- a/doc/operator-notes.md
+++ b/doc/operator-notes.md
@@ -10,9 +10,9 @@ Any HTTP response code less than 500 results in the request being completed, and
 
 Ignition will initially wait 100 milliseconds between failed attempts, and the amount of time to wait doubles for each failed attempt until it reaches 5 seconds.
 
-## EC2 and IAM roles
+## AWS and IAM roles
 
-Ignition has support for fetching files over the S3 protocol. When Ignition is running in EC2, it supports using the IAM role given to the EC2 instance to fetch protected assets from S3. If IAM credentials are not successfully fetched, Ignition will attempt to fetch the file with no credentials.
+Ignition has support for fetching files over the S3 protocol. When Ignition is running in Amazon EC2, it supports using the IAM role given to the EC2 instance to fetch protected assets from S3. If IAM credentials are not successfully fetched, Ignition will attempt to fetch the file with no credentials.
 
 
 ## Filesystem-Reuse Semantics

--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -4,10 +4,10 @@ Ignition is currently only supported for the following platforms:
 
 * [Bare Metal] - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config.
 * [PXE] - Use the `ignition.config.url` and first boot kernel parameters to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config.
-* [Amazon EC2] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
+* [Amazon Web Services] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
 * [VMware] - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
-* [Google Compute Engine] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
+* [Google Compute Platform] - Ignition will read its configuration from the instance metadata entry named "user-data". SSH keys are handled by coreos-metadata.
 * [Packet] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [QEMU] - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device.
 * [DigitalOcean] - Ignition will read its configuration from the droplet userdata. SSH keys and network configuration are handled by coreos-metadata.
@@ -16,10 +16,10 @@ Ignition is under active development so expect this list to expand in the coming
 
 [Bare Metal]: https://github.com/coreos/docs/blob/master/os/installing-to-disk.md
 [PXE]: https://github.com/coreos/docs/blob/master/os/booting-with-pxe.md
-[Amazon EC2]: https://github.com/coreos/docs/blob/master/os/booting-on-ec2.md
+[Amazon Web Services]: https://github.com/coreos/docs/blob/master/os/booting-on-ec2.md
 [Microsoft Azure]: https://github.com/coreos/docs/blob/master/os/booting-on-azure.md
 [VMware]: https://github.com/coreos/docs/blob/master/os/booting-on-vmware.md
-[Google Compute Engine]: https://github.com/coreos/docs/blob/master/os/booting-on-google-compute-engine.md
+[Google Compute Platform]: https://github.com/coreos/docs/blob/master/os/booting-on-google-compute-engine.md
 [Packet]: https://github.com/coreos/docs/blob/master/os/booting-on-packet.md
 [QEMU]: https://github.com/qemu/qemu/blob/d75aa4372f0414c9960534026a562b0302fcff29/docs/specs/fw_cfg.txt
 [DigitalOcean]: https://github.com/coreos/docs/blob/master/os/booting-on-digitalocean.md

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -19,12 +19,12 @@ import (
 
 	"github.com/coreos/ignition/internal/log"
 	"github.com/coreos/ignition/internal/providers"
+	"github.com/coreos/ignition/internal/providers/aws"
 	"github.com/coreos/ignition/internal/providers/azure"
 	"github.com/coreos/ignition/internal/providers/cloudstack"
 	"github.com/coreos/ignition/internal/providers/digitalocean"
-	"github.com/coreos/ignition/internal/providers/ec2"
 	"github.com/coreos/ignition/internal/providers/file"
-	"github.com/coreos/ignition/internal/providers/gce"
+	"github.com/coreos/ignition/internal/providers/gcp"
 	"github.com/coreos/ignition/internal/providers/noop"
 	"github.com/coreos/ignition/internal/providers/openstack"
 	"github.com/coreos/ignition/internal/providers/packet"
@@ -94,13 +94,19 @@ func init() {
 		fetch: openstack.FetchConfig,
 	})
 	configs.Register(Config{
+		name:       "aws",
+		fetch:      aws.FetchConfig,
+		newFetcher: aws.NewFetcher,
+	})
+	// FIXME: compatibility alias; delete after a transition period
+	configs.Register(Config{
 		name:       "ec2",
-		fetch:      ec2.FetchConfig,
-		newFetcher: ec2.NewFetcher,
+		fetch:      aws.FetchConfig,
+		newFetcher: aws.NewFetcher,
 	})
 	configs.Register(Config{
-		name:  "gce",
-		fetch: gce.FetchConfig,
+		name:  "gcp",
+		fetch: gcp.FetchConfig,
 	})
 	configs.Register(Config{
 		name:   "packet",

--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The ec2 provider fetches a remote configuration from the ec2 user-data
+// The aws provider fetches a remote configuration from the EC2 user-data
 // metadata service URL.
 
-package ec2
+package aws
 
 import (
 	"net/url"
@@ -58,7 +58,7 @@ func NewFetcher(l *log.Logger) (resource.Fetcher, error) {
 	}
 	sess.Config.Credentials = ec2rolecreds.NewCredentials(sess)
 
-	// Determine the partition and region this ec2 is in
+	// Determine the partition and region this instance is in
 	regionHint, err := ec2metadata.New(sess).Region()
 	if err != nil {
 		regionHint = "us-east-1"

--- a/internal/providers/gcp/gcp.go
+++ b/internal/providers/gcp/gcp.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The gce provider fetches a remote configuration from the gce user-data
+// The gcp provider fetches a remote configuration from the GCE user-data
 // metadata service URL.
 
-package gce
+package gcp
 
 import (
 	"net/url"

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -73,7 +73,7 @@ type Fetcher struct {
 	// used to set credentials.
 	AWSSession *session.Session
 
-	// The region where the EC2 machine trying to fetch is.
+	// The region where the AWS machine trying to fetch is.
 	// This is used as a hint to fetch the S3 bucket from the right partition and region.
 	S3RegionHint string
 }


### PR DESCRIPTION
Consistently use the name of the cloud platform rather than of its compute service.

Temporarily accept `ec2` as a compatibility alias for `aws` to ease migration.

Not for backport to `spec2x`.

https://github.com/coreos/fedora-coreos-tracker/issues/162