### PR TITLE
Throw error if SSH keys could not be written

### DIFF
--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -173,11 +173,14 @@ func (u Util) AuthorizeSSHKeys(c types.PasswdUser) error {
 		}
 
 		if distro.WriteAuthorizedKeysFragment() {
-			writeAuthKeysFile(usr, filepath.Join(usr.HomeDir, ".ssh", "authorized_keys.d", "ignition"), []byte(ks))
+			err = writeAuthKeysFile(usr, filepath.Join(usr.HomeDir, ".ssh", "authorized_keys.d", "ignition"), []byte(ks))
 		} else {
-			writeAuthKeysFile(usr, filepath.Join(usr.HomeDir, ".ssh", "authorized_keys"), []byte(ks))
+			err = writeAuthKeysFile(usr, filepath.Join(usr.HomeDir, ".ssh", "authorized_keys"), []byte(ks))
 		}
 
+		if err != nil {
+			return fmt.Errorf("failed to set SSH key: %v", err)
+		}
 		return nil
 	}, "adding ssh keys to user %q", c.Name)
 }


### PR DESCRIPTION
Currently errors while setting the SSH key (e.g. when trying to write onto a read-only file system) are silently ignored; report and abort if setting the key fails like Ignition does for any other unsuccessful operation.