### PR TITLE
config/v*: run Node.Validate() as well

### DIFF
--- a/config/v3_0/types/directory.go
+++ b/config/v3_0/types/directory.go
@@ -22,6 +22,7 @@ import (
 )
 
 func (d Directory) Validate(c path.ContextPath) (r report.Report) {
+	r.Merge(d.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(d.Mode))
 	if d.Mode == nil {
 		r.AddOnWarn(c.Append("mode"), errors.ErrDirectoryPermissionsUnset)

--- a/config/v3_0/types/file.go
+++ b/config/v3_0/types/file.go
@@ -22,6 +22,7 @@ import (
 )
 
 func (f File) Validate(c path.ContextPath) (r report.Report) {
+	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
 	if f.Mode == nil {
 		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)

--- a/config/v3_1_experimental/types/directory.go
+++ b/config/v3_1_experimental/types/directory.go
@@ -22,6 +22,7 @@ import (
 )
 
 func (d Directory) Validate(c path.ContextPath) (r report.Report) {
+	r.Merge(d.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(d.Mode))
 	if d.Mode == nil {
 		r.AddOnWarn(c.Append("mode"), errors.ErrDirectoryPermissionsUnset)

--- a/config/v3_1_experimental/types/file.go
+++ b/config/v3_1_experimental/types/file.go
@@ -22,6 +22,7 @@ import (
 )
 
 func (f File) Validate(c path.ContextPath) (r report.Report) {
+	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
 	if f.Mode == nil {
 		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)


### PR DESCRIPTION
Run the node validation as well as the file/directory validation.
Without this the Validate() defined on File and Directory shadow the
definition on Node. It doesn't appear that you can easily isolate them
using reflection either, which is why it should be changed here and not
in vcontext.