### PR TITLE
fetch-offline: signal networking for Tang-pinned LUKS devices

### DIFF
--- a/internal/exec/stages/fetch_offline/fetch-offline.go
+++ b/internal/exec/stages/fetch_offline/fetch-offline.go
@@ -84,6 +84,8 @@ func configNeedsNetRecurse(v reflect.Value) (bool, error) {
 		return false, nil
 	case t == reflect.TypeOf(types.Resource{}):
 		return sourceNeedsNet(v.Interface().(types.Resource))
+	case t == reflect.TypeOf(types.Tang{}):
+		return true, nil
 	case k == reflect.Struct:
 		for i := 0; i < v.NumField(); i += 1 {
 			if needsNet, err := configNeedsNetRecurse(v.Field(i)); err != nil {

--- a/internal/exec/stages/fetch_offline/fetch_offline_test.go
+++ b/internal/exec/stages/fetch_offline/fetch_offline_test.go
@@ -70,4 +70,21 @@ func TestConfigNeedsNet(t *testing.T) {
 	assertNotNeedsNet(t, &cfg)
 	cfg.Storage.Files[0].Contents.Source = util.StrToPtr("http://example.com/payload")
 	assertNeedsNet(t, &cfg)
+	cfg.Storage.Files[0].Contents.Source = nil
+	assertNotNeedsNet(t, &cfg)
+	cfg.Storage.Luks = []types.Luks{
+		{
+			Name:   "foobar",
+			Device: util.StrToPtr("bazboo"),
+			Clevis: &types.Clevis{
+				Tang: []types.Tang{
+					{
+						Thumbprint: util.StrToPtr("mythumbprint"),
+						URL:        "http://tang.example.com",
+					},
+				},
+			},
+		},
+	}
+	assertNeedsNet(t, &cfg)
 }


### PR DESCRIPTION
If there is a Tang-pinned LUKS device, mark the config as requiring
networking.

Closes: #1017