### PR TITLE
[spec2x] oem: add metal oem

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -163,6 +163,10 @@ func init() {
 		name:  "file",
 		fetch: file.FetchConfig,
 	})
+	configs.Register(Config{
+		name:  "metal",
+		fetch: noop.FetchConfig,
+	})
 }
 
 func Get(name string) (config Config, ok bool) {


### PR DESCRIPTION
Add oem for use by bare metal. It does nothing. This allows setting the
oem-id to "metal" for other projects and having Ignition not fail.

(cherry picked from commit a060f2a867ae741a9d27506c0565cf581cf0dc95)