### PR TITLE
files: relabel the systemd preset directory

### DIFF
--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -103,6 +103,9 @@ func (s *stage) createUnits(config types.Config) error {
 	}
 	// if we have presets then create the systemd preset file.
 	if len(presets) != 0 {
+		if err := s.relabelDirsForFile(filepath.Join(s.DestDir, util.PresetPath)); err != nil {
+			return err
+		}
 		if err := s.createSystemdPresetFile(presets); err != nil {
 			return err
 		}


### PR DESCRIPTION
On Fedora CoreOS, the `/etc/systemd/system-preset` directory doesn't
exist, which means that we need to make sure we label it when we create
it.