### PR TITLE
internal/blkid: Clean up the C wrapper to not abuse type casts

### DIFF
--- a/internal/exec/util/blkid.go
+++ b/internal/exec/util/blkid.go
@@ -41,7 +41,7 @@ const (
 )
 
 type DiskInfo struct {
-	LogicalSectorSize int // 4k or 512
+	LogicalSectorSize uint64 // 4k or 512
 	Partitions        []PartitionInfo
 }
 
@@ -58,8 +58,8 @@ type PartitionInfo struct {
 	Label         string
 	GUID          string
 	TypeGUID      string
-	StartSector   int
-	SizeInSectors int
+	StartSector   int64
+	SizeInSectors int64
 	Number        int
 }
 
@@ -147,7 +147,7 @@ func DumpDisk(device string) (DiskInfo, error) {
 	cDevice := C.CString(device)
 	defer C.free(unsafe.Pointer(cDevice))
 
-	cSectorSizeRef := (*C.int)(unsafe.Pointer(&output.LogicalSectorSize))
+	cSectorSizeRef := (*C.ulong)(unsafe.Pointer(&output.LogicalSectorSize))
 	if err := cResultToErr(C.blkid_get_logical_sector_size(cDevice, cSectorSizeRef), device); err != nil {
 		return DiskInfo{}, err
 	}
@@ -168,8 +168,8 @@ func DumpDisk(device string) (DiskInfo, error) {
 			GUID:          strings.ToUpper(CBufToGoStr(cInfo.uuid)),
 			TypeGUID:      strings.ToUpper(CBufToGoStr(cInfo.type_guid)),
 			Number:        int(cInfo.number),
-			StartSector:   int(cInfo.start),
-			SizeInSectors: int(cInfo.size),
+			StartSector:   int64(cInfo.start),
+			SizeInSectors: int64(cInfo.size),
 		}
 
 		output.Partitions = append(output.Partitions, current)

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -17,6 +17,7 @@
 
 #include <string.h>
 #include <stdbool.h>
+#include <blkid/blkid.h>
 
 typedef enum {
 	RESULT_OK,
@@ -43,8 +44,8 @@ struct partition_info {
 	char label[PART_INFO_BUF_SIZE];
 	char uuid[PART_INFO_BUF_SIZE];
 	char type_guid[PART_INFO_BUF_SIZE];
-	long long start; // needs to be 64 bit
-	long long size;  // to handle large partitions
+	blkid_loff_t start; // needs to be 64 bit
+	blkid_loff_t size;  // to handle large partitions
 	int number;
 };
 
@@ -52,7 +53,7 @@ result_t blkid_lookup(const char *device, bool allow_ambivalent, const char *fie
 
 result_t blkid_get_num_partitions(const char *device, int *ret);
 
-result_t blkid_get_logical_sector_size(const char *device, int *ret_sector_size);
+result_t blkid_get_logical_sector_size(const char *device, unsigned long *ret_sector_size);
 
 // WARNING part_num may not be what you expect. see the .c file's comment for why
 result_t blkid_get_partition(const char *device, int part_num, struct partition_info *info);


### PR DESCRIPTION
Use blkid_loff_t typedef of int64_t as libblkid is using it. This caused issue on s390x that lead to precision loss. Sector size and partition size would be incorrect, leading to errors in creating fs(partition too small) or partition schema(partitioning to big for the underlying disk).

It would be great if we can make the *MiB "json" fields int64 too to mirror the precision from the blkid(Implementation in this PR could have issues on the 32bit platforms, do we care?). Do you know how well that would play with the schema, parser?
Tested as backport on top of Fedora's ignition on x86_64 and s390x.