### PR TITLE
config/*: reinstate config structure checks; fix nil deref on invalid partitions

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,9 +77,12 @@ func testConfigType(t reflect.Type) error {
 			}
 			if field.Type.Kind() == reflect.Slice && field.Type.Elem().Kind() != reflect.String {
 				if _, ignored := ignoredFields[field.Name]; !ignored {
-					if _, ok := reflect.New(field.Type.Elem()).Interface().(util.Keyed); !ok {
+					keyed, ok := reflect.New(field.Type.Elem()).Interface().(util.Keyed)
+					if !ok {
 						return fmt.Errorf("Type %s has slice field %s without Key() defined on %s debug: %v", t.Name(), field.Name, field.Type.Elem().Name(), ignoredFields)
 					}
+					// check for nil pointer dereference when calling Key() on zero value
+					keyed.Key()
 				}
 			}
 		}

--- a/config/v3_0/types/partition.go
+++ b/config/v3_0/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/config/v3_1/types/partition.go
+++ b/config/v3_1/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/config/v3_2/types/partition.go
+++ b/config/v3_2/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/config/v3_3_experimental/types/partition.go
+++ b/config/v3_3_experimental/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -137,6 +137,7 @@ The changes that are required to achieve these effects are typically the followi
 - Update `config/vX_(Y+1)_experimental/config_test.go` to test that the new stable version is invalid and the new experimental version is valid
 - Update `config/vX_(Y+1)_experimental/translate/translate.go` to translate from the previous stable version.  Update the `old_types` import, delete all functions except `translateIgnition` and `Translate`, and ensure `translateIgnition` translates the entire `Ignition` struct.
 - Update `config/config.go` to handle the new stable and experimental versions.
+- Update `config/config_test.go` to add the new experimental version to `TestConfigStructure`.
 - Update `generate` to generate the new stable and experimental versions, and rerun `generate`.
 
 ### Update all relevant places to use the new experimental package


### PR DESCRIPTION
`TestConfigStructure()` was testing only spec 3.0 because the spec bump instructions don't mention it.  Add newer specs and update the instructions.  Also allowlist the struct pointers in 3.2 and 3.3-exp (#1132) that would have been caught if the test had been run on those versions; there's nothing we can do about 3.2 at least.

Extend `TestConfigStructure()` to call `Key()` on a zero value to check for nil dereference, since duplicate key detection will call `Key()` on structs that fail validation.  Then fix `Partition.Key()` nil dereference.