### PR TITLE
disks: add support for nested RAID devices

### DIFF
--- a/tests/kola/raid/config.ign
+++ b/tests/kola/raid/config.ign
@@ -1,0 +1,89 @@
+{
+  "ignition": {
+    "version": "3.0.0"
+  },
+  "storage": {
+    "disks": [
+      {
+        "device": "/dev/disk/by-id/virtio-disk1",
+        "partitions": [
+          {
+            "label": "foo"
+          }
+        ],
+        "wipeTable": true
+      },
+      {
+        "device": "/dev/disk/by-id/virtio-disk2",
+        "partitions": [
+          {
+            "label": "bar"
+          }
+        ],
+        "wipeTable": true
+      },
+      {
+        "device": "/dev/disk/by-id/virtio-disk3",
+        "partitions": [
+          {
+            "label": "baz"
+          }
+        ],
+        "wipeTable": true
+      },
+      {
+        "device": "/dev/disk/by-id/virtio-disk4",
+        "partitions": [
+          {
+            "label": "boo"
+          }
+        ],
+        "wipeTable": true
+      }
+    ],
+    "raid": [
+      {
+        "devices": [
+          "/dev/md/foobar",
+          "/dev/md/bazboo"
+        ],
+        "level": "raid0",
+        "name": "foobarbazboo"
+      },
+      {
+        "devices": [
+          "/dev/disk/by-partlabel/baz",
+          "/dev/disk/by-partlabel/boo"
+        ],
+        "level": "raid1",
+        "name": "bazboo"
+      },
+      {
+        "devices": [
+          "/dev/disk/by-partlabel/foo",
+          "/dev/disk/by-partlabel/bar"
+        ],
+        "level": "raid1",
+        "name": "foobar"
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/md/foobarbazboo",
+        "path": "/var",
+        "format": "xfs",
+        "wipeFilesystem": true,
+        "label": "VAR"
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nBefore=local-fs.target\nRequires=systemd-fsck@dev-disk-by\\x2dlabel-VAR.service\nAfter=systemd-fsck@dev-disk-by\\x2dlabel-VAR.service\n\n[Mount]\nWhere=/var\nWhat=/dev/disk/by-label/VAR\nType=xfs\n\n[Install]\nRequiredBy=local-fs.target",
+        "enabled": true,
+        "name": "var.mount"
+      }
+    ]
+  }
+}

--- a/tests/kola/raid/nested.sh
+++ b/tests/kola/raid/nested.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# kola: {"platforms": "qemu", "additionalDisks": ["1G", "1G", "1G", "1G"]}
+set -euo pipefail
+
+srcdev=$(findmnt -nvr /var -o SOURCE)
+[[ ${srcdev} == /dev/md* ]]
+
+devtype=$(lsblk --nodeps --noheadings "${srcdev}" -o TYPE)
+[[ ${devtype} == raid0 ]]
+
+for dev in /sys/block/"$(basename "${srcdev}")"/slaves/*; do
+    dev=/dev/$(basename "${dev}")
+    devtype=$(lsblk --nodeps --noheadings "${dev}" -o TYPE)
+    [[ ${devtype} == raid1 ]]
+done


### PR DESCRIPTION
Add support for RAID devices which use other RAID devices. To do this,
instead of trying to be clever and figure out the dependencies between
the various RAID devices, we just run all the operations in parallel.
The goroutines which have dependencies will naturally wait for the
lower-level devices to appear.

Hit this while testing FCOS rootfs-on-RAID. Wanted to make sure that my
code recursed correctly up the block device hierarchy when figuring out
the rootmap by doing a RAID10 (i.e. RAID0 on RAID1).

Closes: #581