### PR TITLE
blkid: Backport: Explicitly use C int variable for numParts

### DIFF
--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -109,13 +109,13 @@ func DumpPartitionTable(device string) ([]types.Partition, error) {
 	cDevice := C.CString(device)
 	defer C.free(unsafe.Pointer(cDevice))
 
-	numParts := 0
+	numParts := C.int(0)
 	cNumPartsRef := (*C.int)(unsafe.Pointer(&numParts))
 	if err := cResultToErr(C.blkid_get_num_partitions(cDevice, cNumPartsRef), device); err != nil {
 		return []types.Partition{}, err
 	}
 
-	for i := 0; i < numParts; i++ {
+	for i := 0; i < int(numParts); i++ {
 		if err := cResultToErr(C.blkid_get_partition(cDevice, C.int(i), cInfoRef), device); err != nil {
 			return []types.Partition{}, err
 		}


### PR DESCRIPTION
This was an issue I encountered while testing partition creation on s390x, where the
number of partitions returned by numParts was a bogus number.This is because the int
variable is 64 bit in golang and 32 bit in C. This was further exposed because s390x is
big endian.

The fix is to make numParts a C int variable to be consistent with what is returned by blkid
Backport of: https://github.com/coreos/ignition/commit/76a71f08d3c1e27b2c4a3451c2d98ce5e054c7fd