### PR TITLE
aws: Log if we fail to determine the EC2 region

### DIFF
--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -62,11 +62,13 @@ func NewFetcher(l *log.Logger) (resource.Fetcher, error) {
 	}, nil
 }
 
+// Init prepares the fetcher for this platform
 func Init(f *resource.Fetcher) error {
 	// Determine the partition and region this instance is in
 	regionHint, err := ec2metadata.New(f.AWSSession).Region()
 	if err != nil {
 		regionHint = "us-east-1"
+		f.Logger.Warning("failed to determine EC2 region, falling back to default %s: %v", regionHint, err)
 	}
 	f.S3RegionHint = regionHint
 	return nil


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1902996
where I think we might be hitting this.  It'd be good to log
when this happens because I believe we always want it to work.