### PR TITLE
providers/vultr: Add Vultr provider

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/qemu"
 	"github.com/coreos/ignition/v2/internal/providers/virtualbox"
 	"github.com/coreos/ignition/v2/internal/providers/vmware"
+	"github.com/coreos/ignition/v2/internal/providers/vultr"
 	"github.com/coreos/ignition/v2/internal/providers/zvm"
 	"github.com/coreos/ignition/v2/internal/registry"
 	"github.com/coreos/ignition/v2/internal/resource"
@@ -133,6 +134,10 @@ func init() {
 	configs.Register(Config{
 		name:  "metal",
 		fetch: noop.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "vultr",
+		fetch: vultr.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "zvm",

--- a/internal/providers/vultr/vultr.go
+++ b/internal/providers/vultr/vultr.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The vultr provider fetches a remote configuration from the vultr
+// user-data metadata service URL.
+// https://web.archive.org/web/20190513194756/https://www.vultr.com/metadata/#user
+
+package vultr
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	userdataUrl = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "user-data/user-data",
+	}
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{})
+	if err != nil && err != resource.ErrNotFound {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}


### PR DESCRIPTION
* Add Vultr as a provider, user-data can be an Ignition config
* Metadata endpoint is http://169.254.169.254/user-data/user-data

Background:

Hi! :wave:  I've been using Fedora CoreOS on Vultr for some time. Using the installer ISO crashing to an emergency shell to supply a shim Ignition config that points to Vultr metadata server's user-data to create an image that will boot with Ignition on Vultr. Recently the Fedora CoreOS installer ISO seems to have been removed, so I'd like to add proper support.