### PR TITLE
*: fix deadcode warnings

### DIFF
--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -47,17 +47,6 @@ type FetchOp struct {
 	Node         types.Node
 }
 
-// newHashedReader returns a new ReadCloser that also writes to the provided hash.
-func newHashedReader(reader io.ReadCloser, hasher hash.Hash) io.ReadCloser {
-	return struct {
-		io.Reader
-		io.Closer
-	}{
-		Reader: io.TeeReader(reader, hasher),
-		Closer: reader,
-	}
-}
-
 func newFetchOp(l *log.Logger, node types.Node, contents types.Resource) (FetchOp, error) {
 	var expectedSum []byte
 

--- a/internal/exec/util/util.go
+++ b/internal/exec/util/util.go
@@ -15,16 +15,11 @@
 package util
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
-)
-
-var (
-	errEscapedMountpoint = errors.New("Symlink traversal resulted in path outside of filesystem")
 )
 
 // Util encapsulates logging and destdir indirection for the util methods.
@@ -44,10 +39,6 @@ func SplitPath(p string) []string {
 	}
 	dir = filepath.Clean(dir)
 	return append(SplitPath(dir), file)
-}
-
-func wantsToEscape(p string) bool {
-	return filepath.Join("/", p) == filepath.Join("/a", p)
 }
 
 // ResolveSymlink resolves the symlink path, respecting the u.DestDir root. If

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -405,16 +405,6 @@ func intJoin(ints []int, delimiter string) string {
 	return strings.Join(strArr, delimiter)
 }
 
-func removeEmpty(strings []string) []string {
-	var r []string
-	for _, str := range strings {
-		if str != "" {
-			r = append(r, str)
-		}
-	}
-	return r
-}
-
 func createFilesForPartition(ctx context.Context, partition *types.Partition) (err error) {
 	if len(partition.Directories) == 0 &&
 		len(partition.Files) == 0 &&


### PR DESCRIPTION
Fixes part of https://github.com/coreos/ignition/issues/1121
Addresses the following warnings:
```
internal/exec/util/file.go:51:6: `newHashedReader` is unused (deadcode)
func newHashedReader(reader io.ReadCloser, hasher hash.Hash) io.ReadCloser {
     ^
internal/exec/util/util.go:27:2: `errEscapedMountpoint` is unused (deadcode)
        errEscapedMountpoint = errors.New("Symlink traversal resulted in path outside of filesystem")
        ^
internal/exec/util/util.go:49:6: `wantsToEscape` is unused (deadcode)
func wantsToEscape(p string) bool {

tests/filesystem.go:408:6: `removeEmpty` is unused (deadcode)
func removeEmpty(strings []string) []string {
```