### PR TITLE
WIP: support for `fetch --detect-offline-config`

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -42,11 +42,14 @@ func main() {
 		stage        stages.Name
 		version      bool
 		logToStdout  bool
+
+		detectOfflineConfig string
 	}{}
 
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
 	flag.StringVar(&flags.configCache, "config-cache", "/run/ignition.json", "where to cache the config")
 	flag.DurationVar(&flags.fetchTimeout, "fetch-timeout", exec.DefaultFetchTimeout, "initial duration for which to wait for config")
+	flag.StringVar(&flags.detectOfflineConfig, "detect-config-provided", "", "If a config is provided, create a file at this path")
 	flag.Var(&flags.platform, "platform", fmt.Sprintf("current platform. %v", platform.Names()))
 	flag.StringVar(&flags.root, "root", "/", "root of the filesystem")
 	flag.Var(&flags.stage, "stage", fmt.Sprintf("execution stage. %v", stages.Names()))
@@ -95,6 +98,8 @@ func main() {
 		ConfigCache:    flags.configCache,
 		PlatformConfig: platformConfig,
 		Fetcher:        &fetcher,
+
+		DetectOfflineConfig: flags.detectOfflineConfig,
 	}
 
 	err = engine.Run(flags.stage.String())

--- a/internal/providers/cmdline/cmdline.go
+++ b/internal/providers/cmdline/cmdline.go
@@ -36,6 +36,14 @@ const (
 	cmdlineUrlFlag = "ignition.config.url"
 )
 
+func DetectConfig(f *resource.Fetcher) (bool, error) {
+	url, err := readCmdline(f.Logger)
+	if err != nil {
+		return false, err
+	}
+	return url != nil, nil
+}
+
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	url, err := readCmdline(f.Logger)
 	if err != nil {

--- a/internal/providers/file/file.go
+++ b/internal/providers/file/file.go
@@ -30,12 +30,29 @@ const (
 	defaultFilename   = "config.ign"
 )
 
-func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+func getPath(f *resource.Fetcher) string {
 	filename := os.Getenv(cfgFilenameEnvVar)
 	if filename == "" {
 		filename = defaultFilename
 		f.Logger.Info("using default filename")
 	}
+	return filename
+}
+
+func DetectConfig(f *resource.Fetcher) (bool, error) {
+	filename := getPath(f)
+	_, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	filename := getPath(f)
 	f.Logger.Info("using config file at %q", filename)
 
 	rawConfig, err := ioutil.ReadFile(filename)

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -28,6 +28,7 @@ var (
 	ErrNoProvider = errors.New("config provider was not online")
 )
 
+type FuncDetectConfig func(f *resource.Fetcher) (bool, error)
 type FuncFetchConfig func(f *resource.Fetcher) (types.Config, report.Report, error)
 type FuncNewFetcher func(logger *log.Logger) (resource.Fetcher, error)
 type FuncPostStatus func(stageName string, f resource.Fetcher, e error) error


### PR DESCRIPTION
In some cases, we want to make a decision in the initramfs
based on whether or not an Ignition config was provided at all.

A good example of this is for live ISOs, we only want
to turn on networking if a config was provided:
https://github.com/coreos/ignition-dracut/issues/94

So the idea is that we'd end up running `ignition fetch --detect-offline-config`
as part of a systemd generator, which could then take futher
steps like pulling in `network-online.target` if a config was
provided.