### PR TITLE
Add a way to erase a block device without creating a filesystem

### DIFF
--- a/config/v3_3_experimental/types/filesystem.go
+++ b/config/v3_3_experimental/types/filesystem.go
@@ -57,7 +57,7 @@ func (f Filesystem) validateFormat() error {
 		}
 	} else {
 		switch *f.Format {
-		case "ext4", "btrfs", "xfs", "swap", "vfat":
+		case "ext4", "btrfs", "xfs", "swap", "vfat", "none":
 		default:
 			return errors.ErrFilesystemInvalidFormat
 		}

--- a/docs/configuration-v3_3_experimental.md
+++ b/docs/configuration-v3_3_experimental.md
@@ -69,7 +69,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_options_** (list of strings): any additional options to be passed to mdadm.
   * **_filesystems_** (list of objects): the list of filesystems to be configured. `device` and `format` need to be specified. Every filesystem must have a unique `device`.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
-    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, or swap).
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, swap, or none).
     * **_path_** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
     * **_wipeFilesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](operator-notes.md#filesystem-reuse-semantics) for more information. Defaults to false.
     * **_label_** (string): the label of the filesystem.

--- a/docs/operator-notes.md
+++ b/docs/operator-notes.md
@@ -47,9 +47,9 @@ In the first case, when there is no preexisting filesystem, Ignition will always
 
 In the second two cases, where there is a preexisting filesystem, Ignition's behavior is controlled by the `wipeFilesystem` flag in the `filesystem` section.
 
-If `wipeFilesystem` is set to true, Ignition will always wipe any preexisting filesystem and create the desired filesystem. Note this will result in any data on the old filesystem being lost.
+If `wipeFilesystem` is set to true, Ignition will always wipe any preexisting filesystem and create the desired filesystem (or skip creation if the format is set to `none`). Note this will result in any data on the old filesystem being lost.
 
-If `wipeFilesystem` is set to false, Ignition will then attempt to reuse the existing filesystem. If the filesystem is of the correct type, has a matching label, and has a matching UUID, then Ignition will reuse the filesystem. If the label or UUID is not set in the Ignition config, they don't need to match for Ignition to reuse the filesystem. Any preexisting data will be left on the device and will be available to the installation. If the preexisting filesystem is *not* of the correct type, then Ignition will fail, and the machine will fail to boot.
+If `wipeFilesystem` is set to false, Ignition will then attempt to reuse the existing filesystem. If the filesystem is of the correct type, has a matching label, and has a matching UUID, then Ignition will reuse the filesystem. If the label or UUID is not set in the Ignition config, they don't need to match for Ignition to reuse the filesystem. Any preexisting data will be left on the device and will be available to the installation. If the preexisting filesystem is *not* of the correct type, then Ignition will fail, and the machine will fail to boot. Similarly, if the format is set to `none`, then any preexisting filesystem will cause Ignition to fail.
 
 ## Path Traversal and Following Symlinks
 

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -94,14 +94,14 @@ func checkForNonDirectories(path string) error {
 			return err
 		}
 		if !st.Mode().IsDir() {
-			return fmt.Errorf("Mount path %q contains non-directory component %q", path, p)
+			return fmt.Errorf("mount path %q contains non-directory component %q", path, p)
 		}
 	}
 	return nil
 }
 
 func (s stage) mountFs(fs types.Filesystem) error {
-	if fs.Format == nil || *fs.Format == "swap" || *fs.Format == "" {
+	if fs.Format == nil || *fs.Format == "swap" || *fs.Format == "" || *fs.Format == "none" {
 		return nil
 	}
 

--- a/internal/exec/stages/umount/umount.go
+++ b/internal/exec/stages/umount/umount.go
@@ -80,7 +80,7 @@ func (s stage) Run(config types.Config) error {
 }
 
 func (s stage) umountFs(fs types.Filesystem) error {
-	if fs.Format != nil && *fs.Format == "swap" {
+	if fs.Format == nil || *fs.Format == "swap" || *fs.Format == "" || *fs.Format == "none" {
 		return nil
 	}
 	path, err := s.JoinPath(*fs.Path)

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -301,10 +301,11 @@ func formatPartition(ctx context.Context, partition *types.Partition) error {
 		return writePartitionData(partition.Device, partition.FilesystemImage)
 	default:
 		if partition.FilesystemType == "blank" ||
-			partition.FilesystemType == "" {
+			partition.FilesystemType == "" ||
+			partition.FilesystemType == "none" {
 			return nil
 		}
-		return fmt.Errorf("Unknown partition: %v", partition.FilesystemType)
+		return fmt.Errorf("unknown partition: %v", partition.FilesystemType)
 	}
 
 	if partition.FilesystemLabel != "" {

--- a/tests/negative/filesystems/creation.go
+++ b/tests/negative/filesystems/creation.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystems
+
+import (
+	"github.com/coreos/ignition/v2/tests/register"
+	"github.com/coreos/ignition/v2/tests/types"
+)
+
+func init() {
+	register.Register(register.NegativeTest, EraseBlockDeviceWithInvalidoptions())
+}
+
+// EraseBlockDeviceWithInvalidoptions verifies that the Ignition
+// fails to erase the block device with pre-existing filesystem
+// on it if `wipeFileSystem is set to `false` and the format is
+// set to `none`.
+func EraseBlockDeviceWithInvalidoptions() types.Test {
+	name := "filesystem.erase.block.device.invalidoptions"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "EFI-SYSTEM",
+			Substitution: "$DEVICE",
+		},
+	}
+	config := `{
+		"ignition": { "version": "$version" },
+		"storage": {
+			"filesystems": [{
+				"device": "$DEVICE",
+				"format": "none",
+				"path": "/tmp0",
+				"wipeFilesystem": false
+			}]
+		}
+	}`
+	configMinVersion := "3.3.0-experimental"
+
+	in[0].Partitions.GetPartition("EFI-SYSTEM").FilesystemType = "ext4"
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}


### PR DESCRIPTION
Fixes: #1172
This PR tries to address the problem of erasing a block device with Ignition without creating a filesystem on it.
Also, related to https://bugzilla.redhat.com/show_bug.cgi?id=1926221