### PR TITLE
engine: fix logging interactions with fetch-offline

### DIFF
--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -6,6 +6,8 @@ DefaultDependencies=false
 Before=ignition-complete.target
 After=basic.target
 ConditionPathExists=/run/ignition/neednet
+# Don't run if the `fetch-offline` stage successfully fetched a config
+ConditionPathExists=!/run/ignition.json
 
 # Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
 # We run after the setup stage has run because it may copy in new/different


### PR DESCRIPTION
Right now, even if `fetch-offline` gets `ErrNeedNet`, it might've still
logged info about configs which it did fetch before hitting the error.
This then results in double-logging of e.g. the base config and at least
the first layer of user configs when `fetch` re-fetches them.

But it's also misleading, because anything which runs between
`fetch-offline` and `fetch` and sees the journal messages will think
that Ignition did successfully fetch and cache the merged user config,
when it did not.

And sadly, we still have code which peek at the cached config for
`$reasons` (legacy-style RHCOS LUKS is one of them, RHCOS FIPS support
is another), and those bits get thrown off by seeing the logging
messages yet not seeing a cached Ignition config.

Let's tweak things so that we buffer those messages and only actually
write them out once we've successfully acquired the configs.

While we're here, clean up the base config logging hack now that the
`fetch` stages are canonical.