### PR TITLE
[DRAFT] providers: add ibmcloud-classic

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/file"
 	"github.com/coreos/ignition/v2/internal/providers/gcp"
 	"github.com/coreos/ignition/v2/internal/providers/ibmcloud"
+	"github.com/coreos/ignition/v2/internal/providers/ibmcloud_classic"
 	"github.com/coreos/ignition/v2/internal/providers/noop"
 	"github.com/coreos/ignition/v2/internal/providers/openstack"
 	"github.com/coreos/ignition/v2/internal/providers/packet"
@@ -118,6 +119,10 @@ func init() {
 	configs.Register(Config{
 		name:  "ibmcloud",
 		fetch: ibmcloud.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "ibmcloud-classic",
+		fetch: ibmcloud_classic.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "metal",

--- a/internal/providers/ibmcloud_classic/ibmcloud_classic.go
+++ b/internal/providers/ibmcloud_classic/ibmcloud_classic.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ibmcloud_classic
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+const (
+	cidataPath  = "openstack/latest/user_data"
+	deviceLabel = "config-2"
+	fsType      = "vfat"
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	var data []byte
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	dispatch := func(name string, fn func() ([]byte, error)) {
+		raw, err := fn()
+		if err != nil {
+			switch err {
+			case context.Canceled:
+			case context.DeadlineExceeded:
+				f.Logger.Err("timed out while fetching config from %s", name)
+			default:
+				f.Logger.Err("failed to fetch config from %s: %v", name, err)
+			}
+			return
+		}
+
+		data = raw
+		cancel()
+	}
+
+	go dispatch("config drive (config-2)", func() ([]byte, error) {
+		return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), deviceLabel))
+	})
+
+	<-ctx.Done()
+	if ctx.Err() == context.DeadlineExceeded {
+		f.Logger.Info("config drive was not available in time. Continuing without a config...")
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return (err == nil)
+}
+
+func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string) ([]byte, error) {
+	for !fileExists(path) {
+		logger.Debug("config drive (%q) not found. Waiting...", path)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	logger.Debug("creating temporary mount point")
+	mnt, err := ioutil.TempDir("", "ignition-configdrive")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.Remove(mnt)
+
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", fsType, path, mnt)
+	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
+		return nil, err
+	}
+	defer logger.LogOp(
+		func() error { return syscall.Unmount(mnt, 0) },
+		"unmounting %q at %q", path, mnt,
+	)
+
+	if !fileExists(filepath.Join(mnt, cidataPath)) {
+		return nil, nil
+	}
+
+	return ioutil.ReadFile(filepath.Join(mnt, cidataPath))
+}


### PR DESCRIPTION
DRAFT: it is unclear whether we want to provide RHCOS/FCOS on Classic instances, due to overall limitations of Classic infrastructure. Implementation here is complete though, and manually tested.

---

This adds a new config fetcher for the "ibmcloud-classic" provider.

Ref: https://github.com/coreos/fedora-coreos-docs/pull/45
