### PR TITLE
internal/providers/aws: fix panic when an IMDSv2 token is present

### DIFF
--- a/internal/providers/aws/aws.go
+++ b/internal/providers/aws/aws.go
@@ -92,6 +92,9 @@ func fetchFromAWSMetadata(u url.URL, opts resource.FetchOptions, f *resource.Fet
 	} else if err != nil {
 		return nil, err
 	} else {
+		if opts.Headers == nil {
+			opts.Headers = make(http.Header)
+		}
 		opts.Headers.Add("X-aws-ec2-metadata-token", token)
 	}
 	return f.FetchToBuffer(u, opts)


### PR DESCRIPTION
We are passing an empty `FetchOptions` object to the
`fetchFromAWSMetadata` function as we have yet to fetch the actual
config. This function attempts to append the IMDSv2 token to the HTTP
headers if it is fetched which panics assigning to a nil map.