### PR TITLE
Fix ignition config for the instantiated unit blackbox_test

### DIFF
--- a/tests/positive/files/units.go
+++ b/tests/positive/files/units.go
@@ -32,8 +32,8 @@ func CreateInstantiatedService() types.Test {
 		"systemd": {
 			"units": [
 			  {
-				"name": "echo@.service"
-				"contents": "[Unit]\nDescription=f\n[Service]\nType=oneshot\nExecStart=/bin/echo %i\nRemainAfterExit=yes\n[Install]\nWantedBy=multi-user.target\n",
+				"name": "echo@.service",
+				"contents": "[Unit]\nDescription=f\n[Service]\nType=oneshot\nExecStart=/bin/echo %i\nRemainAfterExit=yes\n[Install]\nWantedBy=multi-user.target\n"
 			  },
 			  {
 				"enabled": true,
@@ -42,7 +42,7 @@ func CreateInstantiatedService() types.Test {
 			  {
 				"enabled": true,
 				"name": "echo@foo.service"
-			  },
+			  }
 			]
 		  }
 		}`


### PR DESCRIPTION
This fixes a blackbox test for the instantiated units which is failing due to the bad config: https://jenkins-container-linux.apps.ci.centos.org/job/os/job/Ignition%20BB%20tests/201/console