### PR TITLE
fetch-offline: immediately return ErrNeedNet on OpenStack

### DIFF
--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -52,10 +52,15 @@ var (
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	// The fetch-offline approach doesn't work well here because of the "split
+	// personality" of this provider. See:
+	// https://github.com/coreos/ignition/issues/1081
+	if f.Offline {
+		return types.Config{}, report.Report{}, resource.ErrNeedNet
+	}
+
 	var data []byte
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-
-	sawErrNeedNet := false
 
 	dispatch := func(name string, fn func() ([]byte, error)) {
 		raw, err := fn()
@@ -64,9 +69,6 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 			case context.Canceled:
 			case context.DeadlineExceeded:
 				f.Logger.Err("timed out while fetching config from %s", name)
-			case resource.ErrNeedNet:
-				sawErrNeedNet = true
-				fallthrough
 			default:
 				f.Logger.Err("failed to fetch config from %s: %v", name, err)
 			}
@@ -91,11 +93,6 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 
 	<-ctx.Done()
 	if ctx.Err() == context.DeadlineExceeded {
-		// Did we hit neednet? If so, propagate that up instead. The OS should
-		// retry fetching again once networking is up.
-		if sawErrNeedNet {
-			return types.Config{}, report.Report{}, resource.ErrNeedNet
-		}
 		f.Logger.Info("neither config drive nor metadata service were available in time. Continuing without a config...")
 	}
 


### PR DESCRIPTION
This is a follow up to (and revert of) #1057.

On OpenStack, we don't actually know if we're fetching from the
config-drive or from the metadata server.

In theory, if it's from the config-drive, we don't strictly need
networking, and so `fetch-offline` would work. The issue is that in the
more common case of the metadata server, `fetch-offline` will still wait
the full 30s for the config-drive to also time out only to then have to
bring up networking and run the `fetch` stage.

Instead, let's just accept the brokenness of the OpenStack provider and
declare it as always requiring networking.

For more information, see:
https://github.com/coreos/ignition/issues/1081#issuecomment-693022160