### PR TITLE
tests: don't panic after failing to run Ignition

### DIFF
--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -155,7 +155,9 @@ func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, app
 	cmd.Dir = cwd
 	cmd.Env = append(os.Environ(), appendEnv...)
 	out, err := cmd.CombinedOutput()
-	t.Logf("PID: %d", cmd.Process.Pid)
+	if cmd != nil && cmd.Process != nil {
+		t.Logf("PID: %d", cmd.Process.Pid)
+	}
 	t.Logf("Ignition output:\n%s", string(out))
 	if strings.Contains(string(out), "panic") {
 		return fmt.Errorf("ignition panicked")


### PR DESCRIPTION
This commit adds a check for errors other than ExitError
before trying to dereference a nil pointer.

Signed-off-by: Kamil Domański <kamil@domanski.co>