### PR TITLE
util/user_group_lookup: handle more error codes

### DIFF
--- a/internal/exec/util/user_group_lookup.c
+++ b/internal/exec/util/user_group_lookup.c
@@ -63,7 +63,10 @@ static int user_lookup_fn(lookup_ctxt_t *ctxt) {
 	}
 
 	if(getpwnam_r(ctxt->name, &p, buf, sizeof(buf), &pptr) != 0) {
-		goto out_err;
+		if (errno != ENOENT && errno != ESRCH) {
+			goto out_err;
+		}
+		errno = 0; /* fallthrough and treat as "not found" */
 	}
 
 	if (!pptr) {
@@ -105,7 +108,10 @@ static int group_lookup_fn(lookup_ctxt_t *ctxt) {
 	}
 
 	if(getgrnam_r(ctxt->name, &g, buf, sizeof(buf), &gptr) != 0) {
-		goto out_err;
+		if (errno != ENOENT && errno != ESRCH) {
+			goto out_err;
+		}
+		errno = 0; /* fallthrough and treat as "not found" */
 	}
 
 	if (!gptr) {


### PR DESCRIPTION
Both `getpwnam_r(3)` and `getgrnam_r(3)` can return `ENOENT` or `ESRCH`
if the record is not found. Handle these.

The manpages also list `EBADF` and `EPERM` (and implies others via
`...`) as other possible codes, which is not great. Digging into this a
bit, I think it may be due to different conventions in different NSS
providers? Let's just handle `ENOENT` and `ESRCH` for now and leave the
less obvious ones until we actually hit something that returns it.

This fixes the error CI is hitting in #1014 where it gets `ESRCH` when
looking up a non-existent group.

Tested-by: Sohan Kunkerkar <sohank2602@gmail.com>