### PR TITLE
config/v3_3_exp: pointerify primitive non-key spec fields

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -248,8 +248,8 @@ func checkNonKeyedStructFields(t reflect.Type, ignoreTypes typeSet) error {
 			if !ignoreType &&
 				util.IsPrimitive(f.Type.Kind()) &&
 				!ignore(t, f, "Version", "Ignition") &&
-				!ignore(t, f, "Config", v3_2.Custom{}, v3_3.ClevisCustom{}) &&
-				!ignore(t, f, "Pin", v3_2.Custom{}, v3_3.ClevisCustom{}) {
+				!ignore(t, f, "Config", v3_2.Custom{}) &&
+				!ignore(t, f, "Pin", v3_2.Custom{}) {
 				return fmt.Errorf("Type %s has non-pointer primitive field %s", t.Name(), f.Name)
 			}
 			if err := checkNonKeyedStructFields(f.Type, ignoreTypes); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,7 +112,7 @@ func checkStructFieldKey(t reflect.Type, keyedStructs typeSet) error {
 				// non-pointer primitive; must affect key
 				haveNonPointerKey = true
 				if !affectsKey &&
-					!ignore(t, field, "Target", v3_0.LinkEmbedded1{}, v3_1.LinkEmbedded1{}, v3_2.LinkEmbedded1{}, v3_3.LinkEmbedded1{}) &&
+					!ignore(t, field, "Target", v3_0.LinkEmbedded1{}, v3_1.LinkEmbedded1{}, v3_2.LinkEmbedded1{}) &&
 					!ignore(t, field, "Level", v3_0.Raid{}, v3_1.Raid{}, v3_2.Raid{}, v3_3.Raid{}) {
 					return fmt.Errorf("Non-pointer %s.%s does not affect key", t.Name(), field.Name)
 				}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,7 +113,7 @@ func checkStructFieldKey(t reflect.Type, keyedStructs typeSet) error {
 				haveNonPointerKey = true
 				if !affectsKey &&
 					!ignore(t, field, "Target", v3_0.LinkEmbedded1{}, v3_1.LinkEmbedded1{}, v3_2.LinkEmbedded1{}) &&
-					!ignore(t, field, "Level", v3_0.Raid{}, v3_1.Raid{}, v3_2.Raid{}, v3_3.Raid{}) {
+					!ignore(t, field, "Level", v3_0.Raid{}, v3_1.Raid{}, v3_2.Raid{}) {
 					return fmt.Errorf("Non-pointer %s.%s does not affect key", t.Name(), field.Name)
 				}
 			case field.Type.Kind() == reflect.Ptr && util.IsPrimitive(field.Type.Elem().Kind()):

--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -56,6 +56,7 @@ var (
 	ErrLuksLabelTooLong          = errors.New("luks device labels cannot be longer than 47 characters")
 	ErrLuksNameContainsSlash     = errors.New("device names cannot contain slashes")
 	ErrInvalidLuksKeyFile        = errors.New("invalid key-file source")
+	ErrClevisPinRequired         = errors.New("missing required custom clevis pin")
 	ErrUnknownClevisPin          = errors.New("unsupported clevis pin")
 	ErrClevisConfigRequired      = errors.New("missing required custom clevis config")
 	ErrClevisCustomWithOthers    = errors.New("cannot use custom clevis config with tpm2, tang, or threshold")

--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -68,6 +68,7 @@ var (
 	ErrNoPath                    = errors.New("path not specified")
 	ErrPathRelative              = errors.New("path not absolute")
 	ErrDirtyPath                 = errors.New("path is not fully simplified")
+	ErrRaidLevelRequired         = errors.New("raid level is required")
 	ErrSparesUnsupportedForLevel = errors.New("spares unsupported for linear and raid0 arrays")
 	ErrUnrecognizedRaidLevel     = errors.New("unrecognized raid level")
 	ErrRaidDevicesRequired       = errors.New("raid devices required")

--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrFileUsedSymlink           = errors.New("file path includes link in config")
 	ErrDirectoryUsedSymlink      = errors.New("directory path includes link in config")
 	ErrLinkUsedSymlink           = errors.New("link path includes link in config")
+	ErrLinkTargetRequired        = errors.New("link target is required")
 	ErrHardLinkToDirectory       = errors.New("hard link target is a directory")
 	ErrDiskDeviceRequired        = errors.New("disk device is required")
 	ErrPartitionNumbersCollide   = errors.New("partition numbers collide")

--- a/config/v3_3_experimental/schema/ignition.json
+++ b/config/v3_3_experimental/schema/ignition.json
@@ -217,7 +217,7 @@
               "type": "string"
             },
             "level": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "spares": {
               "type": ["integer", "null"]
@@ -236,8 +236,7 @@
             }
           },
           "required": [
-              "name",
-              "level"
+              "name"
           ]
         },
         "luks": {

--- a/config/v3_3_experimental/schema/ignition.json
+++ b/config/v3_3_experimental/schema/ignition.json
@@ -410,15 +410,12 @@
               "type": "object",
               "properties": {
                 "target": {
-                  "type": "string"
+                  "type": ["string", "null"]
                 },
                 "hard": {
                   "type": ["boolean", "null"]
                 }
-              },
-              "required": [
-                  "target"
-              ]
+              }
             }
           ]
         },

--- a/config/v3_3_experimental/schema/ignition.json
+++ b/config/v3_3_experimental/schema/ignition.json
@@ -298,19 +298,15 @@
           "type": "object",
           "properties": {
             "pin": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "config": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "needsNetwork": {
               "type": ["boolean", "null"]
             }
-          },
-          "required": [
-            "pin",
-            "config"
-          ]
+          }
         },
         "tang": {
           "type": "object",

--- a/config/v3_3_experimental/translate/translate.go
+++ b/config/v3_3_experimental/translate/translate.go
@@ -28,6 +28,16 @@ func translateIgnition(old old_types.Ignition) (ret types.Ignition) {
 	return
 }
 
+func translateRaid(old old_types.Raid) (ret types.Raid) {
+	tr := translate.NewTranslator()
+	tr.Translate(&old.Devices, &ret.Devices)
+	ret.Level = util.StrToPtr(old.Level)
+	tr.Translate(&old.Name, &ret.Name)
+	tr.Translate(&old.Options, &ret.Options)
+	tr.Translate(&old.Spares, &ret.Spares)
+	return
+}
+
 func translateLuks(old old_types.Luks) (ret types.Luks) {
 	tr := translate.NewTranslator()
 	tr.AddCustomTranslator(translateClevis)
@@ -74,6 +84,7 @@ func translateLinkEmbedded1(old old_types.LinkEmbedded1) (ret types.LinkEmbedded
 func Translate(old old_types.Config) (ret types.Config) {
 	tr := translate.NewTranslator()
 	tr.AddCustomTranslator(translateIgnition)
+	tr.AddCustomTranslator(translateRaid)
 	tr.AddCustomTranslator(translateLuks)
 	tr.AddCustomTranslator(translateLinkEmbedded1)
 	tr.Translate(&old.Ignition, &ret.Ignition)

--- a/config/v3_3_experimental/translate/translate.go
+++ b/config/v3_3_experimental/translate/translate.go
@@ -16,6 +16,7 @@ package translate
 
 import (
 	"github.com/coreos/ignition/v2/config/translate"
+	"github.com/coreos/ignition/v2/config/util"
 	old_types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
 )
@@ -63,10 +64,18 @@ func translateClevisCustom(old old_types.Custom) (ret types.ClevisCustom) {
 	return
 }
 
+func translateLinkEmbedded1(old old_types.LinkEmbedded1) (ret types.LinkEmbedded1) {
+	tr := translate.NewTranslator()
+	tr.Translate(&old.Hard, &ret.Hard)
+	ret.Target = util.StrToPtr(old.Target)
+	return
+}
+
 func Translate(old old_types.Config) (ret types.Config) {
 	tr := translate.NewTranslator()
 	tr.AddCustomTranslator(translateIgnition)
 	tr.AddCustomTranslator(translateLuks)
+	tr.AddCustomTranslator(translateLinkEmbedded1)
 	tr.Translate(&old.Ignition, &ret.Ignition)
 	tr.Translate(&old.Passwd, &ret.Passwd)
 	tr.Translate(&old.Storage, &ret.Storage)

--- a/config/v3_3_experimental/translate/translate.go
+++ b/config/v3_3_experimental/translate/translate.go
@@ -68,9 +68,9 @@ func translateClevis(old old_types.Clevis) (ret types.Clevis) {
 
 func translateClevisCustom(old old_types.Custom) (ret types.ClevisCustom) {
 	tr := translate.NewTranslator()
-	tr.Translate(&old.Config, &ret.Config)
+	ret.Config = util.StrToPtr(old.Config)
 	tr.Translate(&old.NeedsNetwork, &ret.NeedsNetwork)
-	tr.Translate(&old.Pin, &ret.Pin)
+	ret.Pin = util.StrToPtr(old.Pin)
 	return
 }
 

--- a/config/v3_3_experimental/types/clevis.go
+++ b/config/v3_3_experimental/types/clevis.go
@@ -23,22 +23,26 @@ import (
 )
 
 func (c Clevis) IsPresent() bool {
-	return c.Custom.Pin != "" ||
+	return util.NotEmpty(c.Custom.Pin) ||
 		len(c.Tang) > 0 ||
 		util.IsTrue(c.Tpm2) ||
 		c.Threshold != nil && *c.Threshold != 0
 }
 
 func (cu ClevisCustom) Validate(c path.ContextPath) (r report.Report) {
-	if cu.Pin == "" && cu.Config == "" && !util.IsTrue(cu.NeedsNetwork) {
+	if util.NilOrEmpty(cu.Pin) && util.NilOrEmpty(cu.Config) && !util.IsTrue(cu.NeedsNetwork) {
 		return
 	}
-	switch cu.Pin {
-	case "tpm2", "tang", "sss":
-	default:
-		r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
+	if util.NotEmpty(cu.Pin) {
+		switch *cu.Pin {
+		case "tpm2", "tang", "sss":
+		default:
+			r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
+		}
+	} else {
+		r.AddOnError(c.Append("pin"), errors.ErrClevisPinRequired)
 	}
-	if cu.Config == "" {
+	if util.NilOrEmpty(cu.Config) {
 		r.AddOnError(c.Append("config"), errors.ErrClevisConfigRequired)
 	}
 	return

--- a/config/v3_3_experimental/types/clevis_test.go
+++ b/config/v3_3_experimental/types/clevis_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+func TestClevisCustomValidate(t *testing.T) {
+	tests := []struct {
+		in  ClevisCustom
+		at  path.ContextPath
+		out error
+	}{
+		{
+			in:  ClevisCustom{},
+			out: nil,
+		},
+		{
+			in: ClevisCustom{
+				Config:       util.StrToPtr("z"),
+				NeedsNetwork: util.BoolToPtr(true),
+				Pin:          util.StrToPtr("sss"),
+			},
+			out: nil,
+		},
+		{
+			in: ClevisCustom{
+				Config: util.StrToPtr("z"),
+			},
+			at:  path.New("", "pin"),
+			out: errors.ErrClevisPinRequired,
+		},
+		{
+			in: ClevisCustom{
+				Config: util.StrToPtr("z"),
+				Pin:    util.StrToPtr("z"),
+			},
+			at:  path.New("", "pin"),
+			out: errors.ErrUnknownClevisPin,
+		},
+		{
+			in: ClevisCustom{
+				Pin: util.StrToPtr("tpm2"),
+			},
+			at:  path.New("", "config"),
+			out: errors.ErrClevisConfigRequired,
+		},
+	}
+
+	for i, test := range tests {
+		r := test.in.Validate(path.ContextPath{})
+		expected := report.Report{}
+		expected.AddOnError(test.at, test.out)
+		if !reflect.DeepEqual(expected, r) {
+			t.Errorf("#%d: bad report: want %v, got %v", i, expected, r)
+		}
+	}
+}

--- a/config/v3_3_experimental/types/luks.go
+++ b/config/v3_3_experimental/types/luks.go
@@ -45,7 +45,7 @@ func (l Luks) Validate(c path.ContextPath) (r report.Report) {
 		r.AddOnError(c.Append("device"), validatePath(*l.Device))
 	}
 
-	if l.Clevis.Custom.Pin != "" && (len(l.Clevis.Tang) > 0 || util.IsTrue(l.Clevis.Tpm2) || (l.Clevis.Threshold != nil && *l.Clevis.Threshold != 0)) {
+	if util.NotEmpty(l.Clevis.Custom.Pin) && (len(l.Clevis.Tang) > 0 || util.IsTrue(l.Clevis.Tpm2) || (l.Clevis.Threshold != nil && *l.Clevis.Threshold != 0)) {
 		r.AddOnError(c.Append("clevis"), errors.ErrClevisCustomWithOthers)
 	}
 

--- a/config/v3_3_experimental/types/raid.go
+++ b/config/v3_3_experimental/types/raid.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -40,7 +41,10 @@ func (ra Raid) Validate(c path.ContextPath) (r report.Report) {
 }
 
 func (r Raid) validateLevel() error {
-	switch r.Level {
+	if util.NilOrEmpty(r.Level) {
+		return errors.ErrRaidLevelRequired
+	}
+	switch *r.Level {
 	case "linear", "raid0", "0", "stripe":
 		if r.Spares != nil && *r.Spares != 0 {
 			return errors.ErrSparesUnsupportedForLevel

--- a/config/v3_3_experimental/types/raid_test.go
+++ b/config/v3_3_experimental/types/raid_test.go
@@ -34,7 +34,7 @@ func TestRaidValidate(t *testing.T) {
 		{
 			in: Raid{
 				Name:    "name",
-				Level:   "0",
+				Level:   util.StrToPtr("0"),
 				Devices: []Device{"/dev/fd0"},
 				Spares:  util.IntToPtr(0),
 			},
@@ -43,7 +43,15 @@ func TestRaidValidate(t *testing.T) {
 		{
 			in: Raid{
 				Name:    "name",
-				Level:   "0",
+				Devices: []Device{"/dev/fd0"},
+			},
+			at:  path.New("", "level"),
+			out: errors.ErrRaidLevelRequired,
+		},
+		{
+			in: Raid{
+				Name:    "name",
+				Level:   util.StrToPtr("0"),
 				Devices: []Device{"/dev/fd0"},
 				Spares:  util.IntToPtr(1),
 			},
@@ -54,6 +62,7 @@ func TestRaidValidate(t *testing.T) {
 			in: Raid{
 				Name:    "name",
 				Devices: []Device{"/dev/fd0"},
+				Level:   util.StrToPtr("zzz"),
 			},
 			at:  path.New("", "level"),
 			out: errors.ErrUnrecognizedRaidLevel,
@@ -61,7 +70,7 @@ func TestRaidValidate(t *testing.T) {
 		{
 			in: Raid{
 				Name:  "name",
-				Level: "0",
+				Level: util.StrToPtr("0"),
 			},
 			at:  path.New("", "devices"),
 			out: errors.ErrRaidDevicesRequired,

--- a/config/v3_3_experimental/types/schema.go
+++ b/config/v3_3_experimental/types/schema.go
@@ -10,9 +10,9 @@ type Clevis struct {
 }
 
 type ClevisCustom struct {
-	Config       string `json:"config"`
-	NeedsNetwork *bool  `json:"needsNetwork,omitempty"`
-	Pin          string `json:"pin"`
+	Config       *string `json:"config,omitempty"`
+	NeedsNetwork *bool   `json:"needsNetwork,omitempty"`
+	Pin          *string `json:"pin,omitempty"`
 }
 
 type Config struct {

--- a/config/v3_3_experimental/types/schema.go
+++ b/config/v3_3_experimental/types/schema.go
@@ -104,8 +104,8 @@ type Link struct {
 }
 
 type LinkEmbedded1 struct {
-	Hard   *bool  `json:"hard,omitempty"`
-	Target string `json:"target"`
+	Hard   *bool   `json:"hard,omitempty"`
+	Target *string `json:"target,omitempty"`
 }
 
 type Luks struct {

--- a/config/v3_3_experimental/types/schema.go
+++ b/config/v3_3_experimental/types/schema.go
@@ -192,7 +192,7 @@ type Proxy struct {
 
 type Raid struct {
 	Devices []Device     `json:"devices,omitempty"`
-	Level   string       `json:"level"`
+	Level   *string      `json:"level,omitempty"`
 	Name    string       `json:"name"`
 	Options []RaidOption `json:"options,omitempty"`
 	Spares  *int         `json:"spares,omitempty"`

--- a/config/v3_3_experimental/types/storage.go
+++ b/config/v3_3_experimental/types/storage.go
@@ -54,12 +54,16 @@ func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 				r.AddOnError(c.Append("links", i), errors.ErrLinkUsedSymlink)
 			}
 		}
+		if util.NilOrEmpty(l1.Target) {
+			r.AddOnError(c.Append("links", i, "target"), errors.ErrLinkTargetRequired)
+			continue
+		}
 		if !util.IsTrue(l1.Hard) {
 			continue
 		}
-		target := path.Clean(l1.Target)
+		target := path.Clean(*l1.Target)
 		if !path.IsAbs(target) {
-			target = path.Join(l1.Path, l1.Target)
+			target = path.Join(l1.Path, *l1.Target)
 		}
 		for _, d := range s.Directories {
 			if target == d.Path {

--- a/config/v3_3_experimental/types/storage_test.go
+++ b/config/v3_3_experimental/types/storage_test.go
@@ -39,10 +39,12 @@ func TestStorageValidate(t *testing.T) {
 			in: Storage{
 				Links: []Link{
 					{
-						Node: Node{Path: "/foo"},
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foo-t")},
 					},
 					{
-						Node: Node{Path: "/quux"},
+						Node:          Node{Path: "/quux"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/quux-t")},
 					},
 				},
 				Files: []File{
@@ -62,7 +64,8 @@ func TestStorageValidate(t *testing.T) {
 			in: Storage{
 				Links: []Link{
 					{
-						Node: Node{Path: "/foo"},
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foo-t")},
 					},
 				},
 				Files: []File{
@@ -78,7 +81,8 @@ func TestStorageValidate(t *testing.T) {
 			in: Storage{
 				Links: []Link{
 					{
-						Node: Node{Path: "/foo"},
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foo-t")},
 					},
 				},
 				Directories: []Directory{
@@ -94,10 +98,12 @@ func TestStorageValidate(t *testing.T) {
 			in: Storage{
 				Links: []Link{
 					{
-						Node: Node{Path: "/foo"},
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foo-t")},
 					},
 					{
-						Node: Node{Path: "/foo/bar"},
+						Node:          Node{Path: "/foo/bar"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foo-bar-t")},
 					},
 				},
 			},
@@ -108,10 +114,36 @@ func TestStorageValidate(t *testing.T) {
 			in: Storage{
 				Links: []Link{
 					{
-						Node: Node{Path: "/foo"},
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Hard: util.BoolToPtr(true)},
+					},
+				},
+			},
+			out: errors.ErrLinkTargetRequired,
+			at:  path.New("", "links", 0, "target"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("")},
+					},
+				},
+			},
+			out: errors.ErrLinkTargetRequired,
+			at:  path.New("", "links", 0, "target"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node:          Node{Path: "/foo"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foo-t")},
 					},
 					{
-						Node: Node{Path: "/foob/bar"},
+						Node:          Node{Path: "/foob/bar"},
+						LinkEmbedded1: LinkEmbedded1{Target: util.StrToPtr("/foob-bar-t")},
 					},
 				},
 			},
@@ -123,7 +155,7 @@ func TestStorageValidate(t *testing.T) {
 					{
 						Node: Node{Path: "/quux"},
 						LinkEmbedded1: LinkEmbedded1{
-							Target: "/foo/bar",
+							Target: util.StrToPtr("/foo/bar"),
 							Hard:   util.BoolToPtr(true),
 						},
 					},

--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -249,9 +249,9 @@ func (s *stage) createLuks(config types.Config) error {
 			var pin string
 			var config string
 
-			if luks.Clevis.Custom.Pin != "" {
-				pin = luks.Clevis.Custom.Pin
-				config = luks.Clevis.Custom.Config
+			if util.NotEmpty(luks.Clevis.Custom.Pin) {
+				pin = *luks.Clevis.Custom.Pin
+				config = *luks.Clevis.Custom.Config
 			} else {
 				// if the override pin is empty the config must also be empty
 				pin = "sss"

--- a/internal/exec/stages/disks/raid.go
+++ b/internal/exec/stages/disks/raid.go
@@ -56,7 +56,7 @@ func (s stage) createRaids(config types.Config) error {
 			"--force",
 			"--run",
 			"--homehost", "any",
-			"--level", md.Level,
+			"--level", *md.Level,
 			"--raid-devices", fmt.Sprintf("%d", len(md.Devices)-*md.Spares),
 		}
 

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -260,7 +260,7 @@ func (tmp linkEntry) create(l *log.Logger, u util.Util) error {
 		return fmt.Errorf("stat() failed on %s: %v", s.Path, err)
 	case hard:
 		// check that the file at that path points to the same inode as target
-		targetPath, err := u.JoinPath(s.Target)
+		targetPath, err := u.JoinPath(*s.Target)
 		if err != nil {
 			return fmt.Errorf("error resolving target path of hard link %s: %v", s.Path, err)
 		}
@@ -271,17 +271,17 @@ func (tmp linkEntry) create(l *log.Logger, u util.Util) error {
 		if !os.SameFile(st, targetst) {
 			return fmt.Errorf("error creating hard link %s: a file already exists at that path but is not the target and overwrite is false", s.Path)
 		}
-		l.Info("Hardlink %s to %s already exists, doing nothing", s.Path, s.Target)
+		l.Info("Hardlink %s to %s already exists, doing nothing", s.Path, *s.Target)
 		return nil
 	case !hard:
 		// if the existing file is a symlink, check that its target is correct
 		if st.Mode()&os.ModeSymlink != 0 {
 			if target, err := os.Readlink(s.Path); err != nil {
 				return fmt.Errorf("error reading link at %s: %v", s.Path, err)
-			} else if filepath.Clean(target) != filepath.Clean(s.Target) {
-				return fmt.Errorf("error creating symlink %s: a symlink exists at that path but points to %s, not %s and overwrite is false", s.Path, target, s.Target)
+			} else if filepath.Clean(target) != filepath.Clean(*s.Target) {
+				return fmt.Errorf("error creating symlink %s: a symlink exists at that path but points to %s, not %s and overwrite is false", s.Path, target, *s.Target)
 			} else {
-				l.Info("Symlink %s to %s already exists, doing nothing", s.Path, s.Target)
+				l.Info("Symlink %s to %s already exists, doing nothing", s.Path, *s.Target)
 				return nil
 			}
 		}
@@ -291,7 +291,7 @@ func (tmp linkEntry) create(l *log.Logger, u util.Util) error {
 	if err := l.LogOp(
 		func() error {
 			return u.WriteLink(s)
-		}, "writing link %q -> %q", s.Path, s.Target,
+		}, "writing link %q -> %q", s.Path, *s.Target,
 	); err != nil {
 		return fmt.Errorf("failed to create link %q: %v", s.Path, err)
 	}

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -63,7 +63,7 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 		}
 		uuid := strings.TrimSpace(string(out))
 		netdev := ""
-		if len(luks.Clevis.Tang) > 0 || luks.Clevis.Custom.Pin != "" && cutil.IsTrue(luks.Clevis.Custom.NeedsNetwork) {
+		if len(luks.Clevis.Tang) > 0 || cutil.NotEmpty(luks.Clevis.Custom.Pin) && cutil.IsTrue(luks.Clevis.Custom.NeedsNetwork) {
 			netdev = ",_netdev"
 		}
 		keyfile := "none"

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -133,14 +133,14 @@ func (u Util) WriteLink(s types.Link) error {
 	}
 
 	if cutil.IsTrue(s.Hard) {
-		targetPath, err := u.JoinPath(s.Target)
+		targetPath, err := u.JoinPath(*s.Target)
 		if err != nil {
 			return err
 		}
 		return os.Link(targetPath, path)
 	}
 
-	if err := os.Symlink(s.Target, path); err != nil {
+	if err := os.Symlink(*s.Target, path); err != nil {
 		return fmt.Errorf("Could not create symlink: %v", err)
 	}
 

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	cutil "github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
 	"github.com/coreos/ignition/v2/internal/distro"
 
@@ -187,7 +188,7 @@ func (ut Util) EnableRuntimeUnit(unit types.Unit, target string) error {
 			Path: nodePath,
 		},
 		LinkEmbedded1: types.LinkEmbedded1{
-			Target: targetPath,
+			Target: cutil.StrToPtr(targetPath),
 		},
 	}
 


### PR DESCRIPTION
Primitive fields other than keys should be pointers, so they can be overridden by child configs during config merging.

Fixes the first half of #1132, and thus fixes #1132.