### PR TITLE
providers/qemu: fix default to fwcfg

### DIFF
--- a/internal/providers/qemu/qemu_fwcfg.go
+++ b/internal/providers/qemu/qemu_fwcfg.go
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build amd64 arm64
+// +build !s390x,!ppc64le
 
-// The QEMU provider on amd64 and arm64 fetches a local configuration from the
-// firmware config interface (opt/com.coreos/config).
+// The default QEMU provider fetches a local configuration from the firmware
+// config interface (opt/com.coreos/config). Platforms without support for
+// qemu_fw_cfg should use the blockdev implementation instead.
 
 package qemu
 


### PR DESCRIPTION
Commit 3b930b made it impossible to build Ignition on any other arch then s390x, ppc64le, amd64 or arm64 by explicitly stating the allowed platforms. This made it impossible to build e.g. for 386.

Continue to use the fw_cfg interface as default instead.