### PR TITLE
files: don't run `setfiles` with `-i`

### DIFF
--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -66,12 +66,26 @@ func (s *stage) createPasswd(config types.Config) error {
 		}
 
 		s.relabel(deglobbed...)
-		s.relabel(
-			"/etc/.pwd.lock",
-			// for OSTree-based systems
-			"/var/home",
-			"/var/roothome",
-		)
+		s.relabel("/etc/.pwd.lock")
+		for _, user := range config.Passwd.Users {
+			if user.NoCreateHome != nil && *user.NoCreateHome == true {
+				continue
+			}
+			homedir, err := s.GetUserHomeDir(user)
+			if err != nil {
+				return err
+			}
+			s.relabel(homedir)
+
+			// Check if the homedir is actually a symlink, and make sure we
+			// relabel the target too. This is relevant on OSTree-based
+			// platforms, where /root is a link to /var/roothome.
+			if resolved, err := s.ResolveSymlink(homedir); err != nil {
+				return err
+			} else if resolved != "" {
+				s.relabel(resolved)
+			}
+		}
 	}
 
 	return nil

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -180,11 +180,15 @@ func (u Util) AuthorizeSSHKeys(c types.PasswdUser) error {
 		}
 		var path string
 		if distro.WriteAuthorizedKeysFragment() {
-			path = filepath.Join(usr.HomeDir, ".ssh", "authorized_keys.d", "ignition")
-			err = writeAuthKeysFile(usr, path, []byte(ks))
+			path, err = u.JoinPath(usr.HomeDir, ".ssh", "authorized_keys.d", "ignition")
+			if err == nil {
+				err = writeAuthKeysFile(usr, path, []byte(ks))
+			}
 		} else {
-			path = filepath.Join(usr.HomeDir, ".ssh", "authorized_keys")
-			err = writeAuthKeysFile(usr, path, []byte(ks))
+			path, err = u.JoinPath(usr.HomeDir, ".ssh", "authorized_keys")
+			if err == nil {
+				err = writeAuthKeysFile(usr, path, []byte(ks))
+			}
 		}
 		if err != nil {
 			return fmt.Errorf("failed to set SSH key: %v", err)

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -115,6 +115,16 @@ func (u Util) EnsureUser(c types.PasswdUser) error {
 	return err
 }
 
+// GetUserHomeDir returns the user home directory. Note that DestDir is not
+// prefixed.
+func (u Util) GetUserHomeDir(c types.PasswdUser) (string, error) {
+	usr, err := u.userLookup(c.Name)
+	if err != nil {
+		return "", err
+	}
+	return usr.HomeDir, nil
+}
+
 // CheckIfUserExists will return Info log when user is empty
 func (u Util) CheckIfUserExists(c types.PasswdUser) (bool, error) {
 	_, err := u.userLookup(c.Name)

--- a/internal/exec/util/selinux.go
+++ b/internal/exec/util/selinux.go
@@ -77,7 +77,7 @@ func (ut Util) RelabelFiles(patterns []string) error {
 		return err
 	}
 
-	cmd := exec.Command(distro.SetfilesCmd(), "-vFi0", "-r", ut.DestDir, file_contexts, "-f", "-")
+	cmd := exec.Command(distro.SetfilesCmd(), "-vF0", "-r", ut.DestDir, file_contexts, "-f", "-")
 	cmd.Stdin = strings.NewReader(strings.Join(patterns, "\000") + "\000")
 	if _, err := ut.Logger.LogCmd(cmd, "relabeling %d patterns", len(patterns)); err != nil {
 		return err

--- a/internal/exec/util/user_group_lookup.go
+++ b/internal/exec/util/user_group_lookup.go
@@ -40,16 +40,11 @@ func (u Util) userLookup(name string) (*user.User, error) {
 		return nil, user.UnknownUserError(fmt.Sprintf("user %q not found", name))
 	}
 
-	homedir, err := u.JoinPath(C.GoString(res.home))
-	if err != nil {
-		return nil, err
-	}
-
 	usr := &user.User{
 		Name:    C.GoString(res.name),
 		Uid:     fmt.Sprintf("%d", int(res.uid)),
 		Gid:     fmt.Sprintf("%d", int(res.gid)),
-		HomeDir: homedir,
+		HomeDir: C.GoString(res.home),
 	}
 
 	C.user_lookup_res_free(res)


### PR DESCRIPTION
We shouldn't need to run `setfiles` with `-i`, which causes `setfiles`
to ignore files that do not exist. All the files which we pass to
`setfiles` should exist, and it should be a hard error if `setfiles`
fails to find and relabel the file we wrote.

This dates from #632, where we
added `/var/home` and `/var/roothome` for OSTree-based systems. We
actually don't need to special-case OSTree systems at all anymore.

The `/var/home` and `/var/roothome` directories themselves are now
handled by `ignition-ostree-populate-var.service`. All we need to take
care of here is to relabel the homedir files we created or modified for
each user.

Because `setfiles` by default doesn't follow the final symlink, we also
add a check here to relabel the target if the homedir is a link.
(Ideally, we'd change the home directory of `root `to be `/var/roothome`
like we do in rpm-ostree based systems for regular users:
coreos/rpm-ostree#1726, but it's probably not
worth the ripples that would cause.)