### PR TITLE
Add Exoscale Provider support to spec2x

### DIFF
--- a/internal/oem/oem.go
+++ b/internal/oem/oem.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/ignition/internal/providers/cloudstack"
 	"github.com/coreos/ignition/internal/providers/digitalocean"
 	"github.com/coreos/ignition/internal/providers/ec2"
+	"github.com/coreos/ignition/internal/providers/exoscale"
 	"github.com/coreos/ignition/internal/providers/file"
 	"github.com/coreos/ignition/internal/providers/gce"
 	"github.com/coreos/ignition/internal/providers/noop"
@@ -109,7 +110,7 @@ func init() {
 	})
 	configs.Register(Config{
 		name:  "exoscale",
-		fetch: noop.FetchConfig,
+		fetch: exoscale.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "gce",

--- a/internal/providers/exoscale/exoscale.go
+++ b/internal/providers/exoscale/exoscale.go
@@ -1,0 +1,45 @@
+// Copyright 2020 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Exoscale provider fetches a remote configuration from the
+// Exoscale user-data metadata service URL.
+
+package exoscale
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/config/validate/report"
+	"github.com/coreos/ignition/internal/config/types"
+	"github.com/coreos/ignition/internal/providers/util"
+	"github.com/coreos/ignition/internal/resource"
+)
+
+var (
+	userdataURL = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "1.0/user-data",
+	}
+)
+
+// FetchConfig fetch Exoscale ign user-data config
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataURL, resource.FetchOptions{})
+	if err != nil && err != resource.ErrNotFound {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}


### PR DESCRIPTION
Add Exoscale Provider to spec2x branch to be supported  by CL and RHEL CoreOS, which (for now) targets Ignition v0.x (spec 2).