### PR TITLE
blkid: Explicitly use C int variable for numParts

### DIFF
--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -136,13 +136,13 @@ func DumpDisk(device string) (DiskInfo, error) {
 		return DiskInfo{}, err
 	}
 
-	numParts := 0
+	numParts := C.int(0)
 	cNumPartsRef := (*C.int)(unsafe.Pointer(&numParts))
 	if err := cResultToErr(C.blkid_get_num_partitions(cDevice, cNumPartsRef), device); err != nil {
 		return DiskInfo{}, err
 	}
 
-	for i := 0; i < numParts; i++ {
+	for i := 0; i < int(numParts); i++ {
 		if err := cResultToErr(C.blkid_get_partition(cDevice, C.int(i), cInfoRef), device); err != nil {
 			return DiskInfo{}, err
 		}


### PR DESCRIPTION
This was an issue I encountered while testing partition creation on s390x, where the
number of partitions returned by numParts was a bogus number. At first I thought it was
an endianness issue with blkid, but turned out that the C compiler's int variable size and
the Go compiler's int variable sizes are different (on s390x at least) which caused this bug.

The fix is to make numParts a C int variable to be consistent with what is returned by blkid