### PR TITLE
engine: fix provider config precedence

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -34,12 +34,25 @@ cosaPod(buildroot: true) {
 
     fcosKola(extraArgs: "--denylist-test ext.*")
 
-    stage("Blackbox Tests") {
+    parallel blackbox: {
         shwrap("""
             ./build_blackbox_tests
             mkdir -p tests/kola/data
             mv tests.test bin tests/kola/data
         """)
         fcosKola(extraArgs: "--tag external", skipUpgrade: true)
+    }, testiso: {
+        try {
+            shwrap("""
+                cd /srv/fcos
+                cosa buildextend-metal
+                cosa buildextend-live
+                cosa compress --artifact metal
+                kola testiso -S --output-dir tmp/kola-testiso-metal
+            """)
+        } finally {
+            shwrap("cd /srv/fcos && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso*.tar.xz'
+        }
     }
 }


### PR DESCRIPTION
Regression from #958. We switched the list of providers from an array to
a map. But iteration order through a map is undefined, so we lost the
precedence of providers.

I think this is the cause behind a lot of the FCOS installer test
timeouts, such as:

coreos/coreos-assembler#1597

There, we pass the Ignition config for the PXE boot via
`ignition.config.url`, but if the metal (no-op) fetcher appears earlier
than the `cmdline` fetcher, we get no config. And similarly for the
installed system when the no-op fetcher appears before the `system`
fetcher (which coreos-installer's `--ignition-file` leverages).

The likelihood of this happening increased in the v2.4.0 release due to
#1002, which only gave us one try
to iterate over the correct provider first (at the `fetch` stage),
rather than every stage having a go at it.

Closes: coreos/coreos-assembler#1597