### PR TITLE
internal: fix S3 region detection

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -45,6 +45,7 @@ import (
 type Config struct {
 	name       string
 	fetch      providers.FuncFetchConfig
+	init       providers.FuncInit
 	newFetcher providers.FuncNewFetcher
 	status     providers.FuncPostStatus
 }
@@ -68,6 +69,19 @@ func (c Config) NewFetcherFunc() providers.FuncNewFetcher {
 	}
 }
 
+// InitFunc returns a function that performs additional fetcher
+// configuration post-config fetch. This ensures that networking
+// is already available if a platform needs to reach out to the
+// metadata service to fetch additional options / data.
+func (c Config) InitFunc() providers.FuncInit {
+	if c.init != nil {
+		return c.init
+	}
+	return func(f *resource.Fetcher) error {
+		return nil
+	}
+}
+
 // Status takes a Fetcher and the error from Run (from engine)
 func (c Config) Status(stageName string, f resource.Fetcher, statusErr error) error {
 	if c.status != nil {
@@ -86,6 +100,7 @@ func init() {
 	configs.Register(Config{
 		name:       "aws",
 		fetch:      aws.FetchConfig,
+		init:       aws.Init,
 		newFetcher: aws.NewFetcher,
 	})
 	configs.Register(Config{

--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -46,13 +46,6 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		return types.Config{}, report.Report{}, err
 	}
 
-	// Determine the partition and region this instance is in
-	regionHint, err := ec2metadata.New(f.AWSSession).Region()
-	if err != nil {
-		regionHint = "us-east-1"
-	}
-	f.S3RegionHint = regionHint
-
 	return util.ParseConfig(f.Logger, data)
 }
 
@@ -67,4 +60,14 @@ func NewFetcher(l *log.Logger) (resource.Fetcher, error) {
 		Logger:     l,
 		AWSSession: sess,
 	}, nil
+}
+
+func Init(f *resource.Fetcher) error {
+	// Determine the partition and region this instance is in
+	regionHint, err := ec2metadata.New(f.AWSSession).Region()
+	if err != nil {
+		regionHint = "us-east-1"
+	}
+	f.S3RegionHint = regionHint
+	return nil
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -29,5 +29,6 @@ var (
 )
 
 type FuncFetchConfig func(f *resource.Fetcher) (types.Config, report.Report, error)
+type FuncInit func(f *resource.Fetcher) error
 type FuncNewFetcher func(logger *log.Logger) (resource.Fetcher, error)
 type FuncPostStatus func(stageName string, f resource.Fetcher, e error) error


### PR DESCRIPTION
Fetch the S3RegionHint on all stages rather than just after fetching the
config. Doing this allows for authenticated fetches to work when running
in any partition (when fetching objects from S3 in the same partition).