### PR TITLE
fix check path mount

### DIFF
--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -66,7 +66,7 @@ func (stage) Name() string {
 func (s stage) Run(config types.Config) error {
 	fss := []types.Filesystem{}
 	for _, fs := range config.Storage.Filesystems {
-		if fs.Path != nil || *fs.Path != "" {
+		if fs.Path != nil && *fs.Path != "" {
 			fss = append(fss, fs)
 		}
 	}


### PR DESCRIPTION
BUGFIX 
Fixed a logical error- we can't check *fs.Path != "" if it's nil.