### PR TITLE
Move all AWS session setup to Fetcher

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -84,9 +84,8 @@ func init() {
 		fetch: aliyun.FetchConfig,
 	})
 	configs.Register(Config{
-		name:       "aws",
-		fetch:      aws.FetchConfig,
-		newFetcher: aws.NewFetcher,
+		name:  "aws",
+		fetch: aws.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "azure",

--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -21,14 +21,9 @@ import (
 	"net/url"
 
 	"github.com/coreos/ignition/v2/config/v3_2_experimental/types"
-	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/coreos/vcontext/report"
 )
 
@@ -46,25 +41,5 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		return types.Config{}, report.Report{}, err
 	}
 
-	// Determine the partition and region this instance is in
-	regionHint, err := ec2metadata.New(f.AWSSession).Region()
-	if err != nil {
-		regionHint = "us-east-1"
-	}
-	f.S3RegionHint = regionHint
-
 	return util.ParseConfig(f.Logger, data)
-}
-
-func NewFetcher(l *log.Logger) (resource.Fetcher, error) {
-	sess, err := session.NewSession(&aws.Config{})
-	if err != nil {
-		return resource.Fetcher{}, err
-	}
-	sess.Config.Credentials = ec2rolecreds.NewCredentials(sess)
-
-	return resource.Fetcher{
-		Logger:     l,
-		AWSSession: sess,
-	}, nil
 }


### PR DESCRIPTION
Fetching configs from S3 works if the file is in a region other than us-east-1, but fetching "files" content from S3 does not, i think for two reasons.

The first is that the S3 Bucket region hinting isn't calculated for "files" (just for the config fetcher) so it's always using "us-east-1".  Then, because the session is nil for "files", it uses uses Anonymous credentials (which doesn't work on non-public buckets).

Rather than setting up a session and figuring out the region hint in multiple places, just do it as part of that session setup in `fetchFromS3()`.
We also fall back to using Anonymous creds in `fetchFromS3WithCreds` if the first attempt gets a `EC2RoleRequestError`, so try to use "real" creds first.