### PR TITLE
*: fix staticcheck warnings

### DIFF
--- a/config/merge/merge.go
+++ b/config/merge/merge.go
@@ -293,7 +293,7 @@ func mergeStruct(parent reflect.Value, parentPath path.ContextPath, child reflec
 						} else {
 							panic("List of pointers or slices or something else weird")
 						}
-					} else {
+					} else { // nolint:staticcheck
 						// case 2: in child config in different list. Do nothing since it'll be handled iterating over that list
 					}
 				} else {

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -57,8 +57,6 @@ func (creator) Name() string {
 
 type stage struct {
 	util.Util
-
-	client *resource.HttpClient
 }
 
 func (stage) Name() string {

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -93,10 +93,10 @@ func partitionMatchesCommon(existing util.PartitionInfo, spec sgdisk.Partition) 
 	if spec.StartSector != nil && *spec.StartSector != existing.StartSector {
 		return fmt.Errorf("starting sector did not match (specified %d, got %d)", *spec.StartSector, existing.StartSector)
 	}
-	if spec.GUID != nil && *spec.GUID != "" && strings.ToLower(*spec.GUID) != strings.ToLower(existing.GUID) {
+	if spec.GUID != nil && *spec.GUID != "" && !strings.EqualFold(*spec.GUID, existing.GUID) {
 		return fmt.Errorf("GUID did not match (specified %q, got %q)", *spec.GUID, existing.GUID)
 	}
-	if spec.TypeGUID != nil && *spec.TypeGUID != "" && strings.ToLower(*spec.TypeGUID) != strings.ToLower(existing.TypeGUID) {
+	if spec.TypeGUID != nil && *spec.TypeGUID != "" && !strings.EqualFold(*spec.TypeGUID, existing.TypeGUID) {
 		return fmt.Errorf("type GUID did not match (specified %q, got %q)", *spec.TypeGUID, existing.TypeGUID)
 	}
 	if spec.Label != nil && *spec.Label != existing.Label {

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -232,7 +232,7 @@ func (u Util) PerformFetch(f FetchOp) error {
 		}
 		defer targetFile.Close()
 
-		if _, err = tmp.Seek(0, os.SEEK_SET); err != nil {
+		if _, err = tmp.Seek(0, io.SeekStart); err != nil {
 			return err
 		}
 		if _, err = io.Copy(targetFile, tmp); err != nil {

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -432,7 +432,7 @@ func (f *Fetcher) fetchFromS3(u url.URL, dest s3target, opts FetchOptions) error
 	}
 	if opts.Hash != nil {
 		opts.Hash.Reset()
-		_, err = dest.Seek(0, os.SEEK_SET)
+		_, err = dest.Seek(0, io.SeekStart)
 		if err != nil {
 			return err
 		}

--- a/internal/util/tools/docs/docs.go
+++ b/internal/util/tools/docs/docs.go
@@ -40,9 +40,9 @@ const (
 type sectionState int
 
 const (
-	notInSection     sectionState = 0
-	expectingSection              = 1
-	inSection                     = 2
+	notInSection sectionState = iota
+	expectingSection
+	inSection
 )
 
 func main() {
@@ -62,6 +62,10 @@ func main() {
 	}
 
 	if err := filepath.Walk(flags.root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if !strings.HasSuffix(info.Name(), ".md") || info.IsDir() {
 			return nil
 		}

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -155,8 +155,15 @@ func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, app
 	args := []string{"-platform", "file", "-stage", stage,
 		"-root", root, "-log-to-stdout", "--config-cache", filepath.Join(cwd, "ignition.json")}
 	cmd := exec.CommandContext(ctx, "ignition", args...)
+	if cmd == nil {
+		return fmt.Errorf("exec.CommandContext() returned nil")
+	}
 	t.Log("ignition", args)
+	// `staticcheck` linter warns even after resolving
+	// the `nil pointer dereference` warnings.
+	// nolint:staticcheck
 	cmd.Dir = cwd
+	// nolint:staticcheck
 	cmd.Env = append(os.Environ(), appendEnv...)
 	out, err := cmd.CombinedOutput()
 	if cmd != nil && cmd.Process != nil {


### PR DESCRIPTION
Fixes part of https://github.com/coreos/ignition/issues/1121
Addresses the following warnings:
```
tests/filesystem.go:159:6: SA5011: possible nil pointer dereference (staticcheck)
        cmd.Dir = cwd
            ^
tests/filesystem.go:160:6: SA5011: possible nil pointer dereference (staticcheck)
        cmd.Env = append(os.Environ(), appendEnv...)
            ^
config/merge/merge.go:296:13: SA9003: empty branch (staticcheck)
                                        } else {
                                               ^
internal/exec/stages/disks/partitions.go:96:45: SA6005: should use strings.EqualFold instead (staticcheck)
        if spec.GUID != nil && *spec.GUID != "" && strings.ToLower(*spec.GUID) != strings.ToLower(existing.GUID) {
                                                   ^
internal/exec/stages/disks/partitions.go:99:53: SA6005: should use strings.EqualFold instead (staticcheck)
        if spec.TypeGUID != nil && *spec.TypeGUID != "" && strings.ToLower(*spec.TypeGUID) != strings.ToLower(existing.TypeGUID) {
                                                           ^
internal/exec/util/file.go:235:27: SA1019: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (staticcheck)
                if _, err = tmp.Seek(0, os.SEEK_SET); err != nil {
                                        ^
internal/resource/url.go:435:25: SA1019: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (staticcheck)
                _, err = dest.Seek(0, os.SEEK_SET)
                                      ^
internal/util/tools/docs/docs.go:64:74: SA4009: argument err is overwritten before first use (staticcheck)
        if err := filepath.Walk(flags.root, func(path string, info os.FileInfo, err error) error {
                                                                                ^
internal/util/tools/docs/docs.go:43:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
        notInSection     sectionState = 0

internal/exec/stages/disks/disks.go:61:2: `client` is unused (structcheck)
        client *resource.HttpClient
```