### PR TITLE
docs/development: update spec stabilization to avoid CI breakage

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -171,9 +171,9 @@ Finally, update docs.
 
 If there are any external kola tests that were using the now stabilized experimental spec that are not part of the Ignition repo (e.x. tests in the [fedora-coreos-config](https://github.com/coreos/fedora-coreos-config/tree/testing-devel/tests/kola) repo) then CI will fail for the spec stabilization PR.
 
-- Merge the spec stabilization PR on red (assuming only those tests are failing)
+- Add any tests using the experimental spec to the [fedora-coreos-config denylist](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/kola-denylist.yaml) and re-run CI
+- Merge the spec stabilization PR
 - Perform a new Ignition release
 - Bump the Ignition packaging
-- Update other repositories:
-  * Vendor the new Ignition release into [coreos-assembler](https://github.com/coreos/coreos-assembler)
-  * Update the lockfile on the testing-devel branch in [fedora-coreos-config](https://github.com/coreos/fedora-coreos-config) to use the new Ignition release & the external test to use the new stabilized spec version
+- Vendor the new Ignition release into [coreos-assembler](https://github.com/coreos/coreos-assembler)
+- Update the lockfile on the testing-devel branch in [fedora-coreos-config](https://github.com/coreos/fedora-coreos-config) to use the new Ignition release & the external test to use the new stabilized spec version, removing it from the denylist.


### PR DESCRIPTION
Rather than forcibly merging on red and breaking CI, add any tests
targeting the experimental spec version to the denylist until after
everything has merged in external repos.