### PR TITLE
tools/docs: notice invalid configs with stable specs

### DIFF
--- a/docs/migrating-configs.md
+++ b/docs/migrating-configs.md
@@ -26,7 +26,7 @@ The config gained a new top-level `kernelArguments` section. It allows specifyin
 {
   "ignition": { "version": "3.3.0" },
   "kernelArguments": {
-    "shouldExit": [
+    "shouldExist": [
       "foobar",
       "baz boo"
     ],
@@ -123,7 +123,7 @@ Ignition now supports creating LUKS2 encrypted storage volumes. Volumes can be c
       "path": "/var/lib/static_key_example",
       "device": "/dev/disk/by-id/dm-name-static-key-example",
       "format": "ext4",
-      "label": "STATIC-KEY-EXAMPLE"
+      "label": "STATIC-EXAMPLE"
     },{
       "path": "/var/lib/tpm_example",
       "device": "/dev/disk/by-id/dm-name-tpm-example",
@@ -140,7 +140,7 @@ Ignition now supports creating LUKS2 encrypted storage volumes. Volumes can be c
     "units": [{
       "name": "var-lib-static_key_example.mount",
       "enabled": true,
-      "contents": "[Mount]\nWhat=/dev/disk/by-label/STATIC-KEY-EXAMPLE\nWhere=/var/lib/static_key_example\nType=ext4\n\n[Install]\nWantedBy=local-fs.target"
+      "contents": "[Mount]\nWhat=/dev/disk/by-label/STATIC-EXAMPLE\nWhere=/var/lib/static_key_example\nType=ext4\n\n[Install]\nWantedBy=local-fs.target"
     },{
       "name": "var-lib-tpm_example.mount",
       "enabled": true,

--- a/internal/util/tools/docs/docs.go
+++ b/internal/util/tools/docs/docs.go
@@ -88,10 +88,11 @@ func main() {
 		}
 
 		for _, json := range jsonSections {
-			_, r, _ := config.Parse([]byte(strings.Join(json, "\n")))
+			cfg := strings.Join(json, "\n")
+			_, r, _ := config.Parse([]byte(cfg))
 			reportStr := r.String()
 			if reportStr != "" {
-				return fmt.Errorf("non-empty parsing report in %s: %s\nConfig:\n%s", info.Name(), reportStr, json)
+				return fmt.Errorf("non-empty parsing report in %s: %s\nConfig:\n%s", info.Name(), reportStr, cfg)
 			}
 		}
 

--- a/internal/util/tools/docs/docs.go
+++ b/internal/util/tools/docs/docs.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	config "github.com/coreos/ignition/v2/config/v3_4_experimental"
+	"github.com/coreos/ignition/v2/config"
 )
 
 // Specific section marker used in the docs to indicate that the Markdown code
@@ -89,10 +89,15 @@ func main() {
 
 		for _, json := range jsonSections {
 			cfg := strings.Join(json, "\n")
-			_, r, _ := config.Parse([]byte(cfg))
+			_, r, err := config.Parse([]byte(cfg))
+			// the report provides a more specific error
+			// description, so check that first
 			reportStr := r.String()
 			if reportStr != "" {
 				return fmt.Errorf("non-empty parsing report in %s: %s\nConfig:\n%s", info.Name(), reportStr, cfg)
+			}
+			if err != nil {
+				return fmt.Errorf("fatal error parsing %s: %s\nConfig:\n%s", info.Name(), err, cfg)
 			}
 		}
 


### PR DESCRIPTION
In Ignition 2.x, the `Parse()` function from an individual config package doesn't chain to earlier specs, but this code still assumed it does.  As a result, all configs with stable spec versions would fail on `ErrUnknownVersion`, but we wouldn't notice because we were only looking at the report and not the error return.

Switch to the high-level chaining parse function.  Also, check for parse errors that aren't included in the report.

