### PR TITLE
config/v3_0: disallow overwrite and nil source

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -42,7 +42,7 @@ var (
 	ErrPartitionNumbersCollide   = errors.New("partition numbers collide")
 	ErrPartitionsOverlap         = errors.New("partitions overlap")
 	ErrPartitionsMisaligned      = errors.New("partitions misaligned")
-	ErrAppendAndOverwrite        = errors.New("cannot set both append and overwrite to true")
+	ErrOverwriteAndNilSource     = errors.New("overwrite must be false if source is unspecified")
 	ErrFilesystemInvalidFormat   = errors.New("invalid filesystem format")
 	ErrLabelNeedsFormat          = errors.New("filesystem must specify format if label is specified")
 	ErrFormatNilWithOthers       = errors.New("format cannot be empty when path, label, uuid, or options are specified")

--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -43,6 +43,7 @@ var (
 	ErrPartitionsOverlap         = errors.New("partitions overlap")
 	ErrPartitionsMisaligned      = errors.New("partitions misaligned")
 	ErrOverwriteAndNilSource     = errors.New("overwrite must be false if source is unspecified")
+	ErrVerificationAndNilSource  = errors.New("source must be specified if verification is specified")
 	ErrFilesystemInvalidFormat   = errors.New("invalid filesystem format")
 	ErrLabelNeedsFormat          = errors.New("filesystem must specify format if label is specified")
 	ErrFormatNilWithOthers       = errors.New("format cannot be empty when path, label, uuid, or options are specified")

--- a/config/util/helpers.go
+++ b/config/util/helpers.go
@@ -19,13 +19,6 @@ func IntToPtr(x int) *int {
 }
 
 func StrToPtr(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
-}
-
-func StrToPtrStrict(s string) *string {
 	return &s
 }
 

--- a/config/v3_0/types/file.go
+++ b/config/v3_0/types/file.go
@@ -47,9 +47,16 @@ func (fc FileContents) ValidateCompression() (r report.Report) {
 	return
 }
 
-func (f File) ValidateContents() (r report.Report) {
+func (f File) ValidateOverwrite() (r report.Report) {
 	if f.Overwrite != nil && *f.Overwrite && f.Contents.Source == nil {
 		r.AddOnError(errors.ErrOverwriteAndNilSource)
+	}
+	return
+}
+
+func (fc FileContents) ValidateVerification() (r report.Report) {
+	if fc.Verification.Hash != nil && fc.Source == nil {
+		r.AddOnError(errors.ErrVerificationAndNilSource)
 	}
 	return
 }

--- a/config/v3_0/types/file.go
+++ b/config/v3_0/types/file.go
@@ -47,6 +47,13 @@ func (fc FileContents) ValidateCompression() (r report.Report) {
 	return
 }
 
+func (f File) ValidateContents() (r report.Report) {
+	if f.Overwrite != nil && *f.Overwrite && f.Contents.Source == nil {
+		r.AddOnError(errors.ErrOverwriteAndNilSource)
+	}
+	return
+}
+
 func (fc FileContents) ValidateSource() (r report.Report) {
 	if fc.Source == nil {
 		return

--- a/config/v3_0/types/file_test.go
+++ b/config/v3_0/types/file_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/config/shared/errors"
+	"github.com/coreos/ignition/config/util"
+	"github.com/coreos/ignition/config/validate/report"
+)
+
+func TestFileValidateOverwrite(t *testing.T) {
+	tests := []struct {
+		in  File
+		out error
+	}{
+		{
+			in:  File{},
+			out: nil,
+		},
+		{
+			in: File{
+				Node: Node{
+					Overwrite: util.BoolToPtr(true),
+				},
+			},
+			out: errors.ErrOverwriteAndNilSource,
+		},
+		{
+			in: File{
+				Node: Node{
+					Overwrite: util.BoolToPtr(true),
+				},
+				FileEmbedded1: FileEmbedded1{
+					Contents: FileContents{
+						Source: util.StrToPtr(""),
+					},
+				},
+			},
+			out: nil,
+		},
+		{
+			in: File{
+				Node: Node{
+					Overwrite: util.BoolToPtr(true),
+				},
+				FileEmbedded1: FileEmbedded1{
+					Contents: FileContents{
+						Source: util.StrToPtr("http://example.com"),
+					},
+				},
+			},
+			out: nil,
+		},
+	}
+
+	for i, test := range tests {
+		r := test.in.ValidateOverwrite()
+		expected := report.ReportFromError(test.out, report.EntryError)
+		if !reflect.DeepEqual(expected, r) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, expected, r)
+		}
+	}
+}
+
+func TestFileContentsValidate(t *testing.T) {
+	tests := []struct {
+		in  FileContents
+		out error
+	}{
+		{
+			in:  FileContents{},
+			out: nil,
+		},
+		{
+			in: FileContents{
+				Source: util.StrToPtr(""),
+			},
+			out: nil,
+		},
+		{
+			in: FileContents{
+				Source: util.StrToPtr(""),
+				Verification: Verification{
+					Hash: util.StrToPtr(""),
+				},
+			},
+			out: nil,
+		},
+		{
+			in: FileContents{
+				Verification: Verification{
+					Hash: util.StrToPtr(""),
+				},
+			},
+			out: errors.ErrVerificationAndNilSource,
+		},
+	}
+
+	for i, test := range tests {
+		r := test.in.ValidateVerification()
+		expected := report.ReportFromError(test.out, report.EntryError)
+		if !reflect.DeepEqual(expected, r) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, expected, r)
+		}
+	}
+}

--- a/doc/configuration-v3_0.md
+++ b/doc/configuration-v3_0.md
@@ -1,7 +1,5 @@
 # Configuration Specification v3.0.0 #
 
-*NOTE*: Deprecated fields may be removed without notice until the stable Ignition 2.0.0 release.
-
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **ignition** (object): metadata about the configuration itself.
@@ -53,10 +51,10 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
   * **_files_** (list of objects): the list of files to be written.
     * **path** (string): the absolute path to the file.
-    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. Defaults to false.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `source` must be specified if `overwrite` is true. Defaults to false.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
     * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`

--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -117,7 +117,7 @@ func CBufToGoStr(s [C.PART_INFO_BUF_SIZE]C.char) string {
 }
 
 func CBufToGoPtr(s [C.PART_INFO_BUF_SIZE]C.char) *string {
-	return util.StrToPtrStrict(CBufToGoStr(s))
+	return util.StrToPtr(CBufToGoStr(s))
 }
 
 // DumpPartitionTable returns a list of all partitions on device (e.g. /dev/vda). The list

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -326,10 +326,3 @@ func (u Util) getGroupID(name string) (int, error) {
 	}
 	return int(gid), nil
 }
-
-func (u Util) DeletePathOnOverwrite(n types.Node) error {
-	if n.Overwrite == nil || !*n.Overwrite {
-		return nil
-	}
-	return os.RemoveAll(n.Path)
-}

--- a/tests/positive/files/link.go
+++ b/tests/positive/files/link.go
@@ -249,7 +249,8 @@ func WriteOverSymlink() types.Test {
 	    "files": [{
 	      "path": "/etc/file",
 	      "mode": 420,
-	      "overwrite": true
+	      "overwrite": true,
+	      "contents": { "source": "" }
 	    }]
 	  }
 	}`
@@ -311,7 +312,8 @@ func WriteOverBrokenSymlink() types.Test {
 	    "files": [{
 	      "path": "/etc/file",
 	      "mode": 420,
-	      "overwrite": true
+	      "overwrite": true,
+	      "contents": { "source": "" }
 	    }]
 	  }
 	}`


### PR DESCRIPTION
Disallow setting storage.files.overwrite = true when
storage.files.contents.source is unspecified (nil). If a user wants to
force an file to be empty they should set source to empty string.