### PR TITLE
ci: stop skipping rootfs.uuid kola test

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -27,8 +27,7 @@ cosaPod(buildroot: true) {
     // attention to it in the Jenkins UI
     // XXX: need a e.g. `--tag !external`
 
-    // XXX: skip rootfs.uuid to ratchet ignition-dracut merge
-    fcosKola(extraArgs: "--denylist-test ext.* --denylist-test rootfs.uuid")
+    fcosKola(extraArgs: "--denylist-test ext.*")
 
     parallel blackbox: {
         shwrap("""


### PR DESCRIPTION
This reverts commit 12edd76e0df3686e470505a70bae15a8bf5e7c4b and can be merged after https://github.com/coreos/fedora-coreos-config/pull/526 lands.