### PR TITLE
news: fix error in 2.3.0 changelog

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,7 +67,7 @@
     - Allow specifying HTTP headers when fetching remote resources (3.1.0)
     - Support compression for CA certs and merged/replaced configs (3.1.0)
     - Support sha256 verification hashes (3.1.0)
-    - Support compression for file URIs
+    - Support compression for data URIs
     - Log structured journal entry when user config is found
     - Log structured journal entry when SSH keys are written
 


### PR DESCRIPTION
We don't support `file` URLs at all; we added compression support for `data` URIs.