### PR TITLE
*: formally bump Go to 1.13

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,7 @@ nav_order: 10
 1. TOC
 {:toc}
 
-A Go 1.11+ [environment](https://golang.org/doc/install) and the `blkid.h` headers are required. Using go 1.10 may work, but isn't directly supported since it does not support go modules.
+A Go 1.13+ [environment](https://golang.org/doc/install) and the `blkid.h` headers are required.
 
 ```sh
 # Debian/Ubuntu

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/ignition/v2
 
-go 1.11
+go 1.13
 
 require (
 	cloud.google.com/go v0.58.0


### PR DESCRIPTION
We've required it since at least f946e0df.