### PR TITLE
internal/exec/engine: write empty cache config when not provided

### DIFF
--- a/internal/resource/http.go
+++ b/internal/resource/http.go
@@ -209,6 +209,8 @@ func (f *Fetcher) RewriteCAsWithDataUrls(cas []types.Resource) error {
 
 		// Clean HTTP headers
 		cas[i].HTTPHeaders = nil
+		// the rewrite wipes the compression
+		cas[i].Compression = nil
 
 		encoded := dataurl.EncodeBytes(blob)
 		cas[i].Source = &encoded

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -279,6 +279,10 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 	appendEnv = append(appendEnv, "IGNITION_SYSTEM_CONFIG_DIR="+systemConfigDir)
 
 	if !negativeTests {
+		if err := runIgnition(t, ctx, "fetch", "", tmpDirectory, appendEnv); err != nil {
+			return err
+		}
+
 		if err := runIgnition(t, ctx, "disks", "", tmpDirectory, appendEnv); err != nil {
 			return err
 		}
@@ -315,6 +319,10 @@ func outer(t *testing.T, test types.Test, negativeTests bool) error {
 		}
 		return nil
 	} else {
+		if err := runIgnition(t, ctx, "fetch", "", tmpDirectory, appendEnv); err != nil {
+			return nil // error is expected
+		}
+
 		if err := runIgnition(t, ctx, "disks", "", tmpDirectory, appendEnv); err != nil {
 			return nil // error is expected
 		}

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -152,7 +152,7 @@ func umountPartition(p *types.Partition) error {
 
 // returns true if no error, false if error
 func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, appendEnv []string) error {
-	args := []string{"-clear-cache", "-platform", "file", "-stage", stage,
+	args := []string{"-platform", "file", "-stage", stage,
 		"-root", root, "-log-to-stdout", "--config-cache", filepath.Join(cwd, "ignition.json")}
 	cmd := exec.CommandContext(ctx, "ignition", args...)
 	t.Log("ignition", args)


### PR DESCRIPTION
When the user-provided config is empty write an empty cache config to
prevent re-fetching it in every stage.

Closes #950 