### PR TITLE
Various CI tweaks

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -6,13 +6,13 @@ cosaPod(buildroot: true) {
     // hack to satisfy golang compiler wanting to cache things
     shwrap("mkdir cache")
     withEnv(["XDG_CACHE_HOME=${env.WORKSPACE}/cache"]) {
-        // freeze kernel to 5.6.7 for now to avoid a regression in loopback
-        // code which interferes with blackbox testing
-        // https://bugs.archlinux.org/task/66526
         shwrap("""
             mkdir -p /srv/fcos && cd /srv/fcos
             cosa init https://github.com/coreos/fedora-coreos-config
             mkdir -p overrides/rpm && cd overrides/rpm
+            # freeze kernel to 5.6.7 for now to avoid a regression in loopback
+            # code which interferes with blackbox testing
+            # https://bugs.archlinux.org/task/66526
             curl -L --remote-name-all https://kojipkgs.fedoraproject.org//packages/kernel/5.6.7/200.fc31/x86_64/kernel{,-core,-modules}-5.6.7-200.fc31.x86_64.rpm
         """)
         shwrap("""

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -6,6 +6,10 @@ cosaPod(buildroot: true) {
     // hack to satisfy golang compiler wanting to cache things
     shwrap("mkdir cache")
     withEnv(["XDG_CACHE_HOME=${env.WORKSPACE}/cache"]) {
+        // first, run gofmt/govet/unit tests
+        stage("Unit Tests") {
+            shwrap("./test")
+        }
         shwrap("""
             mkdir -p /srv/fcos && cd /srv/fcos
             cosa init https://github.com/coreos/fedora-coreos-config


### PR DESCRIPTION
```
$ git log upstream/master..
commit cdcac7ea8ed9706686abd1f3fd85c3fc1df7cf0c
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Tue Jun 9 17:17:38 2020 -0400

    ci: also run gofmt and unit tests

    Part of the work to replace the CL Jenkins and Travis in favour of
    CoreOS CI.

commit 8267bcf13662b6589ab065920a5030b369f1a28b
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Tue Jun 9 17:16:48 2020 -0400

    ci: move comment about kernel closer to `curl`

    So that it's clearer what it's referring to.
```