### PR TITLE
config: add json tags to embedded structs

### DIFF
--- a/config/v2_1/types/schema.go
+++ b/config/v2_1/types/schema.go
@@ -25,8 +25,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -45,8 +45,8 @@ type Dropin struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -78,8 +78,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_2/types/schema.go
+++ b/config/v2_2/types/schema.go
@@ -30,8 +30,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -45,8 +45,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -82,8 +82,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_3/types/schema.go
+++ b/config/v2_3/types/schema.go
@@ -30,8 +30,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -45,8 +45,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -82,8 +82,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_4/types/schema.go
+++ b/config/v2_4/types/schema.go
@@ -32,8 +32,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -47,8 +47,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -93,8 +93,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_5_experimental/types/schema.go
+++ b/config/v2_5_experimental/types/schema.go
@@ -32,8 +32,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -47,8 +47,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -93,8 +93,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {


### PR DESCRIPTION
tools are tripped up when encountering these structs that do not
have json tags on thier embedded structs.