### PR TITLE
Makefile install fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ifeq ($(GOARCH),x86_64)
 	GOARCH=amd64
 else ifeq ($(GOARCH),aarch64)
 	GOARCH=arm64
+else ifeq ($(patsubst i%86,386,$(GOARCH)),386)
+	GOARCH=386
 endif
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ifeq ($(GOARCH),x86_64)
 	GOARCH=amd64
 else ifeq ($(GOARCH),aarch64)
 	GOARCH=arm64
+else ifeq ($(patsubst armv%,arm,$(GOARCH)),arm)
+	GOARCH=arm
 else ifeq ($(patsubst i%86,386,$(GOARCH)),386)
 	GOARCH=386
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ all:
 install: all
 	for x in dracut/*; do \
 	  bn=$$(basename $$x); \
-	  install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
+	  install -m 0644 -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
 	done
-	install -D -t $(DESTDIR)/usr/lib/systemd/system systemd/*
+	chmod a+x $(DESTDIR)/usr/lib/dracut/modules.d/*/*.sh $(DESTDIR)/usr/lib/dracut/modules.d/*/*-generator
+	install -m 0644 -D -t $(DESTDIR)/usr/lib/systemd/system systemd/*
 	install -m 0755 -D -t $(DESTDIR)/usr/lib/dracut/modules.d/30ignition bin/$(GOARCH)/ignition
 	install -m 0755 -D -t $(DESTDIR)/usr/bin bin/$(GOARCH)/ignition-validate
 


### PR DESCRIPTION
This pull request tries to fix two Makefile bugs of the `install` target:
1. On 32 Bit x86 machines the ignition binaries were searched in the wrong directory due to a missing Go architectures <-> Linux hardware name; another mapping was introduced, handling various machine strings such as _i486_ or _i686_.
2. Dracut and systemd are all installed with the default permissions of _755_. Separate the files by extension and assign the matching permissions so the executable bit is only set for scripts. This will also avoid warning by systemd due to the incorrect permissions.