### PR TITLE
Clean up user/group handling

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -33,9 +33,7 @@ var (
 	systemConfigDir = "/usr/lib/ignition"
 
 	// Helper programs
-	chrootCmd   = "chroot"
 	groupaddCmd = "groupadd"
-	idCmd       = "id"
 	mdadmCmd    = "mdadm"
 	mountCmd    = "mount"
 	sgdiskCmd   = "sgdisk"
@@ -71,9 +69,7 @@ func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
 func KernelCmdlinePath() string { return kernelCmdlinePath }
 func SystemConfigDir() string   { return fromEnv("SYSTEM_CONFIG_DIR", systemConfigDir) }
 
-func ChrootCmd() string     { return chrootCmd }
 func GroupaddCmd() string   { return groupaddCmd }
-func IdCmd() string         { return idCmd }
 func MdadmCmd() string      { return mdadmCmd }
 func MountCmd() string      { return mountCmd }
 func SgdiskCmd() string     { return sgdiskCmd }

--- a/internal/exec/util/user_group_lookup.c
+++ b/internal/exec/util/user_group_lookup.c
@@ -62,8 +62,14 @@ static int user_lookup_fn(lookup_ctxt_t *ctxt) {
 		goto out_err;
 	}
 
-	if(getpwnam_r(ctxt->name, &p, buf, sizeof(buf), &pptr) != 0 || !pptr) {
+	if(getpwnam_r(ctxt->name, &p, buf, sizeof(buf), &pptr) != 0) {
 		goto out_err;
+	}
+
+	if (!pptr) {
+		// successfully found nothing
+		ctxt->res->name = NULL;
+		return 0;
 	}
 
 	if(!(ctxt->res->name = strdup(p.pw_name))) {
@@ -98,8 +104,14 @@ static int group_lookup_fn(lookup_ctxt_t *ctxt) {
 		goto out_err;
 	}
 
-	if(getgrnam_r(ctxt->name, &g, buf, sizeof(buf), &gptr) != 0 || !gptr) {
+	if(getgrnam_r(ctxt->name, &g, buf, sizeof(buf), &gptr) != 0) {
 		goto out_err;
+	}
+
+	if (!gptr) {
+		// successfully found nothing
+		ctxt->res->name = NULL;
+		return 0;
 	}
 
 	if(!(ctxt->res->name = strdup(g.gr_name))) {

--- a/internal/exec/util/user_group_lookup.go
+++ b/internal/exec/util/user_group_lookup.go
@@ -37,7 +37,7 @@ func (u Util) userLookup(name string) (*user.User, error) {
 	}
 
 	if res.name == nil {
-		return nil, fmt.Errorf("user %q not found", name)
+		return nil, user.UnknownUserError(fmt.Sprintf("user %q not found", name))
 	}
 
 	homedir, err := u.JoinPath(C.GoString(res.home))
@@ -67,7 +67,7 @@ func (u Util) groupLookup(name string) (*user.Group, error) {
 	}
 
 	if res.name == nil {
-		return nil, fmt.Errorf("user %q not found", name)
+		return nil, user.UnknownGroupError(fmt.Sprintf("group %q not found", name))
 	}
 
 	grp := &user.Group{


### PR DESCRIPTION
There's a few places where we work around not having a convenient chroot helper. Add one and use it in one place as an example.