### PR TITLE
docs/getting-started.md: modify first boot link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,7 +63,7 @@ When Ignition enables systemd services, it doesn't directly create the symlinks 
 
 Ignition is not typically run more than once during a machine's lifetime in a given role, so this situation requiring manual systemd intervention does not commonly arise.
 
-[conditions]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionArchitecture=
+[conditions]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionFirstBoot=
 [configspec]: specs.md
 [examples]: examples.md
 [mime]: http://www.iana.org/assignments/media-types/application/vnd.coreos.ignition+json


### PR DESCRIPTION
The text `first boot` currently links to the top of the systemd documentation on condition directives by looking to `ConditionArchitecture`, which is confusing. I think it would be clearer to link to `ConditionFirstBoot` directly given the text and context of the link.