### PR TITLE
config/v3_1_exp/types: validate http(s) proxies

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -68,6 +68,8 @@ var (
 	ErrZeroesWithShouldNotExist  = errors.New("shouldExist is false for a partition and other partition(s) has start or size 0")
 	ErrNeedLabelOrNumber         = errors.New("a partition number >= 1 or a label must be specified")
 	ErrDuplicateLabels           = errors.New("cannot use the same partition label twice")
+	ErrInvalidProxy              = errors.New("proxies must be http(s)")
+	ErrInsecureProxy             = errors.New("insecure plaintext HTTP proxy specified for HTTPS resources")
 
 	// Systemd section errors
 	ErrInvalidSystemdExt       = errors.New("invalid systemd unit extension")

--- a/config/v3_1_experimental/types/proxy.go
+++ b/config/v3_1_experimental/types/proxy.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/shared/errors"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+func (p Proxy) Validate(c path.ContextPath) (r report.Report) {
+	validateProxyURL(p.HTTPProxy, c.Append("httpProxy"), &r, true)
+	validateProxyURL(p.HTTPSProxy, c.Append("httpsProxy"), &r, false)
+	return
+}
+
+func validateProxyURL(s *string, p path.ContextPath, r *report.Report, httpOk bool) {
+	if s == nil {
+		return
+	}
+	u, err := url.Parse(*s)
+	if err != nil {
+		r.AddOnError(p, errors.ErrInvalidUrl)
+		return
+	}
+
+	if u.Scheme != "https" && u.Scheme != "http" {
+		r.AddOnError(p, errors.ErrInvalidProxy)
+		return
+	}
+	if u.Scheme == "http" && !httpOk {
+		r.AddOnWarn(p, errors.ErrInsecureProxy)
+	}
+}

--- a/config/v3_1_experimental/types/proxy_test.go
+++ b/config/v3_1_experimental/types/proxy_test.go
@@ -1,0 +1,112 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+func TestValidateProxyURL(t *testing.T) {
+	tests := []struct {
+		in     *string
+		httpOk bool
+		out    report.Entry
+	}{
+		{
+			nil,
+			false,
+			report.Entry{},
+		},
+		{
+			nil,
+			true,
+			report.Entry{},
+		},
+		{
+			util.StrToPtr("https://example.com"),
+			false,
+			report.Entry{},
+		},
+		{
+			util.StrToPtr("https://example.com"),
+			true,
+			report.Entry{},
+		},
+		{
+			util.StrToPtr("http://example.com"),
+			false,
+			report.Entry{
+				Kind:    report.Warn,
+				Message: errors.ErrInsecureProxy.Error(),
+			},
+		},
+		{
+			util.StrToPtr("http://example.com"),
+			true,
+			report.Entry{},
+		},
+		{
+			util.StrToPtr("ftp://example.com"),
+			false,
+			report.Entry{
+				Kind:    report.Error,
+				Message: errors.ErrInvalidProxy.Error(),
+			},
+		},
+		{
+			util.StrToPtr("ftp://example.com"),
+			true,
+			report.Entry{
+				Kind:    report.Error,
+				Message: errors.ErrInvalidProxy.Error(),
+			},
+		},
+		{
+			util.StrToPtr("http://[::1]a"),
+			false,
+			report.Entry{
+				Kind:    report.Error,
+				Message: errors.ErrInvalidUrl.Error(),
+			},
+		},
+		{
+			util.StrToPtr("http://[::1]a"),
+			true,
+			report.Entry{
+				Kind:    report.Error,
+				Message: errors.ErrInvalidUrl.Error(),
+			},
+		},
+	}
+
+	for i, test := range tests {
+		r := report.Report{}
+		validateProxyURL(test.in, path.New(""), &r, test.httpOk)
+		e := report.Entry{}
+		if len(r.Entries) > 0 {
+			e = r.Entries[0]
+		}
+		if !reflect.DeepEqual(test.out, e) {
+			t.Errorf("#%d: bad error: want %v, got %v", i, test.out, e)
+		}
+	}
+}


### PR DESCRIPTION
Validate that the specified http(s) proxies are in fact valid http(s)
urls.

Closes: https://github.com/coreos/ignition/issues/873