### PR TITLE
ci: hook up to CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,30 @@
+@Library('github.com/coreos/coreos-ci-lib@master') _
+
+coreos.pod([image: 'registry.svc.ci.openshift.org/coreos/cosa-buildroot:latest', kvm: true, memory: "9Gi"]) {
+    checkout scm
+
+    stage("Build") {
+        coreos.shwrap("""
+        mkdir cache fcos
+        (cd fcos && coreos-assembler init https://github.com/coreos/fedora-coreos-config)
+        XDG_CACHE_HOME=$PWD/cache make install DESTDIR=fcos/overrides/rootfs
+        """)
+    }
+
+    stage("Build FCOS") {
+        coreos.shwrap("""
+        cd fcos && coreos-assembler build
+        """)
+    }
+
+    stage("Kola") {
+        try {
+            coreos.shwrap("cd fcos && cosa kola run --parallel 8")
+        } finally {
+            coreos.shwrap("tar -c -C fcos/tmp kola | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
+        }
+        // sanity check kola actually ran and dumped its output in tmp/
+        coreos.shwrap("test -d fcos/tmp/kola")
+    }
+}


### PR DESCRIPTION
This is a basic CI job that builds Ignition, shoves it into FCOS, and
then runs the kola testsuite.

This is a pattern we'll dedupe more in the future with other OS
components like rpm-ostree, ostree, afterburn, etc...