### PR TITLE
providers/qemu: support Ignition block device on all arches

### DIFF
--- a/internal/providers/qemu/qemu_fwcfg_unsupported.go
+++ b/internal/providers/qemu/qemu_fwcfg_unsupported.go
@@ -1,4 +1,4 @@
-// Copyright 2016 CoreOS, Inc.
+// Copyright 2020 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,30 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !s390x,!ppc64le
+// +build s390x ppc64le
 
 package qemu
 
 import (
-	"io/ioutil"
-	"os/exec"
-
 	"github.com/coreos/ignition/v2/internal/resource"
 )
 
-const (
-	firmwareConfigPath = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
-)
-
 func fwCfgSupported() bool {
-	return true
+	return false
 }
 
-func fetchFromFwCfg(f *resource.Fetcher) ([]byte, error) {
-	_, err := f.Logger.LogCmd(exec.Command("modprobe", "qemu_fw_cfg"), "loading QEMU firmware config module")
-	if err != nil {
-		return nil, err
-	}
-
-	return ioutil.ReadFile(firmwareConfigPath)
+func fetchFromFwCfg(_ *resource.Fetcher) ([]byte, error) {
+	panic("unreachable")
 }


### PR DESCRIPTION
We've had some good success with the new block device approach on s390x
and ppc64le. Let's now make it available on all arches. This is the
first step towards eventually deprecating `fw_cfg`:

https://github.com/coreos/ignition/issues/928#issuecomment-640695503

Early adopters will benefit from simplified code which works across all
architectures, as well as better compatibility with other virtualization
tooling like libvirt, which today doesn't expose `fw_cfg` easily (though
there's work in flight for that).