### PR TITLE
Azure: allow custom-data volume to be either UDF or iso9660

### DIFF
--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -67,7 +67,7 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 
 	logger.Debug("mounting config device")
 	if err := logger.LogOp(
-		func() error { return unix.Mount(devicePath, mnt, "udf", unix.MS_RDONLY, "") },
+		func() error { return unix.Mount(devicePath, mnt, "udf,iso9660", unix.MS_RDONLY, "") },
 		"mounting %q at %q", devicePath, mnt,
 	); err != nil {
 		return types.Config{}, report.Report{}, fmt.Errorf("failed to mount device %q at %q: %v", devicePath, mnt, err)


### PR DESCRIPTION
On AzureStack, the custom-data volume may be iso9660. WALinuxAgent
currently uses "udf,iso9660" as the mount device, while cloud-init finds
devices that either "udf" or "iso9660".

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/476