### PR TITLE
internal/config: allow Ignition generated key-files for all devices

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -54,7 +54,7 @@ var (
 	ErrVfatLabelTooLong          = errors.New("filesystem labels cannot be longer than 11 characters when using vfat")
 	ErrLuksLabelTooLong          = errors.New("luks device labels cannot be longer than 47 characters")
 	ErrLuksNameContainsSlash     = errors.New("device names cannot contain slashes")
-	ErrInvalidLuksVolume         = errors.New("a key-file or clevis configuration must be specified")
+	ErrInvalidLuksKeyFile        = errors.New("invalid key-file source")
 	ErrTangThumbprintRequired    = errors.New("thumbprint is required")
 	ErrFileIllegalMode           = errors.New("illegal file mode")
 	ErrBothIDAndNameSet          = errors.New("cannot set both id and name")

--- a/config/v3_2_experimental/types/luks.go
+++ b/config/v3_2_experimental/types/luks.go
@@ -45,19 +45,11 @@ func (l Luks) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("device"), validatePath(*l.Device))
 	}
 
-	// fail if there is no valid keyfile & no clevis entries
-	if err := l.KeyFile.validateRequiredSource(); err != nil && l.emptyClevis() {
-		r.AddOnError(c.Append("keys"), errors.ErrInvalidLuksVolume)
+	// fail if a key file is provided and is not valid
+	if err := validateURLNilOK(l.KeyFile.Source); err != nil {
+		r.AddOnError(c.Append("keys"), errors.ErrInvalidLuksKeyFile)
 	}
 	return
-}
-
-func (l Luks) emptyClevis() bool {
-	if l.Clevis == nil {
-		return true
-	}
-
-	return len(l.Clevis.Tang) == 0 && (l.Clevis.Tpm2 == nil || !*l.Clevis.Tpm2)
 }
 
 func (l Luks) validateLabel() error {

--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -208,8 +208,8 @@ func (s *stage) createLuks(config types.Config) error {
 			}
 		}
 
-		// assume the user does not want a key file, remove it
-		if ignitionCreatedKeyFile {
+		// assume the user does not want a key file & remove it for clevis based devices
+		if ignitionCreatedKeyFile && luks.Clevis != nil {
 			if _, err := s.Logger.LogCmd(
 				exec.Command(distro.CryptsetupCmd(), "luksRemoveKey", *luks.Device, keyFilePath),
 				"removing key file for %v", luks.Name,


### PR DESCRIPTION
Allows Ignition to generate the key-file in all cases (instead of just
for clevis based devices).

Closes #1021 