### PR TITLE
*: fix gosimple warnings

### DIFF
--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -128,29 +128,29 @@ func TestValidateWithContext(t *testing.T) {
 		},
 		{
 			in: test3{
-				NoDups: make([]testDup, 1, 1),
+				NoDups: make([]testDup, 1),
 			},
 		},
 		{
 			in: test3{
-				NoDups: make([]testDup, 2, 2),
+				NoDups: make([]testDup, 2),
 			},
 			out: mkReport(ignerrors.ErrDuplicate, path.New("json", "dups", 1), report.Error, 0, 0),
 		},
 		{
 			in: test4{
-				Ignored: make([]testDup, 2, 2),
+				Ignored: make([]testDup, 2),
 			},
 		},
 		{
 			in: test5{
-				NoDups1: make([]testDup, 1, 1),
+				NoDups1: make([]testDup, 1),
 			},
 		},
 		{
 			in: test5{
-				NoDups1: make([]testDup, 1, 1),
-				NoDups2: make([]testDup, 1, 1),
+				NoDups1: make([]testDup, 1),
+				NoDups2: make([]testDup, 1),
 			},
 			out: mkReport(ignerrors.ErrDuplicate, path.New("json", "dups2", 0), report.Error, 0, 0),
 		},

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -220,8 +220,8 @@ func parseSgdiskPretend(sgdiskOut string, partitionNumbers []int) (map[int]sgdis
 	if len(partitionNumbers) == 0 {
 		return nil, nil
 	}
-	startRegex := regexp.MustCompile("^First sector: (\\d*) \\(.*\\)$")
-	endRegex := regexp.MustCompile("^Last sector: (\\d*) \\(.*\\)$")
+	startRegex := regexp.MustCompile(`^First sector: (\d*) \(.*\)$`)
+	endRegex := regexp.MustCompile(`^Last sector: (\d*) \(.*\)$`)
 	const (
 		START             = iota
 		END               = iota

--- a/tests/negative/proxy/http.go
+++ b/tests/negative/proxy/http.go
@@ -26,7 +26,6 @@ import (
 var (
 	proxyServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Proxy is unavailable", http.StatusServiceUnavailable)
-		return
 	}))
 
 	mockConfigURL = "http://www.fake.tld"

--- a/tests/types/types.go
+++ b/tests/types/types.go
@@ -247,7 +247,7 @@ func (disk *Disk) replaceAllUUIDVarsInPartitions(UUIDmap map[string]string) erro
 func replaceUUIDVars(str string, UUIDmap map[string]string) (string, error) {
 	finalStr := str
 
-	pattern := regexp.MustCompile("\\$uuid([0-9]+)")
+	pattern := regexp.MustCompile(`\$uuid([0-9]+)`)
 	for _, match := range pattern.FindAllStringSubmatch(str, -1) {
 		if len(match) != 2 {
 			return str, fmt.Errorf("find all string submatch error: want length of 2, got length of %d", len(match))
@@ -269,7 +269,7 @@ func getUUID(key string, UUIDmap map[string]string) string {
 // ReplaceAllVersionVars replaces Version variable (format $version) in configs with ConfigMinVersion
 // Updates the old config version (oldVersion) with a new one (newVersion)
 func (t *Test) ReplaceAllVersionVars(version string) {
-	pattern := regexp.MustCompile("\\$version")
+	pattern := regexp.MustCompile(`\$version`)
 	t.Config = pattern.ReplaceAllString(t.Config, version)
 	t.Name += " " + version
 }


### PR DESCRIPTION
Fixes part of https://github.com/coreos/ignition/issues/1121

Addresses the following warnings:
```

internal/exec/stages/disks/partitions.go:223:16: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
        startRegex := regexp.MustCompile("^First sector: (\\d*) \\(.*\\)$")
                      ^
internal/exec/stages/disks/partitions.go:224:14: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
        endRegex := regexp.MustCompile("^Last sector: (\\d*) \\(.*\\)$")

            ^
tests/types/types.go:250:13: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
        pattern := regexp.MustCompile("\\$uuid([0-9]+)")
                   ^
tests/negative/proxy/http.go:29:3: S1023: redundant `return` statement (gosimple)
                return
                ^
config/validate/validate_test.go:131:29: S1019: should use make([]testDup, 1) instead (gosimple)
                                NoDups: make([]testDup, 1, 1),
                                                        ^
config/validate/validate_test.go:136:29: S1019: should use make([]testDup, 2) instead (gosimple)
                                NoDups: make([]testDup, 2, 2),
                                                        ^
config/validate/validate_test.go:142:30: S1019: should use make([]testDup, 2) instead (gosimple)
                                Ignored: make([]testDup, 2, 2),
                                                         ^
config/validate/validate_test.go:147:30: S1019: should use make([]testDup, 1) instead (gosimple)
                                NoDups1: make([]testDup, 1, 1),
                                                         ^
config/validate/validate_test.go:152:30: S1019: should use make([]testDup, 1) instead (gosimple)
                                NoDups1: make([]testDup, 1, 1),
```