### PR TITLE
release-checklist: drop mention of commit hash variable

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -11,7 +11,6 @@ Tagging:
 
 Packaging:
  - [ ] Update the Ignition spec file in [Fedora](https://src.fedoraproject.org/rpms/ignition):
-   - Update the commit hash global variable
    - Bump the `Version`
    - Switch the `Release` back to `1%{?dist}`
    - Remove any patches obsoleted by the new release


### PR DESCRIPTION
We removed commit hashes from the specfile in 2.9.0-4