### PR TITLE
ci: run blackbox tests in CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -6,6 +6,22 @@ cosaPod(buildroot: true) {
     // hack to satisfy golang compiler wanting to cache things
     shwrap("mkdir cache")
     withEnv(["XDG_CACHE_HOME=${env.WORKSPACE}/cache"]) {
-        fcosBuild(make: true)
+        fcosBuild(make: true, skipKola: true)
+    }
+
+    // we run the blackbox tests separately instead of as part of the main kola
+    // run since it's a distinct kind of test and we want to draw more
+    // attention to it in the Jenkins UI
+    // XXX: need a e.g. `--tag !external`
+
+    fcosKola(extraArgs: "--blacklist-test ext.*")
+
+    stage("Blackbox Tests") {
+        shwrap("""
+            ./build_blackbox_tests
+            mkdir -p tests/kola/data
+            mv tests.test bin tests/kola/data
+        """)
+        fcosKola(extraArgs: "--tag external", skipUpgrade: true)
     }
 }

--- a/tests/kola/blackbox.sh
+++ b/tests/kola/blackbox.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+export PATH=${KOLA_EXT_DATA}/bin/amd64:$PATH
+exec ${KOLA_EXT_DATA}/tests.test


### PR DESCRIPTION
Right now, the blackbox test is running in a job on the CL Jenkins
instance. We want to migrate this to CoreOS CI where we have the right
perms set up for everyone to see.

Use the new external host tests support in kola to just run it directly
in the just-built FCOS where it'll have all the privs it needs to e.g.
set up loopback devices.

Aside: I'm thinking we should be able to migrate all of those blackbox
tests to external host tests if we gained the ability to specify the
Ignition config. Booting VMs would be more expensive of course, but way
closer to how Ignition is actually run and it would allow cleaning up
the blackbox testing-specific code. We could also do tricks like not
actually switch root to make each test less expensive.