### PR TITLE
fetch-offline: new stage for conditional networking

### DIFF
--- a/internal/exec/stages/fetch_offline/fetch-offline.go
+++ b/internal/exec/stages/fetch_offline/fetch-offline.go
@@ -1,0 +1,124 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The storage stage is responsible for partitioning disks, creating RAID
+// arrays, formatting partitions, writing files, writing systemd units, and
+// writing network units.
+
+package fetch_offline
+
+import (
+	"net/url"
+	"reflect"
+
+	cfgutil "github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_2_experimental/types"
+	"github.com/coreos/ignition/v2/internal/exec"
+	"github.com/coreos/ignition/v2/internal/exec/stages"
+	executil "github.com/coreos/ignition/v2/internal/exec/util"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/util"
+)
+
+const (
+	name = "fetch-offline"
+)
+
+func init() {
+	stages.Register(creator{})
+}
+
+type creator struct{}
+
+func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher) stages.Stage {
+	return &stage{
+		Util: executil.Util{
+			DestDir: root,
+			Logger:  logger,
+		},
+	}
+}
+
+func (creator) Name() string {
+	return name
+}
+
+type stage struct {
+	executil.Util
+}
+
+func (stage) Name() string {
+	return name
+}
+
+func (s stage) Run(cfg types.Config) error {
+	if needsNet, err := configNeedsNet(&cfg); err != nil {
+		return err
+	} else if needsNet {
+		return exec.SignalNeedNet()
+	}
+	return nil
+}
+
+func configNeedsNet(cfg *types.Config) (bool, error) {
+	return configNeedsNetRecurse(reflect.ValueOf(cfg))
+}
+
+func configNeedsNetRecurse(v reflect.Value) (bool, error) {
+	t := v.Type()
+	k := t.Kind()
+	switch {
+	case cfgutil.IsPrimitive(k):
+		return false, nil
+	case t == reflect.TypeOf(types.Resource{}):
+		return sourceNeedsNet(v.Interface().(types.Resource))
+	case k == reflect.Struct:
+		for i := 0; i < v.NumField(); i += 1 {
+			if needsNet, err := configNeedsNetRecurse(v.Field(i)); err != nil {
+				return false, err
+			} else if needsNet {
+				return true, nil
+			}
+		}
+	case k == reflect.Slice:
+		for i := 0; i < v.Len(); i += 1 {
+			if needsNet, err := configNeedsNetRecurse(v.Index(i)); err != nil {
+				return false, err
+			} else if needsNet {
+				return true, nil
+			}
+		}
+	case k == reflect.Ptr:
+		v = v.Elem()
+		if v.IsValid() {
+			return configNeedsNetRecurse(v)
+		}
+	default:
+		panic("unreachable code reached")
+	}
+
+	return false, nil
+}
+
+func sourceNeedsNet(res types.Resource) (bool, error) {
+	if res.Source == nil {
+		return false, nil
+	}
+	if u, err := url.Parse(*res.Source); err != nil {
+		return false, err
+	} else {
+		return util.UrlNeedsNet(*u), nil
+	}
+}

--- a/internal/exec/stages/fetch_offline/fetch_offline_test.go
+++ b/internal/exec/stages/fetch_offline/fetch_offline_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetch_offline
+
+import (
+	"testing"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_2_experimental/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func checkNeedsNet(t *testing.T, cfg *types.Config) bool {
+	needsNet, err := configNeedsNet(cfg)
+	assert.Equal(t, err, nil, "unexpected error: %v", err)
+	return needsNet
+}
+
+func assertNeedsNet(t *testing.T, cfg *types.Config) {
+	assert.Equal(t, checkNeedsNet(t, cfg), true, "unexpected config doesn't need net: %v", *cfg)
+}
+
+func assertNotNeedsNet(t *testing.T, cfg *types.Config) {
+	assert.Equal(t, checkNeedsNet(t, cfg), false, "unexpected config needs net: %v", *cfg)
+}
+
+func TestConfigNeedsNet(t *testing.T) {
+	cfg := types.Config{
+		Ignition: types.Ignition{
+			Version: "3.2.0-experimental",
+			Config: types.IgnitionConfig{
+				Replace: types.Resource{
+					Source: util.StrToPtr("http://example.com/config.ign"),
+				},
+			},
+		},
+	}
+	assertNeedsNet(t, &cfg)
+	cfg.Ignition.Config.Replace.Source = nil
+	assertNotNeedsNet(t, &cfg)
+	cfg.Storage.Files = []types.File{
+		{
+			Node: types.Node{
+				Path: "/etc/foobar.conf",
+			},
+			FileEmbedded1: types.FileEmbedded1{
+				Contents: types.Resource{
+					Source: util.StrToPtr("data:,hello"),
+				},
+			},
+		},
+	}
+	assertNotNeedsNet(t, &cfg)
+	cfg.Storage.Files[0].Contents.Source = util.StrToPtr("http://example.com/payload")
+	assertNeedsNet(t, &cfg)
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/stages"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/disks"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/fetch"
+	_ "github.com/coreos/ignition/v2/internal/exec/stages/fetch_offline"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/files"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/mount"
 	_ "github.com/coreos/ignition/v2/internal/exec/stages/umount"

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"net/url"
+)
+
+func UrlNeedsNet(u url.URL) bool {
+	return u.Scheme != "data"
+}


### PR DESCRIPTION
Add a new `fetch-offline` stage which can optionally be run before the
`fetch` stage. The major difference between the two is that the former
tries to operate in offline mode: if it encounters any resource which
requires network access, it quietly exits, creating a stamp file on the
way out.

This allows OS integrators to make use of this to only bring up
networking if Ignition actually requires it. It does not solve the
harder problem of "partially" up networking, where some fetches might
succeed and some others might fail. However, it provides an incremental
step to get there by reusing the same signalling mechanism.