### PR TITLE
Source build file correctly

### DIFF
--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -10,7 +10,7 @@ GLDFLAGS="-X github.com/coreos/ignition/v2/internal/distro.useraddCmd=useradd-st
 GLDFLAGS+="-X github.com/coreos/ignition/v2/internal/distro.usermodCmd=usermod-stub "
 GLDFLAGS+="-X github.com/coreos/ignition/v2/internal/distro.blackboxTesting=true "
 
-. build
+. ./build
 
 PKG=$(go list ./tests/)
 


### PR DESCRIPTION
If a file to be sourced by a shell script does not contain a slash it will be
searched in PATH first. This is not intended here, the build file in the
local directory is always supposed to used.

Discovered on an openSUSE installation, where `build` is an actual command
used by the Open Build Service - resulting in obscure error messages after
that file was sourced.