### PR TITLE
ci: drop cosa compress call

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -44,7 +44,6 @@ cosaPod(buildroot: true) {
                 cosa buildextend-metal
                 cosa buildextend-metal4k
                 cosa buildextend-live
-                cosa compress --artifact metal
                 kola testiso -S --output-dir tmp/kola-testiso-metal
             """)
         } finally {


### PR DESCRIPTION
With https://github.com/coreos/coreos-assembler/pull/1620, this is no longer more efficient for running `kola testiso`.  We're not testing with the legacy installer, so no compression is needed at all.