### PR TITLE
providers/file: Return ErrNoProvider on ENOENT

### DIFF
--- a/internal/providers/file/file.go
+++ b/internal/providers/file/file.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
+	"github.com/coreos/ignition/v2/internal/providers"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
 
@@ -40,6 +41,9 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 
 	rawConfig, err := ioutil.ReadFile(filename)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = providers.ErrNoProvider
+		}
 		f.Logger.Err("couldn't read config %q: %v", filename, err)
 		return types.Config{}, report.Report{}, err
 	}


### PR DESCRIPTION
If the file doesn't exist, return the internal error which
means "not found" as opposed to a parse error.

Prep for further changes around detecting whether an Ignition
config is provided.