### PR TITLE
[spec2x] internal: create dev aliases in /run/ignition/ instead of /

### DIFF
--- a/internal/exec/util/device_alias.go
+++ b/internal/exec/util/device_alias.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	deviceAliasDir      = "/dev_aliases"
+	deviceAliasDir      = "/run/ignition/dev_aliases"
 	retrySymlinkDelay   = 10 * time.Millisecond
 	retrySymlinkTimeout = 30 * time.Second
 	retrySymlinkCount   = int(retrySymlinkTimeout / retrySymlinkDelay)


### PR DESCRIPTION
This is useful while running on immutable host system like
Silverblue where root ('/') directory is immutable

Backported fix in spec2x from master commit 3566041

Signed-off-by: Sinny Kumari <sinny@redhat.com>