### PR TITLE
Convert httpHeaders from arrays of strings to structs

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -90,7 +90,6 @@ var (
 	// Misc errors
 	ErrInvalidScheme                   = errors.New("invalid url scheme")
 	ErrInvalidUrl                      = errors.New("unable to parse url")
-	ErrInvalidHTTPHeader               = errors.New("unable to parse HTTP header")
 	ErrEmptyHTTPHeaderName             = errors.New("HTTP header name can't be empty")
 	ErrDuplicateHTTPHeaders            = errors.New("all header names in the list must be unique")
 	ErrUnsupportedSchemeForHTTPHeaders = errors.New("cannot use HTTP headers with this source scheme")

--- a/config/v2_4_experimental/append_test.go
+++ b/config/v2_4_experimental/append_test.go
@@ -227,8 +227,8 @@ func TestAppend(t *testing.T) {
 								{
 									Source: "http://example.com/myconf.ign",
 									HTTPHeaders: []types.HTTPHeader{
-										[]types.HTTPHeaderItem{"old-header1", "old-value1"},
-										[]types.HTTPHeaderItem{"old-header2", "old-value2"},
+										{Name: "old-header1", Value: "old-value1"},
+										{Name: "old-header2", Value: "old-value2"},
 									},
 								},
 							},
@@ -242,8 +242,8 @@ func TestAppend(t *testing.T) {
 								{
 									Source: "http://example.com/myconf.ign",
 									HTTPHeaders: []types.HTTPHeader{
-										[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-										[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+										{Name: "new-header1", Value: "new-value1"},
+										{Name: "new-header2", Value: "new-value2"},
 									},
 								},
 							},
@@ -258,8 +258,8 @@ func TestAppend(t *testing.T) {
 							{
 								Source: "http://example.com/myconf.ign",
 								HTTPHeaders: []types.HTTPHeader{
-									[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-									[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+									{Name: "new-header1", Value: "new-value1"},
+									{Name: "new-header2", Value: "new-value2"},
 								},
 							},
 						},
@@ -277,8 +277,8 @@ func TestAppend(t *testing.T) {
 							Replace: &types.ConfigReference{
 								Source: "http://example.com/myconf.ign",
 								HTTPHeaders: []types.HTTPHeader{
-									[]types.HTTPHeaderItem{"old-header1", "old-value1"},
-									[]types.HTTPHeaderItem{"old-header2", "old-value2"},
+									{Name: "old-header1", Value: "old-value1"},
+									{Name: "old-header2", Value: "old-value2"},
 								},
 							},
 						},
@@ -290,8 +290,8 @@ func TestAppend(t *testing.T) {
 							Replace: &types.ConfigReference{
 								Source: "http://example.com/myconf.ign",
 								HTTPHeaders: []types.HTTPHeader{
-									[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-									[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+									{Name: "new-header1", Value: "new-value1"},
+									{Name: "new-header2", Value: "new-value2"},
 								},
 							},
 						},
@@ -304,8 +304,8 @@ func TestAppend(t *testing.T) {
 						Replace: &types.ConfigReference{
 							Source: "http://example.com/myconf.ign",
 							HTTPHeaders: []types.HTTPHeader{
-								[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-								[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+								{Name: "new-header1", Value: "new-value1"},
+								{Name: "new-header2", Value: "new-value2"},
 							},
 						},
 					},
@@ -324,8 +324,8 @@ func TestAppend(t *testing.T) {
 									{
 										Source: "http://example.com/myca.cert",
 										HTTPHeaders: []types.HTTPHeader{
-											[]types.HTTPHeaderItem{"old-header1", "old-value1"},
-											[]types.HTTPHeaderItem{"old-header2", "old-value2"},
+											{Name: "old-header1", Value: "old-value1"},
+											{Name: "old-header2", Value: "old-value2"},
 										},
 									},
 								},
@@ -341,8 +341,8 @@ func TestAppend(t *testing.T) {
 									{
 										Source: "http://example.com/myca.cert",
 										HTTPHeaders: []types.HTTPHeader{
-											[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-											[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+											{Name: "new-header1", Value: "new-value1"},
+											{Name: "new-header2", Value: "new-value2"},
 										},
 									},
 								},
@@ -359,15 +359,15 @@ func TestAppend(t *testing.T) {
 								{
 									Source: "http://example.com/myca.cert",
 									HTTPHeaders: []types.HTTPHeader{
-										[]types.HTTPHeaderItem{"old-header1", "old-value1"},
-										[]types.HTTPHeaderItem{"old-header2", "old-value2"},
+										{Name: "old-header1", Value: "old-value1"},
+										{Name: "old-header2", Value: "old-value2"},
 									},
 								},
 								{
 									Source: "http://example.com/myca.cert",
 									HTTPHeaders: []types.HTTPHeader{
-										[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-										[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+										{Name: "new-header1", Value: "new-value1"},
+										{Name: "new-header2", Value: "new-value2"},
 									},
 								},
 							},
@@ -388,8 +388,8 @@ func TestAppend(t *testing.T) {
 									Contents: types.FileContents{
 										Source: "http://example.com/myfile.txt",
 										HTTPHeaders: []types.HTTPHeader{
-											[]types.HTTPHeaderItem{"old-header1", "old-value1"},
-											[]types.HTTPHeaderItem{"old-header2", "old-value2"},
+											{Name: "old-header1", Value: "old-value1"},
+											{Name: "old-header2", Value: "old-value2"},
 										},
 									},
 								},
@@ -405,8 +405,8 @@ func TestAppend(t *testing.T) {
 									Contents: types.FileContents{
 										Source: "http://example.com/myfile.txt",
 										HTTPHeaders: []types.HTTPHeader{
-											[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-											[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+											{Name: "new-header1", Value: "new-value1"},
+											{Name: "new-header2", Value: "new-value2"},
 										},
 									},
 								},
@@ -423,8 +423,8 @@ func TestAppend(t *testing.T) {
 								Contents: types.FileContents{
 									Source: "http://example.com/myfile.txt",
 									HTTPHeaders: []types.HTTPHeader{
-										[]types.HTTPHeaderItem{"old-header1", "old-value1"},
-										[]types.HTTPHeaderItem{"old-header2", "old-value2"},
+										{Name: "old-header1", Value: "old-value1"},
+										{Name: "old-header2", Value: "old-value2"},
 									},
 								},
 							},
@@ -434,8 +434,8 @@ func TestAppend(t *testing.T) {
 								Contents: types.FileContents{
 									Source: "http://example.com/myfile.txt",
 									HTTPHeaders: []types.HTTPHeader{
-										[]types.HTTPHeaderItem{"new-header1", "new-value1"},
-										[]types.HTTPHeaderItem{"new-header2", "new-value2"},
+										{Name: "new-header1", Value: "new-value1"},
+										{Name: "new-header2", Value: "new-value2"},
 									},
 								},
 							},

--- a/config/v2_4_experimental/types/headers_test.go
+++ b/config/v2_4_experimental/types/headers_test.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -38,8 +39,8 @@ func TestHeadersValidate(t *testing.T) {
 			// Valid headers
 			in: in{
 				headers: HTTPHeaders{
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-					HTTPHeader{HTTPHeaderItem("header2"), HTTPHeaderItem("header2value")},
+					HTTPHeader{Name: "header1", Value: "header1value"},
+					HTTPHeader{Name: "header2", Value: ""},
 				},
 			},
 			out: out{},
@@ -48,51 +49,21 @@ func TestHeadersValidate(t *testing.T) {
 			// Duplicate headers
 			in: in{
 				headers: HTTPHeaders{
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header2value")},
+					HTTPHeader{Name: "header1", Value: "header1value"},
+					HTTPHeader{Name: "header1", Value: "header2value"},
 				},
 			},
-			out: out{err: errors.ErrDuplicateHTTPHeaders},
+			out: out{err: fmt.Errorf("Found duplicate HTTP header: \"header1\"")},
 		},
 		{
 			// Empty headers
 			in: in{
 				headers: HTTPHeaders{
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-					HTTPHeader{HTTPHeaderItem(""), HTTPHeaderItem("header2value")},
+					HTTPHeader{Name: "header1", Value: "header1value"},
+					HTTPHeader{Name: "", Value: "header2value"},
 				},
 			},
 			out: out{err: errors.ErrEmptyHTTPHeaderName},
-		},
-		{
-			// Invalid headers with 3 elements
-			in: in{
-				headers: HTTPHeaders{
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-					HTTPHeader{HTTPHeaderItem("invalid"), HTTPHeaderItem("value1"), HTTPHeaderItem("value2")},
-				},
-			},
-			out: out{err: errors.ErrInvalidHTTPHeader},
-		},
-		{
-			// Invalid header with 1 element
-			in: in{
-				headers: HTTPHeaders{
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-					HTTPHeader{HTTPHeaderItem("invalid")},
-				},
-			},
-			out: out{err: errors.ErrInvalidHTTPHeader},
-		},
-		{
-			// Invalid header without elements
-			in: in{
-				headers: HTTPHeaders{
-					HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-					HTTPHeader{},
-				},
-			},
-			out: out{err: errors.ErrInvalidHTTPHeader},
 		},
 	}
 

--- a/config/v2_4_experimental/types/schema.go
+++ b/config/v2_4_experimental/types/schema.go
@@ -72,9 +72,10 @@ type Filesystem struct {
 
 type Group string
 
-type HTTPHeader []HTTPHeaderItem
-
-type HTTPHeaderItem string
+type HTTPHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
 
 type HTTPHeaders []HTTPHeader
 

--- a/doc/configuration-v2_4-experimental.md
+++ b/doc/configuration-v2_4-experimental.md
@@ -9,12 +9,16 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_config_** (objects): options related to the configuration.
     * **_append_** (list of objects): a list of the configs to be appended to the current config.
       * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
-      * **httpHeaders** (list of lists of strings): specifies a list of headers. Each header is represented by a list of two strings, where the first string is the header name, and the second is its value. Example: `["Keep-Alive", "300"]`. Note: applicable for `http` and `https` source schemes only.
+      * **httpHeaders** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **value** (string): the header contents.
       * **_verification_** (object): options related to the verification of the config.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
     * **_replace_** (object): the config that will replace the current.
       * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
-      * **httpHeaders** (list of lists of strings): specifies a list of headers. Each header is represented by a list of two strings, where the first string is the header name, and the second is its value. Example: `["Keep-Alive", "300"]`. Note: applicable for `http` and `https` source schemes only.
+      * **httpHeaders** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **value** (string): the header contents.
       * **_verification_** (object): options related to the verification of the config.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
   * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
@@ -24,7 +28,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_tls_** (object): options relating to TLS when fetching resources over `https`.
       * **_certificateAuthorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`.
         * **source** (string): the URL of the certificate (in PEM format). Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
-        * **httpHeaders** (list of lists of strings): specifies a list of headers. Each header is represented by a list of two strings, where the first string is the header name, and the second is its value. Example: `["Keep-Alive", "300"]`. Note: applicable for `http` and `https` source schemes only.
+        * **httpHeaders** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **value** (string): the header contents.
         * **_verification_** (object): options related to the verification of the certificate.
           * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is sha512.
   * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
@@ -73,7 +79,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
-      * **_httpHeaders_** (list of lists of strings): specifies a list of headers. Each header is represented by a list of two strings, where the first string is the header name, and the second is its value. Example: `["Keep-Alive", "300"]`. Note: applicable for `http` and `https` source schemes only.
+      * **httpHeaders** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **value** (string): the header contents.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
     * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420).

--- a/internal/config/translate.go
+++ b/internal/config/translate.go
@@ -35,17 +35,13 @@ func boolToPtr(b bool) *bool {
 }
 
 func Translate(old from.Config) types.Config {
-	translateHTTPHeader := func(old from.HTTPHeader) types.HTTPHeader {
-		var res types.HTTPHeader
-		for _, x := range old {
-			res = append(res, types.HTTPHeaderItem(x))
-		}
-		return res
-	}
 	translateHTTPHeaderSlice := func(old []from.HTTPHeader) []types.HTTPHeader {
 		var res []types.HTTPHeader
 		for _, x := range old {
-			res = append(res, translateHTTPHeader(x))
+			res = append(res, types.HTTPHeader{
+				Name:  x.Name,
+				Value: x.Value,
+			})
 		}
 		return res
 	}

--- a/internal/config/types/headers.go
+++ b/internal/config/types/headers.go
@@ -23,30 +23,18 @@ import (
 // Parse generates standard net/http headers from the data in HTTPHeaders
 func (h HTTPHeaders) Parse() (http.Header, error) {
 	headers := http.Header{}
-	for _, headerData := range h {
-		// Validate that the header has just two elements
-		if len(headerData) != 2 {
-			return nil, errors.ErrInvalidHTTPHeader
-		}
-
+	found := make(map[string]struct{})
+	for _, header := range h {
 		// Header name can't be empty
-		headerName := string(headerData[0])
-		if headerName == "" {
+		if header.Name == "" {
 			return nil, errors.ErrEmptyHTTPHeaderName
 		}
-
-		headerValue := string(headerData[1])
-		headers.Add(headerName, headerValue)
+		// Header names must be unique
+		if _, ok := found[header.Name]; ok {
+			return nil, errors.ErrDuplicateHTTPHeaders
+		}
+		found[header.Name] = struct{}{}
+		headers.Add(header.Name, header.Value)
 	}
-
-	// Validate that all header names in the list are unique
-	set := make(map[string]struct{}) // New empty set
-	for _, header := range h {
-		set[string(header[0])] = struct{}{}
-	}
-	if len(set) != len(h) {
-		return nil, errors.ErrDuplicateHTTPHeaders
-	}
-
 	return headers, nil
 }

--- a/internal/config/types/headers_test.go
+++ b/internal/config/types/headers_test.go
@@ -41,50 +41,26 @@ func TestHeadersParse(t *testing.T) {
 		{
 			// Valid headers
 			HTTPHeaders{
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-				HTTPHeader{HTTPHeaderItem("header2"), HTTPHeaderItem("header2value")},
+				HTTPHeader{Name: "header1", Value: "header1value"},
+				HTTPHeader{Name: "header2", Value: ""},
 			},
 			nil,
 		},
 		{
 			// Duplicate headers
 			HTTPHeaders{
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("value1")},
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("value2")},
+				HTTPHeader{Name: "header1", Value: "value1"},
+				HTTPHeader{Name: "header1", Value: "value2"},
 			},
 			errors.ErrDuplicateHTTPHeaders,
 		},
 		{
 			// Empty headers
 			HTTPHeaders{
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-				HTTPHeader{HTTPHeaderItem(""), HTTPHeaderItem("emptyheadervalue")},
+				HTTPHeader{Name: "header1", Value: "header1value"},
+				HTTPHeader{Name: "", Value: "emptyheadervalue"},
 			},
 			errors.ErrEmptyHTTPHeaderName,
-		},
-		{
-			// Invalid headers with 3 elements
-			HTTPHeaders{
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-				HTTPHeader{HTTPHeaderItem("invalid"), HTTPHeaderItem("value1"), HTTPHeaderItem("value2")},
-			},
-			errors.ErrInvalidHTTPHeader,
-		},
-		{
-			// Invalid header with 1 element
-			HTTPHeaders{
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-				HTTPHeader{HTTPHeaderItem("invalid")},
-			},
-			errors.ErrInvalidHTTPHeader,
-		},
-		{
-			// Invalid header without elements
-			HTTPHeaders{
-				HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-				HTTPHeader{},
-			},
-			errors.ErrInvalidHTTPHeader,
 		},
 	}
 
@@ -99,8 +75,8 @@ func TestHeadersParse(t *testing.T) {
 func TestValidHeadersParse(t *testing.T) {
 	// Valid headers
 	headers := HTTPHeaders{
-		HTTPHeader{HTTPHeaderItem("header1"), HTTPHeaderItem("header1value")},
-		HTTPHeader{HTTPHeaderItem("header2"), HTTPHeaderItem("header2value")},
+		HTTPHeader{Name: "header1", Value: "header1value"},
+		HTTPHeader{Name: "header2", Value: "header2value"},
 	}
 	parseHeaders, err := headers.Parse()
 	if err != nil {

--- a/internal/config/types/schema.go
+++ b/internal/config/types/schema.go
@@ -72,9 +72,10 @@ type Filesystem struct {
 
 type Group string
 
-type HTTPHeader []HTTPHeaderItem
-
-type HTTPHeaderItem string
+type HTTPHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
 
 type HTTPHeaders []HTTPHeader
 

--- a/schema/ignition.json
+++ b/schema/ignition.json
@@ -30,15 +30,19 @@
       }
     },
     "httpHeaders": {
-      "type" : "array",
-      "items" : {
-          "type" : "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 2,
-          "maxItems": 2
-      }
+      "type" : "object",
+      "properties" : {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+          "name",
+          "value"
+      ]
     },
     "ignition": {
       "type": "object",

--- a/tests/negative/files/missing_file.go
+++ b/tests/negative/files/missing_file.go
@@ -64,7 +64,7 @@ func InvalidHeaderRemoteContentsHTTP() types.Test {
 	      "filesystem": "root",
 	      "path": "/foo/bar",
 	      "contents": {
-			"httpHeaders": [["X-Auth", "INVALID"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "INVALID"}, {"name": "Keep-Alive", "value": "300"}],
 	        "source": "http://127.0.0.1:8080/contents_headers"
 	      }
 	    }]

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -142,7 +142,7 @@ func ReplaceConfigWithInvalidHeaderHTTP() types.Test {
 	    "version": "$version",
 	    "config": {
 	      "replace": {
-			"httpHeaders": [["X-Auth", "INVALID"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "INVALID"}, {"name": "Keep-Alive", "value": "300"}],
 	        "source": "http://127.0.0.1:8080/config_headers"
 	      }
 	    }
@@ -243,7 +243,7 @@ func AppendConfigWithInvalidHeaderHTTP() types.Test {
 	    "version": "$version",
 	    "config": {
 	      "append": [{
-			"httpHeaders": [["X-Auth", "INVALID"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "INVALID"}, {"name": "Keep-Alive", "value": "300"}],
 	        "source": "http://127.0.0.1:8080/config_headers"
 	      }]
 	    }

--- a/tests/negative/security/tls.go
+++ b/tests/negative/security/tls.go
@@ -198,7 +198,7 @@ func AppendConfigCustomCertInvalidHeaderHTTP() types.Test {
 			"security": {
 				"tls": {
 					"certificateAuthorities": [{
-						"httpHeaders": [["X-Auth", "INVALID"], ["Keep-Alive", "300"]],
+						"httpHeaders": [{"name": "X-Auth", "value": "INVALID"}, {"name": "Keep-Alive", "value": "300"}],
 						"source": "http://127.0.0.1:8080/certificates_headers"
 					}]
 				}

--- a/tests/positive/files/hash.go
+++ b/tests/positive/files/hash.go
@@ -111,7 +111,7 @@ func ValidateFileHashFromHTTPURLUsingHeaders() types.Test {
 	      "path": "/foo/bar",
 	      "contents": {
 			"source": "http://127.0.0.1:8080/contents_headers",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 			"verification": {"hash": "sha512-1a04c76c17079cd99e688ba4f1ba095b927d3fecf2b1e027af361dfeafb548f7f5f6fdd675aaa2563950db441d893ca77b0c3e965cdcb891784af96e330267d7"}
 	      }
 	    }]

--- a/tests/positive/files/remote.go
+++ b/tests/positive/files/remote.go
@@ -74,7 +74,7 @@ func CreateFileFromRemoteContentsHTTPUsingHeaders() types.Test {
 	      "filesystem": "root",
 	      "path": "/foo/bar",
 	      "contents": {
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 	        "source": "http://127.0.0.1:8080/contents_headers"
 	      }
 	    }]
@@ -111,7 +111,7 @@ func CreateFileFromRemoteContentsHTTPRedirectHeaders() types.Test {
 	      "filesystem": "root",
 	      "path": "/foo/bar",
 	      "contents": {
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 	        "source": "http://127.0.0.1:8080/contents_headers_redirect"
 	      }
 	    }]

--- a/tests/positive/general/general.go
+++ b/tests/positive/general/general.go
@@ -135,7 +135,7 @@ func ReplaceConfigWithRemoteConfigHTTPUsingHeaders() types.Test {
 	    "config": {
 	      "replace": {
 			"source": "http://127.0.0.1:8080/config_headers",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 			"verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
 	      }
 	    }
@@ -171,7 +171,7 @@ func ReplaceConfigWithRemoteConfigHTTPReplaceOriginalHeaders() types.Test {
 	    "config": {
 	      "replace": {
 			"source": "http://127.0.0.1:8080/config_headers_replace",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"], ["Accept", "text/html, application/json"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}, {"name": "Accept", "value": "text/html, application/json"}],
 			"verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
 	      }
 	    }
@@ -207,7 +207,7 @@ func ReplaceConfigWithRemoteConfigHTTPRedirectHeaders() types.Test {
 	    "config": {
 	      "replace": {
 			"source": "http://127.0.0.1:8080/config_headers_redirect",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 			"verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
 	      }
 	    }
@@ -379,7 +379,7 @@ func AppendConfigWithRemoteConfigHTTPUsingHeaders() types.Test {
 	    "config": {
 	      "append": [{
 			"source": "http://127.0.0.1:8080/config_headers",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 			"verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
 	      }]
 	    }
@@ -429,7 +429,7 @@ func AppendConfigWithRemoteConfigHTTPReplaceOriginalHeaders() types.Test {
 	    "config": {
 	      "append": [{
 			"source": "http://127.0.0.1:8080/config_headers_replace",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"], ["Accept", "text/html, application/json"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}, {"name": "Accept", "value": "text/html, application/json"}],
 			"verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
 	      }]
 	    }
@@ -479,7 +479,7 @@ func AppendConfigWithRemoteConfigHTTPRedirectHeaders() types.Test {
 	    "config": {
 	      "append": [{
 			"source": "http://127.0.0.1:8080/config_headers_redirect",
-			"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+			"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 			"verification": { "hash": "sha512-41d9a1593dd4cbcacc966dce574523ffe3780ec2710716fab28b46f0f24d20b5ec49f307a9e9d331af958e508f472f32135c740d1214c5f02fc36016b538e7ff" }
 	      }]
 	    }

--- a/tests/positive/security/tls.go
+++ b/tests/positive/security/tls.go
@@ -236,7 +236,7 @@ func FetchFileCustomCertHTTPUsingHeaders() types.Test {
 			"security": {
 				"tls": {
 					"certificateAuthorities": [{
-						"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+						"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 						"source": "http://127.0.0.1:8080/certificates_headers"
 					}]
 				}
@@ -283,7 +283,7 @@ func FetchFileCustomCertHTTPRedirectHeaders() types.Test {
 			"security": {
 				"tls": {
 					"certificateAuthorities": [{
-						"httpHeaders": [["X-Auth", "r8ewap98gfh4d8"], ["Keep-Alive", "300"]],
+						"httpHeaders": [{"name": "X-Auth", "value": "r8ewap98gfh4d8"}, {"name": "Keep-Alive", "value": "300"}],
 						"source": "http://127.0.0.1:8080/certificates_headers_redirect"
 					}]
 				}


### PR DESCRIPTION
In the future, we might want to add options, such as the ability to preserve certain headers across HTTP redirects.  That's much cleaner with a struct than an array.

While we're here:
- Have config validation report duplicate headers by name.
- Have unit tests try empty header values.