### PR TITLE
files: don't relabel homedir symlinks themselves

### DIFF
--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -75,15 +75,18 @@ func (s *stage) createPasswd(config types.Config) error {
 			if err != nil {
 				return err
 			}
-			s.relabel(homedir)
 
 			// Check if the homedir is actually a symlink, and make sure we
-			// relabel the target too. This is relevant on OSTree-based
-			// platforms, where /root is a link to /var/roothome.
+			// relabel the target instead in that case. This is relevant on
+			// OSTree-based platforms, where /root is a link to /var/roothome.
 			if resolved, err := s.ResolveSymlink(homedir); err != nil {
 				return err
 			} else if resolved != "" {
+				// note we don't relabel the symlink itself; we assume it's
+				// already properly labeled
 				s.relabel(resolved)
+			} else {
+				s.relabel(homedir)
 			}
 		}
 	}


### PR DESCRIPTION
Regression from #996. If the home directory is a symlink, then just
relabel the referent, not the symlink itself. Since the symlink already
existed, we assume that it's properly labeled.

This causes an error on the FCOS live ISO, where `/sysroot` is mounted
from the squashfs, and so is read-only. But even on non-live, we should
just assume that whatever created the `/root -> /var/roothome` symlink
labeled it correctly.

This would normally be a no-op because `setfiles` would see that it's
properly labeled and not even attempt a `setxattr`. But because we can't
yet read SELinux labels from the initrd, it thinks it's unlabeled. (That
will be fixed by https://bugzilla.redhat.com/show_bug.cgi?id=1845210).