### PR TITLE
ci: Freeze kernel at 5.6.7 due to loop regression breaking blackbox test

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -6,7 +6,16 @@ cosaPod(buildroot: true) {
     // hack to satisfy golang compiler wanting to cache things
     shwrap("mkdir cache")
     withEnv(["XDG_CACHE_HOME=${env.WORKSPACE}/cache"]) {
-        fcosBuild(make: true, skipKola: true)
+        // freeze kernel to 5.6.7 for now to avoid a regression in loopback
+        // code which interferes with blackbox testing
+        // https://bugs.archlinux.org/task/66526
+        shwrap("""
+            mkdir -p /srv/fcos && cd /srv/fcos
+            cosa init https://github.com/coreos/fedora-coreos-config
+            mkdir -p overrides/rpm && cd overrides/rpm
+            curl -L --remote-name-all https://kojipkgs.fedoraproject.org//packages/kernel/5.6.7/200.fc31/x86_64/kernel{,-core,-modules}-5.6.7-200.fc31.x86_64.rpm
+        """)
+        fcosBuild(skipInit: true, make: true, skipKola: true)
     }
 
     // we run the blackbox tests separately instead of as part of the main kola


### PR DESCRIPTION
It seems like there's a regression in the 5.6.8 kernel causing our
blackbox tests to fail with e.g.:

```
blackbox_test.go:114: failed: "mkfs.vfat": exit status 1
    mkfs.vfat: unable to open /dev/loop0p1: No such file or directory
    mkfs.fat 4.1 (2017-01-24)
```

And looking at dmesg, one can see the partition rescan is failing with
`-EBUSY`:

```
__loop_clr_fd: partition scan of loop3 failed (rc=-16)
loop_reread_partitions: partition scan of loop0 (/var/tmp/ignition-blackbox-570148150/hd0) failed (rc=-16)
loop_reread_partitions: partition scan of loop1 (/var/tmp/ignition-blackbox-134124829/hd0) failed (rc=-16)
loop_reread_partitions: partition scan of loop2 (/var/tmp/ignition-blackbox-492917208/hd0) failed (rc=-16)
loop_reread_partitions: partition scan of loop3 (/var/tmp/ignition-blackbox-966528855/hd0) failed (rc=-16)
```

Looking at the 5.6.8 notes, the only commit that jumps out is
https://lkml.org/lkml/2019/5/6/1059, though it seems focused on loop
devices backed by block devices.

The only other report I found of this is:
https://bugs.archlinux.org/task/66526

Anyway, I don't think this is a serious enough regression to hold the
kernel in FCOS. But I really want blackbox tests to work in CoreOS CI
where it's easy for everyone to inspect results, download, retry, etc..
So let's override the kernel for now.

According to the Arch Linux bug, it seems like it's partially fixed in
5.7 (though I haven't tried it), so we should be able to unfreeze it
then (or if we want, fast-track it once there's a build for f32).