### PR TITLE
config/*: return report from previous parser when chaining

### DIFF
--- a/config/v3_0/config_test.go
+++ b/config/v3_0/config_test.go
@@ -99,6 +99,10 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.0.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	testsCompt := []struct {
@@ -129,11 +133,18 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.0.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 	for i, test := range tests {
 		config, report, err := Parse(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
+		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}
@@ -141,6 +152,9 @@ func TestParse(t *testing.T) {
 		config, report, err := ParseCompatibleVersion(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
+		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}

--- a/config/v3_1/config_test.go
+++ b/config/v3_1/config_test.go
@@ -119,6 +119,10 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.1.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	testsCompt := []struct {
@@ -149,6 +153,14 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.0.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.1.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	for i, test := range tests {
@@ -156,12 +168,18 @@ func TestParse(t *testing.T) {
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
+		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}
 	for i, test := range testsCompt {
 		config, report, err := ParseCompatibleVersion(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
+		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}

--- a/config/v3_2/config.go
+++ b/config/v3_2/config.go
@@ -72,7 +72,7 @@ func ParseCompatibleVersion(raw []byte) (types.Config, report.Report, error) {
 	}
 	prevCfg, r, err := prev.ParseCompatibleVersion(raw)
 	if err != nil {
-		return types.Config{}, report.Report{}, err
+		return types.Config{}, r, err
 	}
 	return translate.Translate(prevCfg), r, nil
 }

--- a/config/v3_2/config_test.go
+++ b/config/v3_2/config_test.go
@@ -127,6 +127,10 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.2.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	testsCompt := []struct {
@@ -157,6 +161,14 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.0.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.2.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	for i, test := range tests {
@@ -164,12 +176,18 @@ func TestParse(t *testing.T) {
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
+		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}
 	for i, test := range testsCompt {
 		config, report, err := ParseCompatibleVersion(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
+		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}

--- a/config/v3_3/config.go
+++ b/config/v3_3/config.go
@@ -72,7 +72,7 @@ func ParseCompatibleVersion(raw []byte) (types.Config, report.Report, error) {
 	}
 	prevCfg, r, err := prev.ParseCompatibleVersion(raw)
 	if err != nil {
-		return types.Config{}, report.Report{}, err
+		return types.Config{}, r, err
 	}
 	return translate.Translate(prevCfg), r, nil
 }

--- a/config/v3_3/config_test.go
+++ b/config/v3_3/config_test.go
@@ -135,6 +135,10 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.3.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	testsCompt := []struct {
@@ -165,6 +169,14 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.0.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.3.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	for i, test := range tests {
@@ -172,12 +184,18 @@ func TestParse(t *testing.T) {
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
+		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}
 	for i, test := range testsCompt {
 		config, report, err := ParseCompatibleVersion(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
+		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}

--- a/config/v3_4_experimental/config.go
+++ b/config/v3_4_experimental/config.go
@@ -72,7 +72,7 @@ func ParseCompatibleVersion(raw []byte) (types.Config, report.Report, error) {
 	}
 	prevCfg, r, err := prev.ParseCompatibleVersion(raw)
 	if err != nil {
-		return types.Config{}, report.Report{}, err
+		return types.Config{}, r, err
 	}
 	return translate.Translate(prevCfg), r, nil
 }

--- a/config/v3_4_experimental/config_test.go
+++ b/config/v3_4_experimental/config_test.go
@@ -139,6 +139,10 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.4.0-experimental"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	testsCompt := []struct {
@@ -173,6 +177,14 @@ func TestParse(t *testing.T) {
 			in:  in{config: []byte{}},
 			out: out{err: errors.ErrEmpty},
 		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.0.0"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
+		{
+			in:  in{config: []byte(`{"ignition": {"version": "3.4.0-experimental"}, "storage": {"filesystems": [{"format": "ext4", "label": "zzzzzzzzzzzzzzzzzzzzzzzzzzz"}]}}`)},
+			out: out{err: errors.ErrInvalid},
+		},
 	}
 
 	for i, test := range tests {
@@ -180,12 +192,18 @@ func TestParse(t *testing.T) {
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
 		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
+		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}
 	for i, test := range testsCompt {
 		config, report, err := ParseCompatibleVersion(test.in.config)
 		if test.out.err != err {
 			t.Errorf("#%d: bad error: want %v, got %v, report: %+v", i, test.out.err, err, report)
+		}
+		if test.out.err == errors.ErrInvalid && len(report.Entries) == 0 {
+			t.Errorf("#%d: expected report, got none", i)
 		}
 		assert.Equal(t, test.out.config, config, "#%d: bad config, report: %+v", i, report)
 	}


### PR DESCRIPTION
When we chain into the previous parser and it fails, return its report rather than an empty one.  3.1 was doing this correctly and 3.0 doesn't have this code, but newer specs were affected.

Add tests checking that both parse functions return a report on invalid configs.

Fixes #1193.