### PR TITLE
tests: Remove unused checkOnStrings

### DIFF
--- a/config/v3_0/config_test.go
+++ b/config/v3_0/config_test.go
@@ -27,9 +27,8 @@ func TestParse(t *testing.T) {
 		config []byte
 	}
 	type out struct {
-		config         types.Config
-		err            error
-		checkOnStrings bool
+		config types.Config
+		err    error
 	}
 
 	tests := []struct {
@@ -104,8 +103,7 @@ func TestParse(t *testing.T) {
 
 	for i, test := range tests {
 		config, report, err := Parse(test.in.config)
-		if (!test.out.checkOnStrings && test.out.err != err) ||
-			(test.out.checkOnStrings && test.out.err.Error() != err.Error()) {
+		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)

--- a/config/v3_1/config_test.go
+++ b/config/v3_1/config_test.go
@@ -27,9 +27,8 @@ func TestParse(t *testing.T) {
 		config []byte
 	}
 	type out struct {
-		config         types.Config
-		err            error
-		checkOnStrings bool
+		config types.Config
+		err    error
 	}
 
 	tests := []struct {
@@ -124,8 +123,7 @@ func TestParse(t *testing.T) {
 
 	for i, test := range tests {
 		config, report, err := Parse(test.in.config)
-		if (!test.out.checkOnStrings && test.out.err != err) ||
-			(test.out.checkOnStrings && test.out.err.Error() != err.Error()) {
+		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)

--- a/config/v3_2/config_test.go
+++ b/config/v3_2/config_test.go
@@ -27,9 +27,8 @@ func TestParse(t *testing.T) {
 		config []byte
 	}
 	type out struct {
-		config         types.Config
-		err            error
-		checkOnStrings bool
+		config types.Config
+		err    error
 	}
 
 	tests := []struct {
@@ -132,8 +131,7 @@ func TestParse(t *testing.T) {
 
 	for i, test := range tests {
 		config, report, err := Parse(test.in.config)
-		if (!test.out.checkOnStrings && test.out.err != err) ||
-			(test.out.checkOnStrings && test.out.err.Error() != err.Error()) {
+		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)

--- a/config/v3_3_experimental/config_test.go
+++ b/config/v3_3_experimental/config_test.go
@@ -27,9 +27,8 @@ func TestParse(t *testing.T) {
 		config []byte
 	}
 	type out struct {
-		config         types.Config
-		err            error
-		checkOnStrings bool
+		config types.Config
+		err    error
 	}
 
 	tests := []struct {
@@ -136,8 +135,7 @@ func TestParse(t *testing.T) {
 
 	for i, test := range tests {
 		config, report, err := Parse(test.in.config)
-		if (!test.out.checkOnStrings && test.out.err != err) ||
-			(test.out.checkOnStrings && test.out.err.Error() != err.Error()) {
+		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)


### PR DESCRIPTION
This seems to have transitioned into being unused in
https://github.com/coreos/ignition/commit/9910ed2530f43fa9e4926e45c947cc1cfbba5646
and then it was cargo culted forward into parser tests thereafter.

Prep for further cleanup.