### PR TITLE
resource/url: update schema version in Accept header

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -54,7 +54,7 @@ var (
 	// config is being fetched
 	ConfigHeaders = http.Header{
 		"Accept-Encoding": []string{"identity"},
-		"Accept":          []string{"application/vnd.coreos.ignition+json; version=2.2.0, application/vnd.coreos.ignition+json; version=1; q=0.5, */*; q=0.1"},
+		"Accept":          []string{"application/vnd.coreos.ignition+json;version=3.0.0, */*;q=0.1"},
 	}
 )
 


### PR DESCRIPTION
This updates the HTTP "Accept" header to prefer v3.0.0 schema configs.

This is already covered by an explicit step in the development guide,
but it looks like we forgot to update the value when stabilizing
latest schema version.

Ref: https://github.com/coreos/ignition/blob/v2.0.1/doc/development.md#marking-an-experimental-spec-as-stable