### PR TITLE
docs: Add Ignition release / Spec version table

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -167,7 +167,7 @@ Finally, update docs.
 - In `docs/configuration-vX_Y.md`, drop `-experimental` from the version number in the heading and the `ignition.version` field, and drop the prerelease warning. Update the `nav_order` field in the Jekyll front matter to be one less than the `nav_order` of the previous stable spec.
 - In `docs/configuration-vX_(Y+1)_experimental.md`, update the version of the experimental spec in the heading and the `ignition.version` field.
 - Add a section to `docs/migrating-configs.md`.
-- In `docs/specs.md`, update the list of stable and experimental spec versions, listing the latest stable release first.
+- In `docs/specs.md`, update the list of stable and experimental spec versions (listing the latest stable release first) and update the table listing the Ignition release where a spec has been marked as stable.
 
 ### External Tests
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -40,3 +40,16 @@ Documentation for the spec 1 and 2.x configuration specifications is available
 in the legacy [`spec2x` branch](https://github.com/coreos/ignition/tree/spec2x/doc)
 of Ignition. Those specification versions are used by older versions of RHEL
 CoreOS and Flatcar Container Linux. This branch is no longer maintained.
+
+## Specification versions and Ignition releases
+
+This table lists, for each stable specification version, the first released
+version of Ignition that supports it. To get all bug fixes, it is usually
+recommended to use the latest Ignition release.
+
+| Spec version | Ignition release |
+|--------------|------------------|
+| 3.0.0        | 2.0.0            |
+| 3.1.0        | 2.3.0            |
+| 3.2.0        | 2.7.0            |
+| 3.3.0        | 2.11.0           |


### PR DESCRIPTION
This helps to find which Ignition release first introduced support for a
given stable Ignition spec version.