### PR TITLE
[spec2x] backport: build*: use --always with git describe

### DIFF
--- a/build
+++ b/build
@@ -9,7 +9,7 @@ GLDFLAGS=${GLDFLAGS:-}
 
 if [ -z ${VERSION+a} ]; then
 	echo "Using version from git..."
-	VERSION=$(git describe --dirty)
+	VERSION=$(git describe --dirty --always)
 fi
 
 GLDFLAGS+="-X github.com/coreos/ignition/internal/version.Raw=${VERSION}"

--- a/build_releases
+++ b/build_releases
@@ -9,7 +9,7 @@ GLDFLAGS=${GLDFLAGS:-}
 
 if [ -z ${VERSION+a} ]; then
 	echo "Using version from git..."
-	VERSION=$(git describe --dirty)
+	VERSION=$(git describe --dirty --always)
 fi
 
 GLDFLAGS+="-X github.com/coreos/ignition/internal/version.Raw=${VERSION}"


### PR DESCRIPTION
git describe --dirty can fail in some cases without --always. This can
cause travis to fail.