### PR TITLE
*: fix golangci-lint warnings

### DIFF
--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -110,7 +110,9 @@ func (s *stage) createLuks(config types.Config) error {
 		var ignitionCreatedKeyFile bool
 		// create keyfile inside of tmpfs, it will be copied to the
 		// sysroot by the files stage
-		os.MkdirAll(distro.LuksInitramfsKeyFilePath(), 0700)
+		if err := os.MkdirAll(distro.LuksInitramfsKeyFilePath(), 0700); err != nil {
+			return fmt.Errorf("creating directory for keyfile: %v", err)
+		}
 		keyFilePath := filepath.Join(distro.LuksInitramfsKeyFilePath(), luks.Name)
 		devAlias := execUtil.DeviceAlias(*luks.Device)
 		if util.NilOrEmpty(luks.KeyFile.Source) {

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -322,7 +322,9 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 		op := sgdisk.Begin(s.Logger, devAlias)
 		s.Logger.Info("wiping partition table requested on %q", devAlias)
 		op.WipeTable(true)
-		op.Commit()
+		if err := op.Commit(); err != nil {
+			return err
+		}
 	}
 
 	// Ensure all partitions with number 0 are last

--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -43,9 +43,7 @@ func (s *stage) warnOnOldSystemdVersion() error {
 		return err
 	}
 	if systemdVersion < 240 {
-		if err := s.Logger.Warning("The version of systemd (%q) is less than 240. Enabling/disabling instantiated units may not work. See https://github.com/coreos/ignition/issues/586 for more information.", systemdVersion); err != nil {
-			return err
-		}
+		s.Logger.Warning("The version of systemd (%q) is less than 240. Enabling/disabling instantiated units may not work. See https://github.com/coreos/ignition/issues/586 for more information.", systemdVersion)
 	}
 	return nil
 }

--- a/internal/exec/util/passwd.go
+++ b/internal/exec/util/passwd.go
@@ -218,7 +218,7 @@ func (u Util) AuthorizeSSHKeys(c types.PasswdUser) error {
 		if err != nil {
 			return fmt.Errorf("failed to set SSH key: %v", err)
 		}
-		journal.Send(fmt.Sprintf("wrote ssh authorized keys file for user: %s", c.Name), journal.PriInfo, map[string]string{
+		_ = journal.Send(fmt.Sprintf("wrote ssh authorized keys file for user: %s", c.Name), journal.PriInfo, map[string]string{
 			"IGNITION_USER_NAME": c.Name,
 			"IGNITION_PATH":      path,
 			"MESSAGE_ID":         ignitionSSHAuthorizedkeysMessageID,

--- a/internal/exec/util/user_group_lookup_test.go
+++ b/internal/exec/util/user_group_lookup_test.go
@@ -63,7 +63,10 @@ func TestUserLookup(t *testing.T) {
 
 	// perform a user lookup to ensure libnss_files.so is loaded
 	// note this assumes /etc/nsswitch.conf invokes files.
-	user.Lookup("root")
+	_, err := user.Lookup("root")
+	if err != nil {
+		t.Fatalf("user lookup failed (libnss_files.so might not be loaded): %v", err)
+	}
 
 	td, err := tempBase()
 	if err != nil {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -65,43 +65,43 @@ func (l Logger) Close() {
 }
 
 // Emerg logs a message at emergency priority.
-func (l Logger) Emerg(format string, a ...interface{}) error {
-	return l.log(l.ops.Emerg, format, a...)
+func (l Logger) Emerg(format string, a ...interface{}) {
+	l.log(l.ops.Emerg, format, a...)
 }
 
 // Alert logs a message at alert priority.
-func (l Logger) Alert(format string, a ...interface{}) error {
-	return l.log(l.ops.Alert, format, a...)
+func (l Logger) Alert(format string, a ...interface{}) {
+	l.log(l.ops.Alert, format, a...)
 }
 
 // Crit logs a message at critical priority.
-func (l Logger) Crit(format string, a ...interface{}) error {
-	return l.log(l.ops.Crit, format, a...)
+func (l Logger) Crit(format string, a ...interface{}) {
+	l.log(l.ops.Crit, format, a...)
 }
 
 // Err logs a message at error priority.
-func (l Logger) Err(format string, a ...interface{}) error {
-	return l.log(l.ops.Err, format, a...)
+func (l Logger) Err(format string, a ...interface{}) {
+	l.log(l.ops.Err, format, a...)
 }
 
 // Warning logs a message at warning priority.
-func (l Logger) Warning(format string, a ...interface{}) error {
-	return l.log(l.ops.Warning, format, a...)
+func (l Logger) Warning(format string, a ...interface{}) {
+	l.log(l.ops.Warning, format, a...)
 }
 
 // Notice logs a message at notice priority.
-func (l Logger) Notice(format string, a ...interface{}) error {
-	return l.log(l.ops.Notice, format, a...)
+func (l Logger) Notice(format string, a ...interface{}) {
+	l.log(l.ops.Notice, format, a...)
 }
 
 // Info logs a message at info priority.
-func (l Logger) Info(format string, a ...interface{}) error {
-	return l.log(l.ops.Info, format, a...)
+func (l Logger) Info(format string, a ...interface{}) {
+	l.log(l.ops.Info, format, a...)
 }
 
 // Debug logs a message at debug priority.
-func (l Logger) Debug(format string, a ...interface{}) error {
-	return l.log(l.ops.Debug, format, a...)
+func (l Logger) Debug(format string, a ...interface{}) {
+	l.log(l.ops.Debug, format, a...)
 }
 
 // PushPrefix pushes the supplied message onto the Logger's prefix stack.
@@ -189,8 +189,8 @@ func (l Logger) logFinish(format string, a ...interface{}) {
 }
 
 // log logs a formatted message using the supplied logFunc.
-func (l Logger) log(logFunc func(string) error, format string, a ...interface{}) error {
-	return logFunc(l.sprintf(format, a...))
+func (l Logger) log(logFunc func(string) error, format string, a ...interface{}) {
+	_ = logFunc(l.sprintf(format, a...))
 }
 
 // sprintf returns the current prefix stack, if any, concatenated with the supplied format string and args in expanded form.

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -90,10 +90,12 @@ func FetchFromOvfDevice(f *resource.Fetcher, ovfFsTypes []string) (types.Config,
 	); err != nil {
 		return types.Config{}, report.Report{}, fmt.Errorf("failed to mount device %q at %q: %v", devicePath, mnt, err)
 	}
-	defer logger.LogOp(
-		func() error { return unix.Unmount(mnt, 0) },
-		"unmounting %q at %q", devicePath, mnt,
-	)
+	defer func() {
+		_ = logger.LogOp(
+			func() error { return unix.Unmount(mnt, 0) },
+			"unmounting %q at %q", devicePath, mnt,
+		)
+	}()
 
 	logger.Debug("reading config")
 	rawConfig, err := ioutil.ReadFile(filepath.Join(mnt, configPath))

--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -205,10 +205,12 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, label string
 	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
 		return nil, err
 	}
-	defer logger.LogOp(
-		func() error { return unix.Unmount(mnt, 0) },
-		"unmounting %q at %q", path, mnt,
-	)
+	defer func() {
+		_ = logger.LogOp(
+			func() error { return unix.Unmount(mnt, 0) },
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
 
 	if !fileExists(filepath.Join(mnt, configDriveUserdataPath)) {
 		return nil, nil

--- a/internal/providers/ibmcloud/ibmcloud.go
+++ b/internal/providers/ibmcloud/ibmcloud.go
@@ -102,10 +102,12 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
 		return nil, err
 	}
-	defer logger.LogOp(
-		func() error { return syscall.Unmount(mnt, 0) },
-		"unmounting %q at %q", path, mnt,
-	)
+	defer func() {
+		_ = logger.LogOp(
+			func() error { return syscall.Unmount(mnt, 0) },
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
 
 	if !fileExists(filepath.Join(mnt, cidataPath)) {
 		return nil, nil

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -143,10 +143,12 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
 		return nil, err
 	}
-	defer logger.LogOp(
-		func() error { return unix.Unmount(mnt, 0) },
-		"unmounting %q at %q", path, mnt,
-	)
+	defer func() {
+		_ = logger.LogOp(
+			func() error { return unix.Unmount(mnt, 0) },
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
 
 	if !fileExists(filepath.Join(mnt, configDriveUserdataPath)) {
 		return nil, nil

--- a/internal/providers/packet/packet.go
+++ b/internal/providers/packet/packet.go
@@ -107,7 +107,7 @@ func postMessage(stageName string, e error, url string) error {
 		State   string `json:"state"`
 		Message string `json:"message"`
 	}
-	m := mStruct{}
+	var m mStruct
 	if e != nil {
 		m = mStruct{
 			State:   "failed",

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -224,7 +224,7 @@ func setupDisk(ctx context.Context, disk *types.Disk, diskIndex int, imageSize i
 	loopdev := disk.Device
 	defer func() {
 		if err != nil {
-			destroyDevice(loopdev)
+			_ = destroyDevice(loopdev)
 		}
 	}()
 
@@ -470,7 +470,9 @@ func createFilesFromSlice(basedir string, files []types.File) error {
 			}
 			writer.Flush()
 		}
-		os.Chown(filepath.Join(basedir, file.Directory, file.Name), file.User, file.Group)
+		if err := os.Chown(filepath.Join(basedir, file.Directory, file.Name), file.User, file.Group); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/tests/negative/security/tls.go
+++ b/tests/negative/security/tls.go
@@ -74,10 +74,10 @@ var (
 		}`)
 
 	customCAServer = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(customCAServerFile)
+		_, _ = w.Write(customCAServerFile)
 	}))
 	customCAServer2 = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(customCAServerFile2)
+		_, _ = w.Write(customCAServerFile2)
 	}))
 )
 

--- a/tests/negative/timeouts/timeouts.go
+++ b/tests/negative/timeouts/timeouts.go
@@ -44,7 +44,7 @@ var (
 		time.Sleep(time.Second * 2)
 		// Give a config that merges ourselves and sets the timeouts to 1
 		// second (less than we wait!)
-		w.Write([]byte(fmt.Sprintf(`{
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
 			"ignition": {
 				"version": "$version",
 				"config": {
@@ -161,7 +161,7 @@ func AppendNoneThenLowerHTTPTimeouts() types.Test {
 			time.Sleep(time.Second * 2)
 			// Give a config that merges ourselves and sets the timeouts to 1
 			// second (less than we wait!)
-			w.Write([]byte(`{
+			_, _ = w.Write([]byte(`{
 				"ignition": {
 					"version": "$version"
 				}
@@ -171,7 +171,7 @@ func AppendNoneThenLowerHTTPTimeouts() types.Test {
 		configNoDelayServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Give a config that merges ourselves and sets the timeouts to 1
 			// second (less than we wait!)
-			w.Write([]byte(fmt.Sprintf(`{
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
 			"ignition": 
 				"version": "$version",
 				"config": {

--- a/tests/positive/proxy/http.go
+++ b/tests/positive/proxy/http.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	proxyServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(ignConfig))
+		_, _ = w.Write([]byte(ignConfig))
 	}))
 
 	mockConfigURL = "http://www.fake.tld"

--- a/tests/positive/security/tls.go
+++ b/tests/positive/security/tls.go
@@ -78,10 +78,10 @@ var (
 		}`)
 
 	customCAServer = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(customCAServerFile)
+		_, _ = w.Write(customCAServerFile)
 	}))
 	customCAServer2 = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(customCAServerFile2)
+		_, _ = w.Write(customCAServerFile2)
 	}))
 )
 

--- a/tests/servers/servers.go
+++ b/tests/servers/servers.go
@@ -61,19 +61,19 @@ fdsa`)
 
 // HTTP Server
 func (server *HTTPServer) Config(w http.ResponseWriter, r *http.Request) {
-	w.Write(servedConfig)
+	_, _ = w.Write(servedConfig)
 }
 
 func (server *HTTPServer) Contents(w http.ResponseWriter, r *http.Request) {
-	w.Write(servedContents)
+	_, _ = w.Write(servedContents)
 }
 
 func (server *HTTPServer) Certificates(w http.ResponseWriter, r *http.Request) {
-	w.Write(fixtures.PublicKey)
+	_, _ = w.Write(fixtures.PublicKey)
 }
 
 func (server *HTTPServer) CABundle(w http.ResponseWriter, r *http.Request) {
-	w.Write(fixtures.CABundle)
+	_, _ = w.Write(fixtures.CABundle)
 }
 
 func compress(contents []byte) []byte {
@@ -89,20 +89,20 @@ func compress(contents []byte) []byte {
 }
 
 func (server *HTTPServer) ConfigCompressed(w http.ResponseWriter, r *http.Request) {
-	w.Write(compress(servedConfig))
+	_, _ = w.Write(compress(servedConfig))
 }
 
 func (server *HTTPServer) ContentsCompressed(w http.ResponseWriter, r *http.Request) {
-	w.Write(compress(servedContents))
+	_, _ = w.Write(compress(servedContents))
 }
 
 func (server *HTTPServer) CertificatesCompressed(w http.ResponseWriter, r *http.Request) {
-	w.Write(compress(fixtures.PublicKey))
+	_, _ = w.Write(compress(fixtures.PublicKey))
 }
 
 func errorHandler(w http.ResponseWriter, message string) {
 	w.WriteHeader(http.StatusBadRequest)
-	w.Write([]byte(message))
+	_, _ = w.Write([]byte(message))
 }
 
 // headerCheck validates that all required headers are present
@@ -161,19 +161,19 @@ func overwrittenHeaderCheck(w http.ResponseWriter, r *http.Request) {
 func (server *HTTPServer) ConfigHeaders(w http.ResponseWriter, r *http.Request) {
 	headerCheck(w, r)
 
-	w.Write(servedConfig)
+	_, _ = w.Write(servedConfig)
 }
 
 func (server *HTTPServer) ContentsHeaders(w http.ResponseWriter, r *http.Request) {
 	headerCheck(w, r)
 
-	w.Write(servedContents)
+	_, _ = w.Write(servedContents)
 }
 
 func (server *HTTPServer) CertificatesHeaders(w http.ResponseWriter, r *http.Request) {
 	headerCheck(w, r)
 
-	w.Write(fixtures.PublicKey)
+	_, _ = w.Write(fixtures.PublicKey)
 }
 
 // redirectedHeaderCheck validates that user's headers from the original request are missing
@@ -198,7 +198,7 @@ func (server *HTTPServer) ConfigRedirect(w http.ResponseWriter, r *http.Request)
 func (server *HTTPServer) ConfigRedirected(w http.ResponseWriter, r *http.Request) {
 	redirectedHeaderCheck(w, r)
 
-	w.Write(servedConfig)
+	_, _ = w.Write(servedConfig)
 }
 
 // ContentsRedirect redirects the request to ContentsRedirected
@@ -210,7 +210,7 @@ func (server *HTTPServer) ContentsRedirect(w http.ResponseWriter, r *http.Reques
 func (server *HTTPServer) ContentsRedirected(w http.ResponseWriter, r *http.Request) {
 	redirectedHeaderCheck(w, r)
 
-	w.Write(servedContents)
+	_, _ = w.Write(servedContents)
 }
 
 // CertificatesRedirect redirects the request to CertificatesRedirected
@@ -222,25 +222,25 @@ func (server *HTTPServer) CertificatesRedirect(w http.ResponseWriter, r *http.Re
 func (server *HTTPServer) CertificatesRedirected(w http.ResponseWriter, r *http.Request) {
 	redirectedHeaderCheck(w, r)
 
-	w.Write(fixtures.PublicKey)
+	_, _ = w.Write(fixtures.PublicKey)
 }
 
 func (server *HTTPServer) ConfigHeadersOverwrite(w http.ResponseWriter, r *http.Request) {
 	overwrittenHeaderCheck(w, r)
 
-	w.Write(servedConfig)
+	_, _ = w.Write(servedConfig)
 }
 
 func (server *HTTPServer) ContentsHeadersOverwrite(w http.ResponseWriter, r *http.Request) {
 	overwrittenHeaderCheck(w, r)
 
-	w.Write(servedContents)
+	_, _ = w.Write(servedContents)
 }
 
 func (server *HTTPServer) CertificatesHeadersOverwrite(w http.ResponseWriter, r *http.Request) {
 	overwrittenHeaderCheck(w, r)
 
-	w.Write(fixtures.PublicKey)
+	_, _ = w.Write(fixtures.PublicKey)
 }
 
 type HTTPServer struct{}
@@ -266,7 +266,9 @@ func (server *HTTPServer) Start() {
 	http.HandleFunc("/config_headers_overwrite", server.ConfigHeadersOverwrite)
 	http.HandleFunc("/caBundle", server.CABundle)
 	s := &http.Server{Addr: ":8080"}
-	go s.ListenAndServe()
+	go func() {
+		_ = s.ListenAndServe()
+	}()
 }
 
 // TFTP Server
@@ -293,5 +295,7 @@ type TFTPServer struct{}
 func (server *TFTPServer) Start() {
 	s := tftp.NewServer(server.ReadHandler, nil)
 	s.SetTimeout(5 * time.Second)
-	go s.ListenAndServe(":69")
+	go func() {
+		_ = s.ListenAndServe(":69")
+	}()
 }


### PR DESCRIPTION
Fixes part of #1121 
Addresses the following warnings:
https://gist.github.com/sohankunkerkar/e7a8a97be039283d841db527acd7d360

And a few more `errcheck` warnings which are not covered in this gist, but appeared in an ad-hoc manner while trying to fix these warnings.