### PR TITLE
internal: allow base64 encoded gziped file

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -288,9 +288,6 @@ func (f *Fetcher) fetchFromHTTP(u url.URL, dest io.Writer, opts FetchOptions) er
 // FetchFromDataURL writes the data stored in the dataurl u into dest, returning
 // an error if one is encountered.
 func (f *Fetcher) fetchFromDataURL(u url.URL, dest io.Writer, opts FetchOptions) error {
-	if opts.Compression != "" {
-		return ErrCompressionUnsupported
-	}
 	url, err := dataurl.DecodeString(u.String())
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi,

I'm not able to inject base64 encoded gzip files. When compression is set to "gzip" the error will be returned in this condition block: 
https://github.com/coreos/ignition/blob/0f686c00b1354d2e911671ccf3580039b0d3c0c7/internal/resource/url.go#L290-L293

However, if I don't set compression, the `decompressCopyHashAndVerify` function will call the `uncompress()` function which allows gzipping decompression:
https://github.com/coreos/ignition/blob/0f686c00b1354d2e911671ccf3580039b0d3c0c7/internal/resource/url.go#L422-L423
https://github.com/coreos/ignition/blob/0f686c00b1354d2e911671ccf3580039b0d3c0c7/internal/resource/url.go#L407-L416

As `dataurl.DecodeString` will decode base64 encoded data and `uncompress()` decompression gzipped strings, removing this condition will allow decompressing base64 encoded files.

Do you think this could be a reasonable improvement?

Thanks

Marc