### PR TITLE
config/*: drop warning on unset file/dir mode

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -34,8 +34,6 @@ var (
 	ErrCompressionInvalid = errors.New("invalid compression method")
 
 	// Storage section errors
-	ErrFilePermissionsUnset      = errors.New("permissions unset, defaulting to 0644")
-	ErrDirectoryPermissionsUnset = errors.New("permissions unset, defaulting to 0755")
 	ErrFileUsedSymlink           = errors.New("file path includes link in config")
 	ErrDirectoryUsedSymlink      = errors.New("directory path includes link in config")
 	ErrLinkUsedSymlink           = errors.New("link path includes link in config")
@@ -91,6 +89,10 @@ var (
 
 	// AWS S3 specific errors
 	ErrInvalidS3ObjectVersionId = errors.New("invalid S3 object VersionId")
+
+	// Obsolete errors, left here for ABI compatibility
+	ErrFilePermissionsUnset      = errors.New("permissions unset, defaulting to 0644")
+	ErrDirectoryPermissionsUnset = errors.New("permissions unset, defaulting to 0755")
 )
 
 // NewNoInstallSectionError produces an error indicating the given unit, named

--- a/config/v3_0/types/directory.go
+++ b/config/v3_0/types/directory.go
@@ -15,8 +15,6 @@
 package types
 
 import (
-	"github.com/coreos/ignition/v2/config/shared/errors"
-
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
@@ -24,8 +22,5 @@ import (
 func (d Directory) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(d.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(d.Mode))
-	if d.Mode == nil {
-		r.AddOnWarn(c.Append("mode"), errors.ErrDirectoryPermissionsUnset)
-	}
 	return
 }

--- a/config/v3_0/types/file.go
+++ b/config/v3_0/types/file.go
@@ -24,9 +24,6 @@ import (
 func (f File) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
-	if f.Mode == nil && f.Contents.Source != nil {
-		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)
-	}
 	r.AddOnError(c.Append("overwrite"), f.validateOverwrite())
 	return
 }

--- a/config/v3_1/types/directory.go
+++ b/config/v3_1/types/directory.go
@@ -15,8 +15,6 @@
 package types
 
 import (
-	"github.com/coreos/ignition/v2/config/shared/errors"
-
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
@@ -24,8 +22,5 @@ import (
 func (d Directory) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(d.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(d.Mode))
-	if d.Mode == nil {
-		r.AddOnWarn(c.Append("mode"), errors.ErrDirectoryPermissionsUnset)
-	}
 	return
 }

--- a/config/v3_1/types/file.go
+++ b/config/v3_1/types/file.go
@@ -24,9 +24,6 @@ import (
 func (f File) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
-	if f.Mode == nil && f.Contents.Source != nil {
-		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)
-	}
 	r.AddOnError(c.Append("overwrite"), f.validateOverwrite())
 	return
 }

--- a/config/v3_2_experimental/types/directory.go
+++ b/config/v3_2_experimental/types/directory.go
@@ -15,8 +15,6 @@
 package types
 
 import (
-	"github.com/coreos/ignition/v2/config/shared/errors"
-
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
@@ -24,8 +22,5 @@ import (
 func (d Directory) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(d.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(d.Mode))
-	if d.Mode == nil {
-		r.AddOnWarn(c.Append("mode"), errors.ErrDirectoryPermissionsUnset)
-	}
 	return
 }

--- a/config/v3_2_experimental/types/file.go
+++ b/config/v3_2_experimental/types/file.go
@@ -24,9 +24,6 @@ import (
 func (f File) Validate(c path.ContextPath) (r report.Report) {
 	r.Merge(f.Node.Validate(c))
 	r.AddOnError(c.Append("mode"), validateMode(f.Mode))
-	if f.Mode == nil && f.Contents.Source != nil {
-		r.AddOnWarn(c.Append("mode"), errors.ErrFilePermissionsUnset)
-	}
 	r.AddOnError(c.Append("overwrite"), f.validateOverwrite())
 	return
 }


### PR DESCRIPTION
The warning was originally added in https://github.com/coreos/ignition/pull/493 because Ignition spec 2 defaulted to mode 0000, which was certainly not what the user wanted.  However, spec 3 defaults to 0755 for dirs and 0644 for files, and is documented as such.  It's therefore reasonable for the user to omit those fields, and by issuing the warnings we're encouraging the user to write unnecessarily verbose Ignition configs (or FCCs).