### PR TITLE
templates: update example releng signing ticket

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -32,7 +32,7 @@ Packaging:
 
 GitHub release:
  - [ ] Wait until the Bodhi update shows "Signed :heavy_check_mark:" in the Metadata box.
- - [ ] [File a releng ticket](https://pagure.io/releng/new_issue) based on [prior signing tickets](https://pagure.io/releng/issue/10099).
+ - [ ] [File a releng ticket](https://pagure.io/releng/new_issue) based on [prior signing tickets](https://pagure.io/releng/issue/10178).
    - [ ] Update the script and test it locally by dropping the `sigul` lines.
      - [ ] If a new Fedora release has gone stable, update the signing key in the script to use the new Fedora signing key [found here](https://getfedora.org/security).
  - [ ] Ping `mboddu` in Libera.Chat `#fedora-coreos`, linking to the ticket


### PR DESCRIPTION
The new ticket includes a couple bugfixes in the script and sample output, ported from the corresponding Butane tickets.