### PR TITLE
AzureStack: fix unfortunate typo of iso9660

### DIFF
--- a/internal/providers/azurestack/azurestack.go
+++ b/internal/providers/azurestack/azurestack.go
@@ -29,7 +29,7 @@ import (
 // udf volume, while Azure Stack might use udf or iso9660.
 const (
 	CDS_FSTYPE_UDF     = "udf"
-	CDS_FSTYPE_ISO9660 = "iso9960"
+	CDS_FSTYPE_ISO9660 = "iso9660"
 )
 
 // FetchConfig implements the platform.NewFetcher interface.


### PR DESCRIPTION
Fixes an error on AzureStack:
`failed to fetch config: filesystem "iso9660" is not a supported ovf device`

