### PR TITLE
[RFC] dracut: add an ignition-sysusers service

### DIFF
--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -5,12 +5,12 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
+# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> sysusers -> files.
 # We need to make sure the partitions and filesystems are set up before
 # mounting. This is also guaranteed through After=initrd-root-fs.target but
 # just to be explicit.
 After=ignition-disks.service
-Before=ignition-files.service
+Before=ignition-sysusers.service
 
 # Make sure ExecStop= runs before we switch root
 Before=initrd-switch-root.target

--- a/dracut/30ignition/ignition-sysusers.service
+++ b/dracut/30ignition/ignition-sysusers.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ignition (files)
+Description=Ignition (sysusers)
 Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
@@ -9,13 +9,11 @@ OnFailure=emergency.target
 OnFailureJobMode=isolate
 
 # Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> sysusers -> files.
-After=ignition-sysusers.service
-
-# Run before initrd-parse-etc so that we can drop files it then picks up.
-Before=initrd-parse-etc.service
+After=ignition-mount.service
+Before=ignition-files.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files --log-to-stdout
+ExecStart=/usr/sbin/chroot /sysroot /bin/bash -c "mount proc /proc -t proc && /usr/bin/systemd-sysusers && umount /proc"

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -85,6 +85,7 @@ install() {
     install_ignition_unit ignition-fetch-offline.service
     install_ignition_unit ignition-disks.service
     install_ignition_unit ignition-mount.service
+    install_ignition_unit ignition-sysusers.service
     install_ignition_unit ignition-files.service
 
     # units only started when we have a boot disk


### PR DESCRIPTION
This adds a new `ignition-sysusers` service, ordered in-between
`mount` and `files` stages.
It takes care of creating system users/groups so that they can
be referenced in configuration, and used by Ignition when
setting ownership for filesystem entries.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/457