### PR TITLE
config/v3*: don't warn on unset mode if appending

### DIFF
--- a/config/v3_0/types/file.go
+++ b/config/v3_0/types/file.go
@@ -24,7 +24,7 @@ import (
 func (f File) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
-	if f.Mode == nil {
+	if f.Mode == nil && f.Contents.Source != nil {
 		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)
 	}
 	r.AddOnError(c.Append("overwrite"), f.validateOverwrite())

--- a/config/v3_1_experimental/types/file.go
+++ b/config/v3_1_experimental/types/file.go
@@ -24,7 +24,7 @@ import (
 func (f File) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
-	if f.Mode == nil {
+	if f.Mode == nil && f.Contents.Source != nil {
 		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)
 	}
 	r.AddOnError(c.Append("overwrite"), f.validateOverwrite())


### PR DESCRIPTION
Don't warn if a file's mode is unset if there are entries in the append
lists. The user is most likely writing to an existing file and does not
want to change mode.

Fixes https://github.com/coreos/ignition/issues/843