### PR TITLE
mount: Skip LABEL=root filesystems

### DIFF
--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -102,6 +102,11 @@ func (s stage) mountFs(fs types.Filesystem) error {
 		return nil
 	}
 
+	// This one is mounted by sysroot.mount in the initramfs already.
+	if *fs.Label == "root" {
+		return nil
+	}
+
 	// mount paths shouldn't include symlinks or other non-directories so we can use filepath.Join()
 	// instead of s.JoinPath(). Check that the resulting path is composed of only directories.
 	path := filepath.Join(s.DestDir, *fs.Path)

--- a/internal/exec/stages/umount/umount.go
+++ b/internal/exec/stages/umount/umount.go
@@ -81,6 +81,12 @@ func (s stage) umountFs(fs types.Filesystem) error {
 	if fs.Format != nil && *fs.Format == "swap" {
 		return nil
 	}
+
+	// This one is mounted by sysroot.mount in the initramfs already.
+	if *fs.Label == "root" {
+		return nil
+	}
+
 	path, err := s.JoinPath(*fs.Path)
 	if err != nil {
 		return err


### PR DESCRIPTION
Part of supporting overriding the rootfs.  We don't want to try
to mount this, as it will already have been taken care of by
the initramfs.  Similarly for unmount.