### PR TITLE
stages/files: don't relabel /home and /root symlinks

### DIFF
--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -68,9 +68,7 @@ func (s *stage) createPasswd(config types.Config) error {
 		s.relabel(deglobbed...)
 		s.relabel(
 			"/etc/.pwd.lock",
-			"/home",
-			"/root",
-			// for OSTree-based systems (newer restorecon doesn't follow symlinks)
+			// for OSTree-based systems
 			"/var/home",
 			"/var/roothome",
 		)


### PR DESCRIPTION
On OSTree systems, those are just symlinks in the deployment root. If
they're not labeled correctly already, it signals an issue with the disk
creation process itself (and might also signal that the next time a
deployment root is created, it'll also be mislabeled).

Anyway, even on non-OSTree systems, it seems reasonable to expect that
`/home` and `/root` at least already exist and don't need to be created
(and thus don't need to be relabeld).

It's possible that [fixing `getxattr` without a policy
loaded](https://github.com/coreos/fedora-coreos-config/pull/245#issuecomment-560578750)
would also fix this, since `setfiles` would see that the symlinks were
already correctly labeled.

In effect, this is completing what #632 started.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/339