### PR TITLE
platform: drop "pxe"

### DIFF
--- a/doc/supported-platforms.md
+++ b/doc/supported-platforms.md
@@ -3,7 +3,6 @@
 Ignition is currently only supported for the following platforms:
 
 * [Bare Metal] - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config.
-* [PXE] - Use the `ignition.config.url` and first boot kernel parameters to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, or `s3://` schemes to specify a remote config.
 * [Amazon Web Services] - Ignition will read its configuration from the instance userdata. SSH keys are handled by coreos-metadata.
 * [Microsoft Azure] - Ignition will read its configuration from the custom data provided to the instance. SSH keys are handled by the Azure Linux Agent.
 * [VMware] - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
@@ -15,7 +14,6 @@ Ignition is currently only supported for the following platforms:
 Ignition is under active development so expect this list to expand in the coming months.
 
 [Bare Metal]: https://github.com/coreos/docs/blob/master/os/installing-to-disk.md
-[PXE]: https://github.com/coreos/docs/blob/master/os/booting-with-pxe.md
 [Amazon Web Services]: https://github.com/coreos/docs/blob/master/os/booting-on-ec2.md
 [Microsoft Azure]: https://github.com/coreos/docs/blob/master/os/booting-on-azure.md
 [VMware]: https://github.com/coreos/docs/blob/master/os/booting-on-vmware.md

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -114,10 +114,6 @@ func init() {
 		status: packet.PostStatus,
 	})
 	configs.Register(Config{
-		name:  "pxe",
-		fetch: noop.FetchConfig,
-	})
-	configs.Register(Config{
 		name:  "virtualbox",
 		fetch: virtualbox.FetchConfig,
 	})


### PR DESCRIPTION
PXE is a boot mechanism, not a platform; for example, VMware instances can be PXE-booted.  We now have a `metal` platform ID which behaves the same as PXE (i.e., it's a no-op) and should be used in the common case.