### PR TITLE
Add json tag to types that don't have it in the schema

### DIFF
--- a/config/v2_2/types/schema.go
+++ b/config/v2_2/types/schema.go
@@ -30,8 +30,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -45,8 +45,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -82,8 +82,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_3/types/schema.go
+++ b/config/v2_3/types/schema.go
@@ -30,8 +30,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -45,8 +45,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -82,8 +82,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_4/types/schema.go
+++ b/config/v2_4/types/schema.go
@@ -32,8 +32,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -47,8 +47,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -93,8 +93,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {

--- a/config/v2_5_experimental/types/schema.go
+++ b/config/v2_5_experimental/types/schema.go
@@ -32,8 +32,8 @@ type CreateOption string
 type Device string
 
 type Directory struct {
-	Node
-	DirectoryEmbedded1
+	Node               `json:",inline"`
+	DirectoryEmbedded1 `json:",inline"`
 }
 
 type DirectoryEmbedded1 struct {
@@ -47,8 +47,8 @@ type Disk struct {
 }
 
 type File struct {
-	Node
-	FileEmbedded1
+	Node          `json:",inline"`
+	FileEmbedded1 `json:",inline"`
 }
 
 type FileContents struct {
@@ -93,8 +93,8 @@ type IgnitionConfig struct {
 }
 
 type Link struct {
-	Node
-	LinkEmbedded1
+	Node          `json:",inline"`
+	LinkEmbedded1 `json:",inline"`
 }
 
 type LinkEmbedded1 struct {


### PR DESCRIPTION
As a user of the machine-config-operator API, we import the structures
into our own API (in the openshift/compliance-operator). MCO, in turn,
uses ignition... hence why I'm here.

We've noticed breakages in the code-generation code because of some
structures that are missing json tags.

e.g.

    $ operator-sdk generate crds --verbose
    DEBU[0000] Debug logging is set
    INFO[0000] Running CRD generator.
    /home/josorior/go/src/github.com/openshift/compliance-operator/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go:33:2: encountered struct field "" without JSON tag in type "Directory"
    /home/josorior/go/src/github.com/openshift/compliance-operator/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go:34:2: encountered struct field "" without JSON tag in type "Directory"
    /home/josorior/go/src/github.com/openshift/compliance-operator/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go:48:2: encountered struct field "" without JSON tag in type "File"
    /home/josorior/go/src/github.com/openshift/compliance-operator/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go:49:2: encountered struct field "" without JSON tag in type "File"
    /home/josorior/go/src/github.com/openshift/compliance-operator/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go:85:2: encountered struct field "" without JSON tag in type "Link"
    /home/josorior/go/src/github.com/openshift/compliance-operator/vendor/github.com/coreos/ignition/config/v2_2/types/schema.go:86:2: encountered struct field "" without JSON tag in type "Link"
    FATA[0000] error generating CRDs from APIs in pkg/apis: error generating CRD manifests: error running CRD generator: not all generators ran successfully

Adding json tags that indicate that the structure will be inlined
fixes the issue and is the desired json structure.