### PR TITLE
interal/providers/*stack: drop timeout for config fetch

### DIFF
--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -56,7 +56,7 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 
 	var data []byte
 	errChan := make(chan error)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	dispatchCount := 0
 
 	dispatch := func(name string, fn func() ([]byte, error)) {

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -61,7 +61,7 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 
 	var data []byte
 	errChan := make(chan error)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	dispatchCount := 0
 
 	dispatch := func(name string, fn func() ([]byte, error)) {


### PR DESCRIPTION
Drop the timer for the config fetch on the *stack platforms. In the no
config case one of the config drive or metadata service should appear
and either not contain the file or return a 404.

Closes #1081 