### PR TITLE
config/*/types/storage: fail on hardlinked dirs

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -38,6 +38,7 @@ var (
 	ErrFileUsedSymlink           = errors.New("file path includes link in config")
 	ErrDirectoryUsedSymlink      = errors.New("directory path includes link in config")
 	ErrLinkUsedSymlink           = errors.New("link path includes link in config")
+	ErrHardLinkToDirectory       = errors.New("hard link target is a directory")
 	ErrDiskDeviceRequired        = errors.New("disk device is required")
 	ErrPartitionNumbersCollide   = errors.New("partition numbers collide")
 	ErrPartitionsOverlap         = errors.New("partitions overlap")

--- a/config/v3_0/types/storage.go
+++ b/config/v3_0/types/storage.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -48,6 +49,18 @@ func (s Storage) Validate() (r report.Report) {
 		for _, l2 := range s.Links {
 			if strings.HasPrefix(l1.Path, l2.Path+"/") {
 				r.AddOnError(errors.ErrLinkUsedSymlink)
+			}
+		}
+		if l1.Hard == nil || !*l1.Hard {
+			continue
+		}
+		target := filepath.Clean(l1.Target)
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(l1.Path, l1.Target)
+		}
+		for _, d := range s.Directories {
+			if target == d.Path {
+				r.AddOnError(errors.ErrHardLinkToDirectory)
 			}
 		}
 	}

--- a/config/v3_0/types/storage_test.go
+++ b/config/v3_0/types/storage_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/validate/report"
 )
 
@@ -109,6 +110,25 @@ func TestStorageValidate(t *testing.T) {
 				},
 			},
 			out: nil,
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{Path: "/quux"},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: "/foo/bar",
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+				Directories: []Directory{
+					{
+						Node: Node{Path: "/foo/bar"},
+					},
+				},
+			},
+			out: errors.ErrHardLinkToDirectory,
 		},
 	}
 

--- a/config/v3_1_experimental/types/storage.go
+++ b/config/v3_1_experimental/types/storage.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -48,6 +49,18 @@ func (s Storage) Validate() (r report.Report) {
 		for _, l2 := range s.Links {
 			if strings.HasPrefix(l1.Path, l2.Path+"/") {
 				r.AddOnError(errors.ErrLinkUsedSymlink)
+			}
+		}
+		if l1.Hard == nil || !*l1.Hard {
+			continue
+		}
+		target := filepath.Clean(l1.Target)
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(l1.Path, l1.Target)
+		}
+		for _, d := range s.Directories {
+			if target == d.Path {
+				r.AddOnError(errors.ErrHardLinkToDirectory)
 			}
 		}
 	}

--- a/config/v3_1_experimental/types/storage_test.go
+++ b/config/v3_1_experimental/types/storage_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/validate/report"
 )
 
@@ -109,6 +110,25 @@ func TestStorageValidate(t *testing.T) {
 				},
 			},
 			out: nil,
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{Path: "/quux"},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: "/foo/bar",
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+				Directories: []Directory{
+					{
+						Node: Node{Path: "/foo/bar"},
+					},
+				},
+			},
+			out: errors.ErrHardLinkToDirectory,
 		},
 	}
 

--- a/tests/positive/files/link.go
+++ b/tests/positive/files/link.go
@@ -26,6 +26,7 @@ func init() {
 	register.Register(register.PositiveTest, ForceHardLinkCreation())
 	register.Register(register.PositiveTest, WriteOverSymlink())
 	register.Register(register.PositiveTest, WriteOverBrokenSymlink())
+	register.Register(register.PositiveTest, CreateHardLinkToSymlink())
 }
 
 func CreateHardLinkOnRoot() types.Test {
@@ -334,6 +335,57 @@ func WriteOverBrokenSymlink() types.Test {
 			},
 			Contents: "",
 			Mode:     420,
+		},
+	})
+	configMinVersion := "3.0.0"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+func CreateHardLinkToSymlink() types.Test {
+	name := "Create a Hard Link on the Root Filesystem"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": { "version": "$version" },
+	  "storage": {
+	    "links": [{
+	      "path": "/foo",
+	      "target": "/bar",
+	      "hard": true
+	    }]
+	  }
+	}`
+	in[0].Partitions.AddLinks("ROOT", []types.Link{
+		{
+			Node: types.Node{
+				Directory: "/",
+				Name:      "bar",
+			},
+			Target: "nonexistent",
+		},
+	})
+	out[0].Partitions.AddLinks("ROOT", []types.Link{
+		{
+			Node: types.Node{
+				Directory: "/",
+				Name:      "bar",
+			},
+			Target: "nonexistent",
+		},
+		{
+			Node: types.Node{
+				Directory: "/",
+				Name:      "foo",
+			},
+			Target: "/bar",
+			Hard:   true,
 		},
 	})
 	configMinVersion := "3.0.0"

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -196,7 +196,7 @@ func validatePartitionNodes(t *testing.T, ctx context.Context, partition *types.
 	}
 	for _, node := range partition.RemovedNodes {
 		path := filepath.Join(partition.MountPath, node.Directory, node.Name)
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
 			t.Error("Node was expected to be removed and is present!", path)
 		}
 	}
@@ -213,7 +213,7 @@ func validateFilesDirectoriesAndLinks(t *testing.T, ctx context.Context, expecte
 
 func validateFile(t *testing.T, partition *types.Partition, file types.File) {
 	path := filepath.Join(partition.MountPath, file.Node.Directory, file.Node.Name)
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		t.Errorf("Error stat'ing file %s: %v", path, err)
 		return
@@ -238,7 +238,7 @@ func validateFile(t *testing.T, partition *types.Partition, file types.File) {
 
 func validateDirectory(t *testing.T, partition *types.Partition, dir types.Directory) {
 	path := filepath.Join(partition.MountPath, dir.Node.Directory, dir.Node.Name)
-	dirInfo, err := os.Stat(path)
+	dirInfo, err := os.Lstat(path)
 	if err != nil {
 		t.Errorf("Error stat'ing directory %s: %v", path, err)
 		return
@@ -259,7 +259,7 @@ func validateLink(t *testing.T, partition *types.Partition, link types.Link) {
 	}
 	if link.Hard {
 		targetPath := filepath.Join(partition.MountPath, link.Target)
-		targetInfo, err := os.Stat(targetPath)
+		targetInfo, err := os.Lstat(targetPath)
 		if err != nil {
 			t.Error("Error stat'ing target \"" + targetPath + "\": " + err.Error())
 			return
@@ -298,7 +298,7 @@ func validateLink(t *testing.T, partition *types.Partition, link types.Link) {
 
 func validateMode(t *testing.T, path string, mode int) {
 	if mode != 0 {
-		fileInfo, err := os.Stat(path)
+		fileInfo, err := os.Lstat(path)
 		if err != nil {
 			t.Error("Error running stat on node", path, err)
 			return


### PR DESCRIPTION
Hardlinks to directories are disallowed, so fail to validate if we know
that we're going to. We could even take this a step further and
blacklist /usr, /etc, /tmp etc but those might be symlinks, which would
be ok, so lets not.

Fixes https://github.com/coreos/ignition/issues/799