### PR TITLE
config/validate: Add fuzzer

### DIFF
--- a/config/validate/fuzz.go
+++ b/config/validate/fuzz.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"github.com/coreos/vcontext/report"
+)
+
+func mangleFuzzReport(r *report.Report) {
+	for i := range r.Entries {
+		if sp := r.Entries[i].Marker.StartP; sp != nil {
+			sp.Index = 0
+		}
+		r.Entries[i].Marker.EndP = nil
+	}
+}
+
+func FuzzValidate(data []byte) int {
+	r := ValidateWithContext(struct{}{}, data)
+	mangleFuzzReport(&r)
+	return 1
+}


### PR DESCRIPTION
This PR moves the fuzzer from https://github.com/google/oss-fuzz/pull/5368 upstream which will allow the coverage build getting to work.

Once merged here, I will do the necessary changes on the OSS-fuzz side.