### PR TITLE
units: empty dropins should be written to disk

### DIFF
--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -186,7 +186,7 @@ func (s *stage) writeSystemdUnit(unit types.Unit, runtime bool) error {
 	return s.Logger.LogOp(func() error {
 		relabeledDropinDir := false
 		for _, dropin := range unit.Dropins {
-			if dropin.Contents == nil || *dropin.Contents == "" {
+			if dropin.Contents == nil {
 				continue
 			}
 			f, err := u.FileFromSystemdUnitDropin(unit, dropin, runtime)

--- a/tests/positive/files/units.go
+++ b/tests/positive/files/units.go
@@ -21,6 +21,7 @@ import (
 
 func init() {
 	register.Register(register.PositiveTest, CreateInstantiatedService())
+	register.Register(register.PositiveTest, CreateEmptyDropinsUnit())
 }
 
 func CreateInstantiatedService() types.Test {
@@ -61,6 +62,47 @@ func CreateInstantiatedService() types.Test {
 				Directory: "etc/systemd/system-preset",
 			},
 			Contents: "enable echo@.service bar foo\n",
+		},
+	})
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+// CreateEmptyDropinsUnit writes an empty dropin to the disk.
+func CreateEmptyDropinsUnit() types.Test {
+	name := "unit.create.emptydropin"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+		"ignition": { "version": "$version" },
+		"systemd": {
+			"units": [
+			  {
+				"name": "zincati.service",
+				"dropins": [
+					{
+						"name": "empty.conf",
+						"contents": ""
+					}
+				]
+			  }
+			]
+		  }
+		}`
+	configMinVersion := "3.0.0"
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "empty.conf",
+				Directory: "etc/systemd/system/zincati.service.d",
+			},
+			Contents: "",
 		},
 	})
 


### PR DESCRIPTION
Fixes https://github.com/coreos/ignition/issues/975