### PR TITLE
config: test that struct fields are properly pointered

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,7 +104,7 @@ func TestConfigStructure(t *testing.T) {
 
 	for _, configType := range configs {
 		if err := testConfigType(configType); err != nil {
-			t.Errorf("Type %s was invalid: %v", configType.Name(), err)
+			t.Errorf("Type %s/%s was invalid: %v", configType.PkgPath(), configType.Name(), err)
 		}
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,126 @@ import (
 	v3_3 "github.com/coreos/ignition/v2/config/v3_3_experimental/types"
 )
 
+// helper to check whether a type and field matches a denylist of known problems
+// examples are either structs or names of structs
+func ignore(t reflect.Type, field reflect.StructField, fieldName string, examples ...interface{}) bool {
+	if field.Name != fieldName {
+		return false
+	}
+	for _, candidate := range examples {
+		if reflect.TypeOf(candidate).Kind() == reflect.String {
+			if t.Name() == candidate.(string) {
+				return true
+			}
+		} else if t == reflect.TypeOf(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// vary the specified field value and check the given key function to see
+// whether the field seems to affect it
+// this function's heuristic can be fooled by complex key functions but it
+// should be fine for typical cases
+func fieldAffectsKey(key func() string, v reflect.Value) bool {
+	kind := v.Kind()
+	switch {
+	case util.IsPrimitive(kind):
+		old := key()
+		v.Set(util.NonZeroValue(v.Type()))
+		new := key()
+		v.Set(reflect.Zero(v.Type()))
+		return old != new
+	case kind == reflect.Ptr:
+		null := key()
+		v.Set(reflect.New(v.Type().Elem()))
+		allocated := key()
+		affectsKey := fieldAffectsKey(key, v.Elem())
+		v.Set(reflect.Zero(v.Type()))
+		return null != allocated || affectsKey
+	case kind == reflect.Struct:
+		ret := false
+		for i := 0; i < v.NumField(); i++ {
+			ret = ret || fieldAffectsKey(key, v.Field(i))
+		}
+		return ret
+	case kind == reflect.Slice:
+		if v.Len() > 0 {
+			panic("Slice started with non-zero length")
+		}
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		ret := fieldAffectsKey(key, v.Index(0))
+		v.SetLen(0)
+		return ret
+	default:
+		panic(fmt.Sprintf("Unexpected value kind %v", kind.String()))
+	}
+}
+
+// check the fields that affect the key function of a keyed struct
+// to ensure that we're using pointer and non-pointer fields properly.
+func checkStructFieldKey(t reflect.Type) error {
+	v := reflect.New(t).Elem()
+	// wrapper to get the current key of @v
+	getKey := func() string {
+		// outer function's caller should have ensured that type
+		// implements Keyed
+		return v.Interface().(util.Keyed).Key()
+	}
+
+	var haveNonPointerKey bool
+	// check the fields of one struct
+	var checkStruct func(t reflect.Type, v reflect.Value) error
+	checkStruct = func(t reflect.Type, v reflect.Value) error {
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			affectsKey := fieldAffectsKey(getKey, v.Field(i))
+
+			switch {
+			case util.IsPrimitive(field.Type.Kind()):
+				// non-pointer primitive; must affect key
+				haveNonPointerKey = true
+				if !affectsKey &&
+					!ignore(t, field, "Target", v3_0.LinkEmbedded1{}, v3_1.LinkEmbedded1{}, v3_2.LinkEmbedded1{}, v3_3.LinkEmbedded1{}) &&
+					!ignore(t, field, "Level", v3_0.Raid{}, v3_1.Raid{}, v3_2.Raid{}, v3_3.Raid{}) {
+					return fmt.Errorf("Non-pointer %s.%s does not affect key", t.Name(), field.Name)
+				}
+			case field.Type.Kind() == reflect.Ptr && util.IsPrimitive(field.Type.Elem().Kind()):
+				// pointer primitive; may affect key if there's also
+				// a non-pointer key
+			case field.Type.Kind() == reflect.Struct && field.Anonymous:
+				// anonymous child struct; treat it as an extension of the
+				// parent
+				if err := checkStruct(field.Type, v.Field(i)); err != nil {
+					return err
+				}
+			default:
+				// slice, struct, or invalid type
+				if affectsKey {
+					return fmt.Errorf("Non-primitive %s.%s affects key", t.Name(), field.Name)
+				}
+			}
+		}
+		return nil
+	}
+	if err := checkStruct(t, v); err != nil {
+		return err
+	}
+
+	// The Resource struct in spec >= 3.1 uses Source as the key, but
+	// it's a pointer because in storage.files the source is optional.
+	// Allow this special case, and the similar ConfigReference one in
+	// 3.0.  This rule is a consistency guideline anyway; there's no
+	// technical reason we can't have pointer keys.
+	if !haveNonPointerKey &&
+		t.Name() != "Resource" &&
+		t != reflect.TypeOf(v3_0.ConfigReference{}) {
+		return fmt.Errorf("No non-pointer key for %s", t.Name())
+	}
+	return nil
+}
+
 func testConfigType(t reflect.Type) error {
 	k := t.Kind()
 	switch {
@@ -76,13 +196,19 @@ func testConfigType(t reflect.Type) error {
 				return fmt.Errorf("Type %s has invalid field %s: %v", t.Name(), field.Name, err)
 			}
 			if field.Type.Kind() == reflect.Slice && field.Type.Elem().Kind() != reflect.String {
+				elemType := field.Type.Elem()
 				if _, ignored := ignoredFields[field.Name]; !ignored {
-					keyed, ok := reflect.New(field.Type.Elem()).Interface().(util.Keyed)
+					// check this here, rather than in checkStructFieldKey(),
+					// so we can provide more context in the error
+					keyed, ok := reflect.New(elemType).Interface().(util.Keyed)
 					if !ok {
 						return fmt.Errorf("Type %s has slice field %s without Key() defined on %s debug: %v", t.Name(), field.Name, field.Type.Elem().Name(), ignoredFields)
 					}
-					// check for nil pointer dereference when calling Key() on zero value
+					// explicitly check for nil pointer dereference when calling Key() on zero value
 					keyed.Key()
+					if err := checkStructFieldKey(elemType); err != nil {
+						return fmt.Errorf("Type %s has invalid field %s: %v", t.Name(), field.Name, err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Add tests for the first part of #1132.  Check that:

1. For "keyed structs" (those that have a key function and are in a slice),
    1. all non-pointer primitive fields affect the key,
    1. there is at least one non-pointer primitive field, and
    1. all fields that affect the key are primitives or pointers to primitives, and are at the top level of the struct or reachable from a chain of anonymous embedded structs.
1. For structs other than keyed structs and structs anonymously embedded in them,
    1. there are no non-pointer primitive fields.

Hardcode exceptions for every struct that breaks these rules.  We can fix the experimental spec as a followup.