### PR TITLE
WIP exec/stages/files: avoid overwriting files if they already exist 

### DIFF
--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -196,6 +196,10 @@ func (tmp fileEntry) create(l *log.Logger, u util.Util) error {
 		return fmt.Errorf("failed to resolve file %q: %v", f.Path, err)
 	}
 
+	if _, err := os.Stat(f.Path); !os.IsNotExist(err) {
+		panic(fmt.Sprintf("filesystem path %s already exists; can't overwrite", f.Path))
+	}
+
 	for _, op := range fetchOps {
 		msg := "writing file %q"
 		if op.Append {

--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -16,6 +16,7 @@ package files
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -202,6 +203,11 @@ func (s *stage) writeSystemdUnit(unit types.Unit, runtime bool) error {
 				}
 				relabelPath = f.Node.Path[len(s.DestDir):]
 			}
+
+			if _, err := os.Stat(f.Node.Path); !os.IsNotExist(err) {
+				panic(fmt.Sprintf("dropin path %s already exists; can't overwrite", f.Node.Path))
+			}
+
 			if err := s.Logger.LogOp(
 				func() error { return u.PerformFetch(f) },
 				"writing systemd drop-in %q at %q", dropin.Name, f.Node.Path,
@@ -231,6 +237,11 @@ func (s *stage) writeSystemdUnit(unit types.Unit, runtime bool) error {
 			}
 			relabelPath = f.Node.Path[len(s.DestDir):]
 		}
+
+		if _, err := os.Stat(f.Node.Path); !os.IsNotExist(err) {
+			panic(fmt.Sprintf("unit path %s already exists; can't overwrite", f.Node.Path))
+		}
+
 		if err := s.Logger.LogOp(
 			func() error { return u.PerformFetch(f) },
 			"writing unit %q at %q", unit.Name, f.Node.Path,

--- a/tests/negative/general/config.go
+++ b/tests/negative/general/config.go
@@ -35,6 +35,7 @@ func init() {
 	register.Register(register.NegativeTest, VersionOnlyConfig25())
 	register.Register(register.NegativeTest, VersionOnlyConfig33())
 	register.Register(register.NegativeTest, MergingCanFail())
+	register.Register(register.NegativeTest, OverWritingExistingFilesFailed())
 }
 
 func ReplaceConfigWithInvalidHash() types.Test {
@@ -348,6 +349,50 @@ func MergingCanFail() types.Test {
 		Out:              out,
 		Config:           config,
 		MntDevices:       mntDevices,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+// OverWritingExistingFilesFailed ensures that users can't
+// overwrite existing files in a system via Ignition.
+func OverWritingExistingFilesFailed() types.Test {
+	name := "config.overwrite.file.failed"
+	configMinVersion := "3.2.0-experimental"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	config := `{
+	  "ignition": {
+	    "version": "3.0.0"
+	  },
+	  "storage": {
+		"files": [
+		  {
+			"group": {},
+			"path": "/etc/systemd/system/echo.service",
+			"user": {},
+			"contents": {
+			  "source": "data:,foo",
+			  "verification": {}
+			}
+		  }
+		]
+	  },
+	  "systemd": {
+		"units": [
+		  {
+			"contents": "foo",
+			"enabled": true,
+			"name": "echo.service"
+		  }
+		]
+	  }
+	}`
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		Config:           config,
 		ConfigMinVersion: configMinVersion,
 	}
 }


### PR DESCRIPTION
Fixes #881
Ignition should panic when users try to overwrite the existing files