### PR TITLE
AzureStack: introduce new provider

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/aliyun"
 	"github.com/coreos/ignition/v2/internal/providers/aws"
 	"github.com/coreos/ignition/v2/internal/providers/azure"
+	"github.com/coreos/ignition/v2/internal/providers/azurestack"
 	"github.com/coreos/ignition/v2/internal/providers/cloudstack"
 	"github.com/coreos/ignition/v2/internal/providers/digitalocean"
 	"github.com/coreos/ignition/v2/internal/providers/exoscale"
@@ -90,6 +91,10 @@ func init() {
 	configs.Register(Config{
 		name:  "azure",
 		fetch: azure.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "azurestack",
+		fetch: azurestack.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "brightbox",

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -53,20 +53,29 @@ const (
 	CDS_DISC_OK
 )
 
-// These constants are the types of CDROM filesystems that might
-// be used to present a custom-data volume. Azure proper uses a
-// udf volume, while Azure Stack might use udf or iso9660.
+// Azure uses a UDF volume for the OVF configuration.
 const (
-	CDS_FSTYPE_UDF     = "udf"
-	CDS_FSTYPE_ISO9660 = "iso9660"
+	CDS_FSTYPE_UDF = "udf"
 )
 
+// FetchConfig wraps FetchOvfDevice to implement the platform.NewFetcher interface.
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	return FetchFromOvfDevice(f, []string{CDS_FSTYPE_UDF})
+}
+
+// FetchFromOvfDevice has the return signature of platform.NewFetcher. It is
+// wrapped by this and AzureStack packages.
+func FetchFromOvfDevice(f *resource.Fetcher, ovfFsTypes []string) (types.Config, report.Report, error) {
 	devicePath := filepath.Join(distro.DiskByIDDir(), configDeviceID)
 
 	logger := f.Logger
 	logger.Debug("waiting for config DVD...")
 	waitForCdrom(logger, devicePath)
+
+	fsType, err := checkOvfFsType(logger, devicePath, ovfFsTypes)
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
 
 	mnt, err := ioutil.TempDir("", "ignition-azure")
 	if err != nil {
@@ -74,17 +83,9 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	}
 	defer os.Remove(mnt)
 
-	fs, err := execUtil.GetFilesystemInfo(devicePath, false)
-	if err != nil {
-		return types.Config{}, report.Report{}, fmt.Errorf("failed to get config fs type %s: %v", devicePath, err)
-	}
-	if !(fs.Type == CDS_FSTYPE_UDF || fs.Type == CDS_FSTYPE_ISO9660) {
-		return types.Config{}, report.Report{}, fmt.Errorf("found unsupported filesystem %s on %s", fs.Type, devicePath)
-	}
-
 	logger.Debug("mounting config device")
 	if err := logger.LogOp(
-		func() error { return unix.Mount(devicePath, mnt, fs.Type, unix.MS_RDONLY, "") },
+		func() error { return unix.Mount(devicePath, mnt, fsType, unix.MS_RDONLY, "") },
 		"mounting %q at %q", devicePath, mnt,
 	); err != nil {
 		return types.Config{}, report.Report{}, fmt.Errorf("failed to mount device %q at %q: %v", devicePath, mnt, err)
@@ -142,4 +143,17 @@ func isCdromPresent(logger *log.Logger, devicePath string) bool {
 	}
 
 	return (status == CDS_DISC_OK)
+}
+
+func checkOvfFsType(logger *log.Logger, devicePath string, fsTypes []string) (string, error) {
+	fs, err := execUtil.GetFilesystemInfo(devicePath, false)
+	if err != nil {
+		return fs.Type, fmt.Errorf("failed to detect filesystem on ovf device %q: %v", devicePath, err)
+	}
+	for _, f := range fsTypes {
+		if f == fs.Type {
+			return fs.Type, nil
+		}
+	}
+	return fs.Type, fmt.Errorf("filesystem %q is not a supported ovf device", fs.Type)
 }

--- a/internal/providers/azurestack/azurestack.go
+++ b/internal/providers/azurestack/azurestack.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The AzureStack provider is a wrapper around the regular Azure provider
+// but allows for the use of both UDF and iso9660 filesystems on the OVF disk.
+
+package azurestack
+
+import (
+	"github.com/coreos/ignition/v2/config/v3_2_experimental/types"
+	"github.com/coreos/ignition/v2/internal/providers/azure"
+	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/vcontext/report"
+)
+
+// These constants are the types of CDROM filesystems that might
+// be used to present a custom-data volume. Azure proper uses a
+// udf volume, while Azure Stack might use udf or iso9660.
+const (
+	CDS_FSTYPE_UDF     = "udf"
+	CDS_FSTYPE_ISO9660 = "iso9960"
+)
+
+// FetchConfig implements the platform.NewFetcher interface.
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	return azure.FetchFromOvfDevice(f, []string{CDS_FSTYPE_UDF, CDS_FSTYPE_ISO9660})
+}


### PR DESCRIPTION
This moves the iso9660 support out of Azure's provider and introduces a
new provider for AzureStack. Per [1], we found that AzureStack should be
treated as its own platform. The Azure provider now is configurable for
the filesystem types.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/476

Signed-off-by: Ben Howard <ben.howard@redhat.com>