### PR TITLE
config/*: require filesystems.format with wipeFilesystem or mountOptions

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -46,7 +46,7 @@ var (
 	ErrVerificationAndNilSource  = errors.New("source must be specified if verification is specified")
 	ErrFilesystemInvalidFormat   = errors.New("invalid filesystem format")
 	ErrLabelNeedsFormat          = errors.New("filesystem must specify format if label is specified")
-	ErrFormatNilWithOthers       = errors.New("format cannot be empty when path, label, uuid, or options are specified")
+	ErrFormatNilWithOthers       = errors.New("format cannot be empty when path, label, uuid, wipeFilesystem, options, or mountOptions is specified")
 	ErrExt4LabelTooLong          = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
 	ErrBtrfsLabelTooLong         = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
 	ErrXfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")

--- a/config/v3_0/types/filesystem.go
+++ b/config/v3_0/types/filesystem.go
@@ -49,6 +49,7 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/config/v3_0/types/filesystem_test.go
+++ b/config/v3_0/types/filesystem_test.go
@@ -43,11 +43,27 @@ func TestFilesystemValidateFormat(t *testing.T) {
 			nil,
 		},
 		{
+			Filesystem{Label: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{Options: []FilesystemOption{FilesystemOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
 			Filesystem{Format: util.StrToPtr(""), Path: util.StrToPtr("/")},
 			errors.ErrFormatNilWithOthers,
 		},
 		{
 			Filesystem{Format: nil, Path: util.StrToPtr("/")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{UUID: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{WipeFilesystem: util.BoolToPtr(true)},
 			errors.ErrFormatNilWithOthers,
 		},
 	}

--- a/config/v3_1/types/filesystem.go
+++ b/config/v3_1/types/filesystem.go
@@ -50,6 +50,8 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
+			len(f.MountOptions) != 0 ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/config/v3_1/types/filesystem_test.go
+++ b/config/v3_1/types/filesystem_test.go
@@ -43,11 +43,31 @@ func TestFilesystemValidateFormat(t *testing.T) {
 			nil,
 		},
 		{
+			Filesystem{Label: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{MountOptions: []MountOption{MountOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{Options: []FilesystemOption{FilesystemOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
 			Filesystem{Format: util.StrToPtr(""), Path: util.StrToPtr("/")},
 			errors.ErrFormatNilWithOthers,
 		},
 		{
 			Filesystem{Format: nil, Path: util.StrToPtr("/")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{UUID: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{WipeFilesystem: util.BoolToPtr(true)},
 			errors.ErrFormatNilWithOthers,
 		},
 	}

--- a/config/v3_2/types/filesystem.go
+++ b/config/v3_2/types/filesystem.go
@@ -50,6 +50,8 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
+			len(f.MountOptions) != 0 ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/config/v3_2/types/filesystem_test.go
+++ b/config/v3_2/types/filesystem_test.go
@@ -43,11 +43,31 @@ func TestFilesystemValidateFormat(t *testing.T) {
 			nil,
 		},
 		{
+			Filesystem{Label: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{MountOptions: []MountOption{MountOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{Options: []FilesystemOption{FilesystemOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
 			Filesystem{Format: util.StrToPtr(""), Path: util.StrToPtr("/")},
 			errors.ErrFormatNilWithOthers,
 		},
 		{
 			Filesystem{Format: nil, Path: util.StrToPtr("/")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{UUID: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{WipeFilesystem: util.BoolToPtr(true)},
 			errors.ErrFormatNilWithOthers,
 		},
 	}

--- a/config/v3_3_experimental/types/filesystem.go
+++ b/config/v3_3_experimental/types/filesystem.go
@@ -50,6 +50,8 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
+			len(f.MountOptions) != 0 ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/config/v3_3_experimental/types/filesystem_test.go
+++ b/config/v3_3_experimental/types/filesystem_test.go
@@ -43,11 +43,31 @@ func TestFilesystemValidateFormat(t *testing.T) {
 			nil,
 		},
 		{
+			Filesystem{Label: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{MountOptions: []MountOption{MountOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{Options: []FilesystemOption{FilesystemOption("z")}},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
 			Filesystem{Format: util.StrToPtr(""), Path: util.StrToPtr("/")},
 			errors.ErrFormatNilWithOthers,
 		},
 		{
 			Filesystem{Format: nil, Path: util.StrToPtr("/")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{UUID: util.StrToPtr("z")},
+			errors.ErrFormatNilWithOthers,
+		},
+		{
+			Filesystem{WipeFilesystem: util.BoolToPtr(true)},
 			errors.ErrFormatNilWithOthers,
 		},
 	}


### PR DESCRIPTION
Filesystem creation and mounting both ignore filesystems with `format` unset, but if the user specified `wipeFilesystem` or `mountOptions` that's clearly not their intent.  Fail validation in this case.