### PR TITLE
internal/util/url: don't require networking for empty schemes

### DIFF
--- a/internal/exec/stages/fetch_offline/fetch_offline_test.go
+++ b/internal/exec/stages/fetch_offline/fetch_offline_test.go
@@ -64,6 +64,10 @@ func TestConfigNeedsNet(t *testing.T) {
 		},
 	}
 	assertNotNeedsNet(t, &cfg)
+	cfg.Storage.Files[0].Contents.Source = util.StrToPtr("")
+	assertNotNeedsNet(t, &cfg)
+	cfg.Storage.Files[0].Contents.Source = nil
+	assertNotNeedsNet(t, &cfg)
 	cfg.Storage.Files[0].Contents.Source = util.StrToPtr("http://example.com/payload")
 	assertNeedsNet(t, &cfg)
 }

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -19,5 +19,5 @@ import (
 )
 
 func UrlNeedsNet(u url.URL) bool {
-	return u.Scheme != "data"
+	return u.Scheme != "data" && u.Scheme != ""
 }


### PR DESCRIPTION
Right now Ignition will incorrectly report that it needs networking when
an empty scheme is given. Modify the `UrlNeedsNet` function to allow
both `data` & empty schemes.

A common case that could hit this is a config that writes a file with
empty contents.