### PR TITLE
Clean up url handling

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -134,13 +134,13 @@ func (f *Fetcher) FetchToBuffer(u url.URL, opts FetchOptions) ([]byte, error) {
 func (f *Fetcher) Fetch(u url.URL, dest *os.File, opts FetchOptions) error {
 	switch u.Scheme {
 	case "http", "https":
-		return f.FetchFromHTTP(u, dest, opts)
+		return f.fetchFromHTTP(u, dest, opts)
 	case "tftp":
-		return f.FetchFromTFTP(u, dest, opts)
+		return f.fetchFromTFTP(u, dest, opts)
 	case "data":
-		return f.FetchFromDataURL(u, dest, opts)
+		return f.fetchFromDataURL(u, dest, opts)
 	case "s3":
-		return f.FetchFromS3(u, dest, opts)
+		return f.fetchFromS3(u, dest, opts)
 	case "":
 		return nil
 	default:
@@ -150,7 +150,7 @@ func (f *Fetcher) Fetch(u url.URL, dest *os.File, opts FetchOptions) error {
 
 // FetchFromTFTP fetches a resource from u via TFTP into dest, returning an
 // error if one is encountered.
-func (f *Fetcher) FetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) error {
+func (f *Fetcher) fetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) error {
 	if !strings.ContainsRune(u.Host, ':') {
 		u.Host = u.Host + ":69"
 	}
@@ -212,7 +212,7 @@ func (f *Fetcher) FetchFromTFTP(u url.URL, dest *os.File, opts FetchOptions) err
 
 // FetchFromHTTP fetches a resource from u via HTTP(S) into dest, returning an
 // error if one is encountered.
-func (f *Fetcher) FetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) error {
+func (f *Fetcher) fetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) error {
 	// for the case when "config is not valid"
 	// this if necessary if not spawned through kola (e.g. Packet Dashboard)
 	if f.client == nil {
@@ -248,7 +248,7 @@ func (f *Fetcher) FetchFromHTTP(u url.URL, dest *os.File, opts FetchOptions) err
 
 // FetchFromDataURL writes the data stored in the dataurl u into dest, returning
 // an error if one is encountered.
-func (f *Fetcher) FetchFromDataURL(u url.URL, dest *os.File, opts FetchOptions) error {
+func (f *Fetcher) fetchFromDataURL(u url.URL, dest *os.File, opts FetchOptions) error {
 	if opts.Compression != "" {
 		return ErrCompressionUnsupported
 	}
@@ -264,7 +264,7 @@ func (f *Fetcher) FetchFromDataURL(u url.URL, dest *os.File, opts FetchOptions) 
 // dest, returning an error if one is encountered. It will attempt to acquire
 // IAM credentials from the EC2 metadata service, and if this fails will attempt
 // to fetch the object with anonymous credentials.
-func (f *Fetcher) FetchFromS3(u url.URL, dest *os.File, opts FetchOptions) error {
+func (f *Fetcher) fetchFromS3(u url.URL, dest *os.File, opts FetchOptions) error {
 	if opts.Compression != "" {
 		return ErrCompressionUnsupported
 	}


### PR DESCRIPTION
Found that Ignition was using tmpfiles when fetching to a buffer while starting in on the multipart work. Minor refactoring to clean that up as prep for the multipart stuff.