### PR TITLE
Fix configspec link to remove `-experimental` in docs

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -52,7 +52,7 @@ When Ignition enables systemd services, it doesn't directly create the symlinks 
 Ignition is not typically run more than once during a machine's lifetime in a given role, so this situation requiring manual systemd intervention does not commonly arise.
 
 [conditions]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionArchitecture=
-[configspec]: configuration-v3_0-experimental.md
+[configspec]: configuration-v3_0.md
 [examples]: examples.md
 [mime]: http://www.iana.org/assignments/media-types/application/vnd.coreos.ignition+json
 [platforms]: supported-platforms.md


### PR DESCRIPTION
Just a small change to fix a link to a file that was recently renamed