### PR TITLE
Implement mount option support

### DIFF
--- a/config/v3_1_experimental/schema/ignition.json
+++ b/config/v3_1_experimental/schema/ignition.json
@@ -244,6 +244,12 @@
                 "type": "string"
               }
             },
+            "mountOptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "wipeFilesystem": {
               "type": ["boolean", "null"]
             },

--- a/config/v3_1_experimental/translate/translate.go
+++ b/config/v3_1_experimental/translate/translate.go
@@ -20,6 +20,19 @@ import (
 	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
 )
 
+func translateFilesystem(old old_types.Filesystem) (ret types.Filesystem) {
+	// use a new translator so we don't recurse infintitely
+	tr := translate.NewTranslator()
+	tr.Translate(&old.Device, &ret.Device)
+	tr.Translate(&old.Format, &ret.Format)
+	tr.Translate(&old.Label, &ret.Label)
+	tr.Translate(&old.Options, &ret.Options)
+	tr.Translate(&old.Path, &ret.Path)
+	tr.Translate(&old.UUID, &ret.UUID)
+	tr.Translate(&old.WipeFilesystem, &ret.WipeFilesystem)
+	return
+}
+
 func translateIgnition(old old_types.Ignition) (ret types.Ignition) {
 	// use a new translator so we don't recurse infintitely
 	tr := translate.NewTranslator()
@@ -33,6 +46,7 @@ func translateIgnition(old old_types.Ignition) (ret types.Ignition) {
 func Translate(old old_types.Config) (ret types.Config) {
 	tr := translate.NewTranslator()
 	tr.AddCustomTranslator(translateIgnition)
+	tr.AddCustomTranslator(translateFilesystem)
 	tr.Translate(&old, &ret)
 	return
 }

--- a/config/v3_1_experimental/types/filesystem.go
+++ b/config/v3_1_experimental/types/filesystem.go
@@ -28,7 +28,8 @@ func (f Filesystem) Key() string {
 
 func (f Filesystem) IgnoreDuplicates() map[string]struct{} {
 	return map[string]struct{}{
-		"Options": {},
+		"Options":      {},
+		"MountOptions": {},
 	}
 }
 

--- a/config/v3_1_experimental/types/schema.go
+++ b/config/v3_1_experimental/types/schema.go
@@ -62,6 +62,7 @@ type Filesystem struct {
 	Device         string             `json:"device"`
 	Format         *string            `json:"format,omitempty"`
 	Label          *string            `json:"label,omitempty"`
+	MountOptions   []MountOption      `json:"mountOptions,omitempty"`
 	Options        []FilesystemOption `json:"options,omitempty"`
 	Path           *string            `json:"path,omitempty"`
 	UUID           *string            `json:"uuid,omitempty"`
@@ -94,6 +95,8 @@ type LinkEmbedded1 struct {
 	Hard   *bool  `json:"hard,omitempty"`
 	Target string `json:"target"`
 }
+
+type MountOption string
 
 type NoProxyItem string
 

--- a/doc/configuration-v3_1-experimental.md
+++ b/doc/configuration-v3_1-experimental.md
@@ -55,6 +55,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_label_** (string): the label of the filesystem.
     * **_uuid_** (string): the uuid of the filesystem.
     * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_mountOptions_** (list of strings): any special options to be passed to the mount command.
   * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
     * **path** (string): the absolute path to the file.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `source` must be specified if `overwrite` is true. Defaults to false.

--- a/tests/negative/filesystems/mount_filesystem.go
+++ b/tests/negative/filesystems/mount_filesystem.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystems
+
+import (
+	"github.com/coreos/ignition/v2/tests/register"
+	"github.com/coreos/ignition/v2/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, MountWithInvalidOptions())
+}
+
+func MountWithInvalidOptions() types.Test {
+	name := "filesystem.mount.invalidoptions"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "OEM",
+			Substitution: "$DEVICE",
+		},
+	}
+	config := `{
+		"ignition": {"version": "$version"},
+		"storage": {
+			"filesystems": [
+			{
+				"path": "/tmp0",
+				"device": "$DEVICE",
+				"wipeFilesystem": false,
+				"format": "ext4",
+				"mountOptions": [
+					"doesnotexist"
+				]
+			}]
+		}
+	}`
+	configMinVersion := "3.1.0-experimental"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}

--- a/tests/positive/filesystems/mount_filesystem.go
+++ b/tests/positive/filesystems/mount_filesystem.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystems
+
+import (
+	"github.com/coreos/ignition/v2/tests/register"
+	"github.com/coreos/ignition/v2/tests/types"
+)
+
+func init() {
+	register.Register(register.PositiveTest, MountFilesystemWithOptions())
+}
+
+func MountFilesystemWithOptions() types.Test {
+	name := "filesystem.mount.options"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "OEM",
+			Substitution: "$DEVICE",
+		},
+	}
+	config := `{
+		"ignition": {"version": "$version"},
+		"storage": {
+			"filesystems": [
+			{
+				"path": "/tmp0",
+				"device": "$DEVICE",
+				"wipeFilesystem": false,
+				"format": "btrfs",
+				"mountOptions": [
+					"noexec",
+					"subvolid=5"
+				]
+			}]
+		}
+	}`
+	in[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
+	out[0].Partitions.GetPartition("OEM").FilesystemType = "btrfs"
+	configMinVersion := "3.1.0-experimental"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}


### PR DESCRIPTION
Implements #872, using the _mkfs_ option implementation as a reference.

With this new `mountOptions` entry it is possible to add mount options for each file system, used during the `mount` stage.