### PR TITLE
Rework fetch/resource to automatically append required headers

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -272,9 +272,7 @@ func (e *Engine) fetchReferencedConfig(cfgRef types.ConfigReference) (types.Conf
 	if err != nil {
 		return types.Config{}, err
 	}
-	rawCfg, err := e.Fetcher.FetchToBuffer(*u, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	rawCfg, err := e.Fetcher.FetchToBuffer(*u, resource.FetchOptions{})
 	if err != nil {
 		return types.Config{}, err
 	}

--- a/internal/providers/aliyun/aliyun.go
+++ b/internal/providers/aliyun/aliyun.go
@@ -36,9 +36,7 @@ var (
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
-	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{})
 	if err != nil && err != resource.ErrNotFound {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -41,9 +41,7 @@ var (
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
-	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{})
 	if err != nil && err != resource.ErrNotFound {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -204,8 +204,6 @@ func fetchConfigFromMetadataService(f *resource.Fetcher) ([]byte, error) {
 		Path:   "/latest/user-data",
 	}
 
-	res, err := f.FetchToBuffer(metadataServiceUrl, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	res, err := f.FetchToBuffer(metadataServiceUrl, resource.FetchOptions{})
 	return res, err
 }

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -46,9 +46,7 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		return types.Config{}, report.Report{}, providers.ErrNoProvider
 	}
 
-	data, err := f.FetchToBuffer(*url, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	data, err := f.FetchToBuffer(*url, resource.FetchOptions{})
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/digitalocean/digitalocean.go
+++ b/internal/providers/digitalocean/digitalocean.go
@@ -36,9 +36,7 @@ var (
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
-	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{})
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}

--- a/internal/providers/gcp/gcp.go
+++ b/internal/providers/gcp/gcp.go
@@ -18,6 +18,7 @@
 package gcp
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
@@ -38,7 +39,7 @@ var (
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
-	headers := resource.ConfigHeaders
+	headers := make(http.Header)
 	headers.Set(metadataHeaderKey, metadataHeaderVal)
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
 		Headers: headers,

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -131,8 +131,6 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 }
 
 func fetchConfigFromMetadataService(f *resource.Fetcher) ([]byte, error) {
-	res, err := f.FetchToBuffer(metadataServiceUrl, resource.FetchOptions{
-		Headers: resource.ConfigHeaders,
-	})
+	res, err := f.FetchToBuffer(metadataServiceUrl, resource.FetchOptions{})
 	return res, err
 }

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -55,7 +55,7 @@ var (
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	// Packet's metadata service returns "Not Acceptable" when queried
 	// with the default Accept header.
-	headers := resource.ConfigHeaders
+	headers := make(http.Header)
 	headers.Set("Accept", "*/*")
 	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{
 		Headers: headers,


### PR DESCRIPTION
Rather than having each platform provider pass down `resource.ConfigHeaders`,
automatically inject it.  Then each platform only needs to pass
additional headers, which in most cases is none.

Unexport `configHeaders` then.

This also avoids mutating a global variable (!).  Queue obligatory
crying for 3 seconds that this code isn't Rust.

Prep for further work around headers.