### PR TITLE
Makefile: drop go mod tidy from make vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,3 @@ all:
 .PHONY: vendor
 vendor:
 	@go mod vendor
-	@go mod tidy


### PR DESCRIPTION
While `go mod tidy` is toted as pruning extraneous dependencies it turns
out that it can bump pinned dependencies. Remove it from the Makefile to
just run go mod vendor which does not do that.