### PR TITLE
doc: clarify wording of files.*.verification.hash

### DIFF
--- a/doc/configuration-v3_0.md
+++ b/doc/configuration-v3_0.md
@@ -56,12 +56,12 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created.
       * **_verification_** (object): options related to the verification of the file contents.
-        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+        * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is `sha512`.
     * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_verification_** (object): options related to the verification of the appended contents.
-        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+        * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is `sha512`.
     * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `source` is unspecified, and a file already exists at the path.
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.

--- a/doc/configuration-v3_1-experimental.md
+++ b/doc/configuration-v3_1-experimental.md
@@ -75,7 +75,7 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **name** (string): the header name.
         * **_value_** (string): the header contents.
       * **_verification_** (object): options related to the verification of the file contents.
-        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+        * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is `sha512`.
     * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
@@ -83,7 +83,7 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **name** (string): the header name.
         * **_value_** (string): the header contents.
       * **_verification_** (object): options related to the verification of the appended contents.
-        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+        * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is `sha512`.
     * **_mode_** (integer): the file's permission mode. Note that the mode must be properly specified as a **decimal** value (i.e. 0644 -> 420). If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `source` is unspecified, and a file already exists at the path.
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.


### PR DESCRIPTION
Fix copy-paste error referring to "config" rather than "contents".

Improves documentation of #961.