### PR TITLE
ci: build metal4k image before live image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -46,6 +46,7 @@ cosaPod(buildroot: true) {
             shwrap("""
                 cd /srv/fcos
                 cosa buildextend-metal
+                cosa buildextend-metal4k
                 cosa buildextend-live
                 cosa compress --artifact metal
                 kola testiso -S --output-dir tmp/kola-testiso-metal


### PR DESCRIPTION
It's required as of https://github.com/coreos/coreos-assembler/pull/1612.