### PR TITLE
types: Use "path" instead of "path/filepath"

### DIFF
--- a/config/v3_0/types/node.go
+++ b/config/v3_0/types/node.go
@@ -15,11 +15,11 @@
 package types
 
 import (
-	"path/filepath"
+	"path"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 
-	"github.com/coreos/vcontext/path"
+	vpath "github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -27,15 +27,15 @@ func (n Node) Key() string {
 	return n.Path
 }
 
-func (n Node) Validate(c path.ContextPath) (r report.Report) {
+func (n Node) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c.Append("path"), validatePath(n.Path))
 	return
 }
 
 func (n Node) Depth() int {
 	count := 0
-	for p := filepath.Clean(string(n.Path)); p != "/"; count++ {
-		p = filepath.Dir(p)
+	for p := path.Clean(string(n.Path)); p != "/"; count++ {
+		p = path.Dir(p)
 	}
 	return count
 }
@@ -47,12 +47,12 @@ func validateIDorName(id *int, name *string) error {
 	return nil
 }
 
-func (nu NodeUser) Validate(c path.ContextPath) (r report.Report) {
+func (nu NodeUser) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c, validateIDorName(nu.ID, nu.Name))
 	return
 }
 
-func (ng NodeGroup) Validate(c path.ContextPath) (r report.Report) {
+func (ng NodeGroup) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c, validateIDorName(ng.ID, ng.Name))
 	return
 }

--- a/config/v3_0/types/storage.go
+++ b/config/v3_0/types/storage.go
@@ -15,12 +15,12 @@
 package types
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 
-	"github.com/coreos/vcontext/path"
+	vpath "github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -32,7 +32,7 @@ func (s Storage) MergedKeys() map[string]string {
 	}
 }
 
-func (s Storage) Validate(c path.ContextPath) (r report.Report) {
+func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 	for i, d := range s.Directories {
 		for _, l := range s.Links {
 			if strings.HasPrefix(d.Path, l.Path+"/") {
@@ -56,9 +56,9 @@ func (s Storage) Validate(c path.ContextPath) (r report.Report) {
 		if l1.Hard == nil || !*l1.Hard {
 			continue
 		}
-		target := filepath.Clean(l1.Target)
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(l1.Path, l1.Target)
+		target := path.Clean(l1.Target)
+		if !path.IsAbs(target) {
+			target = path.Join(l1.Path, l1.Target)
 		}
 		for _, d := range s.Directories {
 			if target == d.Path {

--- a/config/v3_1/types/node.go
+++ b/config/v3_1/types/node.go
@@ -15,11 +15,11 @@
 package types
 
 import (
-	"path/filepath"
+	"path"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 
-	"github.com/coreos/vcontext/path"
+	vpath "github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -27,15 +27,15 @@ func (n Node) Key() string {
 	return n.Path
 }
 
-func (n Node) Validate(c path.ContextPath) (r report.Report) {
+func (n Node) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c.Append("path"), validatePath(n.Path))
 	return
 }
 
 func (n Node) Depth() int {
 	count := 0
-	for p := filepath.Clean(string(n.Path)); p != "/"; count++ {
-		p = filepath.Dir(p)
+	for p := path.Clean(string(n.Path)); p != "/"; count++ {
+		p = path.Dir(p)
 	}
 	return count
 }
@@ -47,12 +47,12 @@ func validateIDorName(id *int, name *string) error {
 	return nil
 }
 
-func (nu NodeUser) Validate(c path.ContextPath) (r report.Report) {
+func (nu NodeUser) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c, validateIDorName(nu.ID, nu.Name))
 	return
 }
 
-func (ng NodeGroup) Validate(c path.ContextPath) (r report.Report) {
+func (ng NodeGroup) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c, validateIDorName(ng.ID, ng.Name))
 	return
 }

--- a/config/v3_1/types/storage.go
+++ b/config/v3_1/types/storage.go
@@ -15,12 +15,12 @@
 package types
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 
-	"github.com/coreos/vcontext/path"
+	vpath "github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -32,7 +32,7 @@ func (s Storage) MergedKeys() map[string]string {
 	}
 }
 
-func (s Storage) Validate(c path.ContextPath) (r report.Report) {
+func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 	for i, d := range s.Directories {
 		for _, l := range s.Links {
 			if strings.HasPrefix(d.Path, l.Path+"/") {
@@ -56,9 +56,9 @@ func (s Storage) Validate(c path.ContextPath) (r report.Report) {
 		if l1.Hard == nil || !*l1.Hard {
 			continue
 		}
-		target := filepath.Clean(l1.Target)
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(l1.Path, l1.Target)
+		target := path.Clean(l1.Target)
+		if !path.IsAbs(target) {
+			target = path.Join(l1.Path, l1.Target)
 		}
 		for _, d := range s.Directories {
 			if target == d.Path {

--- a/config/v3_2_experimental/types/node.go
+++ b/config/v3_2_experimental/types/node.go
@@ -15,11 +15,11 @@
 package types
 
 import (
-	"path/filepath"
+	"path"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 
-	"github.com/coreos/vcontext/path"
+	vpath "github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -27,15 +27,15 @@ func (n Node) Key() string {
 	return n.Path
 }
 
-func (n Node) Validate(c path.ContextPath) (r report.Report) {
+func (n Node) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c.Append("path"), validatePath(n.Path))
 	return
 }
 
 func (n Node) Depth() int {
 	count := 0
-	for p := filepath.Clean(string(n.Path)); p != "/"; count++ {
-		p = filepath.Dir(p)
+	for p := path.Clean(string(n.Path)); p != "/"; count++ {
+		p = path.Dir(p)
 	}
 	return count
 }
@@ -47,12 +47,12 @@ func validateIDorName(id *int, name *string) error {
 	return nil
 }
 
-func (nu NodeUser) Validate(c path.ContextPath) (r report.Report) {
+func (nu NodeUser) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c, validateIDorName(nu.ID, nu.Name))
 	return
 }
 
-func (ng NodeGroup) Validate(c path.ContextPath) (r report.Report) {
+func (ng NodeGroup) Validate(c vpath.ContextPath) (r report.Report) {
 	r.AddOnError(c, validateIDorName(ng.ID, ng.Name))
 	return
 }

--- a/config/v3_2_experimental/types/storage.go
+++ b/config/v3_2_experimental/types/storage.go
@@ -15,12 +15,12 @@
 package types
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 
-	"github.com/coreos/vcontext/path"
+	vpath "github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -32,7 +32,7 @@ func (s Storage) MergedKeys() map[string]string {
 	}
 }
 
-func (s Storage) Validate(c path.ContextPath) (r report.Report) {
+func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 	for i, d := range s.Directories {
 		for _, l := range s.Links {
 			if strings.HasPrefix(d.Path, l.Path+"/") {
@@ -56,9 +56,9 @@ func (s Storage) Validate(c path.ContextPath) (r report.Report) {
 		if l1.Hard == nil || !*l1.Hard {
 			continue
 		}
-		target := filepath.Clean(l1.Target)
-		if !filepath.IsAbs(target) {
-			target = filepath.Join(l1.Path, l1.Target)
+		target := path.Clean(l1.Target)
+		if !path.IsAbs(target) {
+			target = path.Join(l1.Path, l1.Target)
 		}
 		for _, d := range s.Directories {
 			if target == d.Path {


### PR DESCRIPTION
The functions from the "path" package are idempotent while the
implementations of functions in "path/filepath" differ between unix and
windows systems.

This is so the Link validation as well as the Node.Depth() function work
correctly when run on windows systems.