### PR TITLE
packet: Don't report umount stage status to Packet control plane

### DIFF
--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	name = "disks"
+	Name = "disks"
 )
 
 func init() {
@@ -52,7 +52,7 @@ func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stage
 }
 
 func (creator) Name() string {
-	return name
+	return Name
 }
 
 type stage struct {
@@ -62,7 +62,7 @@ type stage struct {
 }
 
 func (stage) Name() string {
-	return name
+	return Name
 }
 
 func (s stage) Run(config types.Config) error {

--- a/internal/exec/stages/fetch/fetch.go
+++ b/internal/exec/stages/fetch/fetch.go
@@ -16,7 +16,7 @@
 // arrays, formatting partitions, writing files, writing systemd units, and
 // writing network units.
 
-package disks
+package fetch
 
 import (
 	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"

--- a/internal/exec/stages/fetch/fetch.go
+++ b/internal/exec/stages/fetch/fetch.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	name = "fetch"
+	Name = "fetch"
 )
 
 func init() {
@@ -46,7 +46,7 @@ func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher) stage
 }
 
 func (creator) Name() string {
-	return name
+	return Name
 }
 
 type stage struct {
@@ -54,7 +54,7 @@ type stage struct {
 }
 
 func (stage) Name() string {
-	return name
+	return Name
 }
 
 func (s stage) Run(_ types.Config) error {

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	name = "files"
+	Name = "files"
 )
 
 var (
@@ -52,7 +52,7 @@ func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stage
 }
 
 func (creator) Name() string {
-	return name
+	return Name
 }
 
 type stage struct {
@@ -61,7 +61,7 @@ type stage struct {
 }
 
 func (stage) Name() string {
-	return name
+	return Name
 }
 
 func (s stage) Run(config types.Config) error {

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -16,7 +16,7 @@
 // arrays, formatting partitions, writing files, writing systemd units, and
 // writing network units.
 
-package disks
+package mount
 
 import (
 	"fmt"

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	name = "mount"
+	Name = "mount"
 )
 
 func init() {
@@ -54,7 +54,7 @@ func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stage
 }
 
 func (creator) Name() string {
-	return name
+	return Name
 }
 
 type stage struct {
@@ -62,7 +62,7 @@ type stage struct {
 }
 
 func (stage) Name() string {
-	return name
+	return Name
 }
 
 func (s stage) Run(config types.Config) error {

--- a/internal/exec/stages/umount/umount.go
+++ b/internal/exec/stages/umount/umount.go
@@ -16,7 +16,7 @@
 // arrays, formatting partitions, writing files, writing systemd units, and
 // writing network units.
 
-package disks
+package umount
 
 import (
 	"sort"

--- a/internal/exec/stages/umount/umount.go
+++ b/internal/exec/stages/umount/umount.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	name = "umount"
+	Name = "umount"
 )
 
 func init() {
@@ -50,7 +50,7 @@ func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stage
 }
 
 func (creator) Name() string {
-	return name
+	return Name
 }
 
 type stage struct {
@@ -58,7 +58,7 @@ type stage struct {
 }
 
 func (stage) Name() string {
-	return name
+	return Name
 }
 
 func (s stage) Run(config types.Config) error {

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
+	"github.com/coreos/ignition/v2/internal/exec/stages/umount"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
 
@@ -69,6 +70,13 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 
 // PostStatus posts a message that will show on the Packet Instance Timeline
 func PostStatus(stageName string, f resource.Fetcher, errMsg error) error {
+	if stageName == umount.Name {
+		// Don't report umount status.  It's unlikely to fail as a
+		// result of anything in the config, and ignition-dracut
+		// may have already torn down networking.
+		return nil
+	}
+
 	f.Logger.Info("POST message to Packet Timeline")
 	// fetch JSON from https://metadata.packet.net/metadata
 	headers := make(http.Header)


### PR DESCRIPTION
https://github.com/coreos/ignition-dracut/pull/159 tears down initramfs networking before the `umount` stage runs, causing Ignition to fail when reporting that stage's status to the Packet control plane.  This can't be changed in ignition-dracut, since `coreos-teardown-initramfs-network.sh` needs filesystems to still be mounted so it can propagate the initramfs network config to the real root.  However, nothing in the user's config is likely to cause `umount` to fail, so it's not as important to report that stage to the Packet console.  Just skip reporting that stage.