### PR TITLE
stages/files: relabel masking symlinks for systemd

### DIFF
--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -50,12 +50,18 @@ func (s *stage) createUnits(config types.Config) error {
 			enabledOneUnit = true
 		}
 		if unit.Mask != nil && *unit.Mask {
+			relabelpath := ""
 			if err := s.Logger.LogOp(
-				func() error { return s.MaskUnit(unit) },
+				func() error {
+					var err error
+					relabelpath, err = s.MaskUnit(unit)
+					return err
+				},
 				"masking unit %q", unit.Name,
 			); err != nil {
 				return err
 			}
+			s.relabel(relabelpath)
 		}
 	}
 	// and relabel the preset file itself if we enabled/disabled something


### PR DESCRIPTION
Change util to return the path of the symlink it wrote when masking
units. Relabel that symlink.

Fixes https://github.com/coreos/ignition/issues/836

Untested, will mark ready when tested.

Will backport to spec2x after merge