### PR TITLE
ignition-firstboot-complete.service: Remove firstboot network dir

### DIFF
--- a/systemd/ignition-firstboot-complete.service
+++ b/systemd/ignition-firstboot-complete.service
@@ -24,7 +24,8 @@ MountFlags=slave
 ExecStart=/bin/sh -c \
 	'mount -o remount,rw /boot && \
 	if [[ $(uname -m) = s390x ]]; then zipl; fi && \
-	rm /boot/ignition.firstboot'
+	rm /boot/ignition.firstboot && \
+	rm -rf /boot/coreos-firstboot-network'
 
 [Install]
 # Part of basic.target so this happens early on in firstboot


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-config/pull/659 attempts to
mount `/boot` read-only. Currently, the firstboot network dir in
`/boot` is cleaned up by a tmpfiles.d conf file. This may not be
possible once `/boot` is read-only, so we do the clean up here.