### PR TITLE
Fix error handling with processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go_import_path: github.com/coreos/ignition/v2
 
 go:
-  - "1.11.x"
+  - "1.12.x"
   - "1.13.x"
 
 arch:

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -20,8 +20,6 @@ import (
 	"log/syslog"
 	"os/exec"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 type LoggerOps interface {
@@ -150,7 +148,7 @@ func (l *Logger) LogCmd(cmd *exec.Cmd, format string, a ...interface{}) (int, er
 		cmd.Stderr = stderr
 		if err := cmd.Run(); err != nil {
 			if exitErr, ok := err.(*exec.ExitError); ok {
-				code = exitErr.Sys().(unix.WaitStatus).ExitStatus()
+				code = exitErr.ExitCode()
 			}
 			return fmt.Errorf("%v: Cmd: %s Stdout: %q Stderr: %q", err, cmdLine, stdout.Bytes(), stderr.Bytes())
 		}

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -332,7 +332,7 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 			return nil
 		}
 		if err := umountPartition(rootPartition); err != nil {
-			return nil
+			return err
 		}
 		if filesErr != nil {
 			return nil // error is expected

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -183,7 +183,7 @@ func validatePartitionNodes(t *testing.T, ctx context.Context, partition *types.
 	defer func() {
 		if err := umountPartition(partition); err != nil {
 			// failing to unmount is not a validation failure
-			t.Logf("Failed to unmount %s: %v", partition.MountPath, err)
+			t.Fatalf("Failed to unmount %s: %v", partition.MountPath, err)
 		}
 	}()
 	for _, file := range partition.Files {


### PR DESCRIPTION
The casts to `unix.WaitStatus` fail. Replace them with the new (1.12) os.ProcessState.ExitCode. Also clean up some error handling