### PR TITLE
platform: drop compat alias for "ec2" platform ID

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -98,12 +98,6 @@ func init() {
 		fetch:      aws.FetchConfig,
 		newFetcher: aws.NewFetcher,
 	})
-	// FIXME: compatibility alias; delete after a transition period
-	configs.Register(Config{
-		name:       "ec2",
-		fetch:      aws.FetchConfig,
-		newFetcher: aws.NewFetcher,
-	})
 	configs.Register(Config{
 		name:  "gcp",
 		fetch: gcp.FetchConfig,


### PR DESCRIPTION
Probably hold for a bit and then merge before 2.0.0 final.