### PR TITLE
ignition-setup-user.service: drop Before=multipathd.service

### DIFF
--- a/dracut/30ignition/ignition-setup-user.service
+++ b/dracut/30ignition/ignition-setup-user.service
@@ -11,10 +11,6 @@ OnFailureJobMode=isolate
 # Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
 Before=ignition-fetch-offline.service
 
-# We want to make sure we're not racing with multipath taking ownership of the
-# boot device.
-Before=multipathd.service
-
 # On diskful boots, ignition-generator adds Requires/After on
 # dev-disk-by\x2dlabel-boot.device
 


### PR DESCRIPTION
We don't officially support multipath enabled on first boot yet. That's
what I'm working on, but this gets in the way because we actually need
to do the *opposite* (i.e. ensure that any I/O going to multipathed
devices is done through the multipath device node).

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1954025