### PR TITLE
Add a `fetch` stage

### DIFF
--- a/internal/exec/stages/fetch/fetch.go
+++ b/internal/exec/stages/fetch/fetch.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The storage stage is responsible for partitioning disks, creating RAID
+// arrays, formatting partitions, writing files, writing systemd units, and
+// writing network units.
+
+package disks
+
+import (
+	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
+	"github.com/coreos/ignition/v2/internal/exec/stages"
+	"github.com/coreos/ignition/v2/internal/exec/util"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/resource"
+)
+
+const (
+	name = "fetch"
+)
+
+func init() {
+	stages.Register(creator{})
+}
+
+type creator struct{}
+
+func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher) stages.Stage {
+	return &stage{
+		Util: util.Util{
+			DestDir: root,
+			Logger:  logger,
+		},
+	}
+}
+
+func (creator) Name() string {
+	return name
+}
+
+type stage struct {
+	util.Util
+}
+
+func (stage) Name() string {
+	return name
+}
+
+func (s stage) Run(_ types.Config) error {
+	// Nothing - all we do is fetch and allow anything else in the initramfs to run
+	s.Logger.Info("fetch complete")
+	return nil
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec"
 	"github.com/coreos/ignition/v2/internal/exec/stages"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/disks"
+	_ "github.com/coreos/ignition/v2/internal/exec/stages/fetch"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/files"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/mount"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/umount"


### PR DESCRIPTION
This stage just triggers the internal code which fetches the
config and writes `/run/ignition.json`; from there it'd be picked
up by later stages the way it was implicitly before.

This is prep for adding support for redeploying the rootfs for
Fedora CoreOS; we need to have a separate process determine
whether the rootfs is being replaced, and if so do a save/restore
across `ignition-disks.service`.

See: https://github.com/coreos/ignition-dracut/pull/107