### PR TITLE
exec: fix permissions for mountpoints in home dirs

### DIFF
--- a/internal/exec/stages/files/passwd.go
+++ b/internal/exec/stages/files/passwd.go
@@ -117,6 +117,11 @@ func (s stage) ensureUsers(config types.Config) error {
 			continue
 		}
 
+		if err := s.ModifyHomeDirPermissions(u); err != nil {
+			return fmt.Errorf("failed to modify home directory permissions for %q: %v",
+				u.Name, err)
+		}
+
 		if err := s.SetPasswordHash(u); err != nil {
 			return fmt.Errorf("failed to set password for %q: %v",
 				u.Name, err)

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -150,8 +150,8 @@ func (s stage) mountFs(fs types.Filesystem) error {
 
 	if distro.SelinuxRelabel() {
 		// relabel the root of the disk if it's fresh
-		if isEmpty, err := util.DirIsEmpty(path); err != nil {
-			return fmt.Errorf("Checking if directory %s is empty: %v", path, err)
+		if isEmpty, err := util.FilesystemIsEmpty(path); err != nil {
+			return fmt.Errorf("Checking if mountpoint %s is empty: %v", path, err)
 		} else if isEmpty {
 			if err := s.RelabelFiles([]string{path}); err != nil {
 				return err

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -109,7 +109,8 @@ func (s stage) mountFs(fs types.Filesystem) error {
 
 	// mount paths shouldn't include symlinks or other non-directories so we can use filepath.Join()
 	// instead of s.JoinPath(). Check that the resulting path is composed of only directories.
-	path := filepath.Join(s.DestDir, *fs.Path)
+	relpath := *fs.Path
+	path := filepath.Join(s.DestDir, relpath)
 	if err := checkForNonDirectories(path); err != nil {
 		return err
 	}
@@ -124,7 +125,9 @@ func (s stage) mountFs(fs types.Filesystem) error {
 	}
 
 	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0755); err != nil {
+		// Record created directories for use by the files stage.
+		// NotateMkdirAll() is relative to the DestDir.
+		if err := s.NotateMkdirAll(relpath, 0755); err != nil {
 			return err
 		}
 	} else if err != nil {

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -267,20 +267,31 @@ func FindFirstMissingDirForFile(path string) (string, error) {
 	}
 }
 
-// DirIsEmpty checks whether a directory is empty.
+// FilesystemIsEmpty checks the mountpoint of a filesystem to see whether
+// the filesystem is empty.
 // Adapted from https://stackoverflow.com/a/30708914
-func DirIsEmpty(dirpath string) (bool, error) {
+func FilesystemIsEmpty(dirpath string) (bool, error) {
 	dfd, err := os.Open(dirpath)
 	if err != nil {
 		return false, err
 	}
 	defer dfd.Close()
 
-	_, err = dfd.Readdirnames(1)
-	if err == io.EOF {
-		return true, nil
+	for {
+		names, err := dfd.Readdirnames(1)
+		if err == io.EOF {
+			return true, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		switch names[0] {
+		case "lost+found":
+			// valid in a fresh filesystem; keep reading
+		default:
+			return false, nil
+		}
 	}
-	return false, err
 }
 
 // getFileOwner will return the uid and gid for the file at a given path. If the

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -31,6 +31,11 @@ type State struct {
 	// from state afterward to avoid leaking the keys into the running
 	// system.
 	LuksPersistKeyFiles map[string]string `json:"luksPersistKeyFiles"`
+	// List of directories created by NotateMkdirAll(), relative to
+	// the configured root dir.  Currently used to record directories
+	// created by the mount stage so the files stage can chown them
+	// when creating users.
+	NotatedDirectories []string `json:"notatedDirectories"`
 }
 
 type FetchedConfig struct {

--- a/tests/positive/files/directory.go
+++ b/tests/positive/files/directory.go
@@ -15,8 +15,6 @@
 package files
 
 import (
-	"os"
-
 	"github.com/coreos/ignition/v2/tests/register"
 	"github.com/coreos/ignition/v2/tests/types"
 )
@@ -139,7 +137,7 @@ func DirCreationOverNonemptyDir() types.Test {
 				Directory: "foo",
 				Name:      "bar",
 			},
-			Mode: 0777 | int(os.ModeDir),
+			Mode: 0777,
 		},
 	})
 	configMinVersion := "3.0.0"
@@ -229,14 +227,14 @@ func CheckOrdering() types.Test {
 				Directory: "/",
 				Name:      "baz",
 			},
-			Mode: 0777 | int(os.ModeDir),
+			Mode: 0777,
 		},
 		{
 			Node: types.Node{
 				Directory: "baz",
 				Name:      "quux",
 			},
-			Mode: 0755 | int(os.ModeDir),
+			Mode: 0755,
 		},
 	})
 	configMinVersion := "3.0.0"
@@ -268,7 +266,7 @@ func ApplyDefaultDirectoryPermissions() types.Test {
 				Name:      "bar",
 				Directory: "foo",
 			},
-			Mode: 0755 | int(os.ModeDir),
+			Mode: 0755,
 		},
 	})
 	configMinVersion := "3.0.0"

--- a/tests/positive/passwd/users.go
+++ b/tests/positive/passwd/users.go
@@ -24,6 +24,7 @@ func init() {
 	register.Register(register.PositiveTest, DeletePasswdUsers())
 	register.Register(register.PositiveTest, DeleteGroups())
 	register.Register(register.PositiveTest, UseAuthorizedKeysFile())
+	register.Register(register.PositiveTest, AddPasswdUserWithMountPoints())
 }
 
 func AddPasswdUsers() types.Test {
@@ -406,6 +407,222 @@ func UseAuthorizedKeysFile() types.Test {
 		Name:             name,
 		In:               in,
 		Out:              out,
+		Env:              env,
+		Config:           config,
+		ConfigMinVersion: configMinVersion,
+	}
+}
+
+func AddPasswdUserWithMountPoints() types.Test {
+	name := "users.add.mountpoint"
+	in := types.GetBaseDisk()
+	out := types.GetBaseDisk()
+	env := []string{"IGNITION_WRITE_AUTHORIZED_KEYS_FRAGMENT=true"}
+	mntDevices := []types.MntDevice{
+		{
+			Label:        "OEM",
+			Substitution: "$DEVICE",
+		},
+	}
+	config := `{
+		"ignition": {
+			"version": "$version"
+		},
+		"storage": {
+			"filesystems": [
+				{
+					"path": "/home/test/.ssh/foo/bar",
+					"device": "$DEVICE",
+					"format": "ext4"
+				}
+			],
+			"directories": [
+				{
+					"path": "/home/test/.ssh",
+					"mode": 488
+				}
+			]
+		},
+		"passwd": {
+			"users": [
+				{
+					"name": "test",
+					"sshAuthorizedKeys": [
+						"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBRZPFJNOvQRfokigTtl0IBi71LHZrFOk4EJ3Zowtk/bX5uIVai0Cd4+hqlocYL10idgtFBH28skeKfsmHwgS9XwOvP+g+kqAl7yCz8JEzIUzl1fxNZDToi0jA3B5MwXkpt+IWfnabwi2cRZhlzrz9rO+eExu5s3NfaRmmmCYrjCJIRPKSCrW8U0n9fVSbX4PDdMXVmH7r+t8MtR8523vCbakFR/Y0YIqkPVdfuUXHh9rDCdH4B7mt7nYX2LWQXGUvmI13mgQoy04ifkaR3ImuOMp3Y1J1gm6clO74IMCq/sK9+XJhbxMPPHUoUJ2EwbaG7Dbh3iqz47e9oVki4gIH stephenlowrie@localhost.localdomain"
+					]
+				}
+			]
+		}
+	}`
+	configMinVersion := "3.0.0"
+	in[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
+	in[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "passwd",
+				Directory: "etc",
+			},
+			Contents: "root:x:0:0:root:/root:/bin/bash\ncore:x:500:500:CoreOS Admin:/home/core:/bin/bash\nsystemd-coredump:x:998:998:systemd Core Dumper:/:/sbin/nologin\nfleet:x:253:253::/:/sbin/nologin\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "shadow",
+				Directory: "etc",
+			},
+			Contents: "root:*:15887:0:::::\ncore:*:15887:0:::::\nsystemd-coredump:!!:17301::::::\nfleet:!!:17301::::::\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "group",
+				Directory: "etc",
+			},
+			Contents: "root:x:0:root\nwheel:x:10:root,core\nsudo:x:150:\ndocker:x:233:core\nsystemd-coredump:x:998:\nfleet:x:253:core\ncore:x:500:\nrkt-admin:x:999:\nrkt:x:251:core\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "gshadow",
+				Directory: "etc",
+			},
+			Contents: "root:*::root\nusers:*::\nsudo:*::\nwheel:*::root,core\nsudo:*::\ndocker:*::core\nsystemd-coredump:!!::\nfleet:!!::core\nrkt-admin:!!::\nrkt:!!::core\ncore:*::\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "nsswitch.conf",
+				Directory: "etc",
+			},
+			Contents: "# /etc/nsswitch.conf:\n\npasswd:      files\nshadow:      files\ngroup:       files\n\nhosts:       files dns myhostname\nnetworks:    files dns\n\nservices:    files\nprotocols:   files\nrpc:         files\n\nethers:      files\nnetmasks:    files\nnetgroup:    files\nbootparams:  files\nautomount:   files\naliases:     files\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "login.defs",
+				Directory: "etc",
+			},
+			Contents: `MAIL_DIR	/var/spool/mail
+PASS_MAX_DAYS	99999
+PASS_MIN_DAYS	0
+PASS_MIN_LEN	5
+PASS_WARN_AGE	7
+UID_MIN                  1000
+UID_MAX                 60000
+SYS_UID_MIN               201
+SYS_UID_MAX               999
+GID_MIN                  1000
+GID_MAX                 60000
+SYS_GID_MIN               201
+SYS_GID_MAX               999
+CREATE_HOME	yes
+UMASK           077
+USERGROUPS_ENAB yes
+ENCRYPT_METHOD SHA512
+`,
+		},
+	})
+	out[0].Partitions.GetPartition("OEM").FilesystemType = "ext4"
+	out[0].Partitions.AddFiles("ROOT", []types.File{
+		{
+			Node: types.Node{
+				Name:      "passwd",
+				Directory: "etc",
+			},
+			Contents: "root:x:0:0:root:/root:/bin/bash\ncore:x:500:500:CoreOS Admin:/home/core:/bin/bash\nsystemd-coredump:x:998:998:systemd Core Dumper:/:/sbin/nologin\nfleet:x:253:253::/:/sbin/nologin\ntest:x:1000:1000::/home/test:/bin/bash\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "group",
+				Directory: "etc",
+			},
+			Contents: "root:x:0:root\nwheel:x:10:root,core\nsudo:x:150:\ndocker:x:233:core\nsystemd-coredump:x:998:\nfleet:x:253:core\ncore:x:500:\nrkt-admin:x:999:\nrkt:x:251:core\ntest:x:1000:\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "shadow",
+				Directory: "etc",
+			},
+			Contents: "root:*:15887:0:::::\ncore:*:15887:0:::::\nsystemd-coredump:!!:17301::::::\nfleet:!!:17301::::::\ntest:*:17331:0:99999:7:::\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "gshadow",
+				Directory: "etc",
+			},
+			Contents: "root:*::root\nusers:*::\nsudo:*::\nwheel:*::root,core\nsudo:*::\ndocker:*::core\nsystemd-coredump:!!::\nfleet:!!::core\nrkt-admin:!!::\nrkt:!!::core\ncore:*::\ntest:!::\n",
+		},
+		{
+			Node: types.Node{
+				Name:      "ignition",
+				Directory: "home/test/.ssh/authorized_keys.d",
+				User:      1000,
+				Group:     1000,
+			},
+			Contents: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBRZPFJNOvQRfokigTtl0IBi71LHZrFOk4EJ3Zowtk/bX5uIVai0Cd4+hqlocYL10idgtFBH28skeKfsmHwgS9XwOvP+g+kqAl7yCz8JEzIUzl1fxNZDToi0jA3B5MwXkpt+IWfnabwi2cRZhlzrz9rO+eExu5s3NfaRmmmCYrjCJIRPKSCrW8U0n9fVSbX4PDdMXVmH7r+t8MtR8523vCbakFR/Y0YIqkPVdfuUXHh9rDCdH4B7mt7nYX2LWQXGUvmI13mgQoy04ifkaR3ImuOMp3Y1J1gm6clO74IMCq/sK9+XJhbxMPPHUoUJ2EwbaG7Dbh3iqz47e9oVki4gIH stephenlowrie@localhost.localdomain\n",
+		},
+	})
+	out[0].Partitions.AddDirectories("ROOT", []types.Directory{
+		{
+			Node: types.Node{
+				Name:      "home",
+				Directory: "",
+				User:      0,
+				Group:     0,
+			},
+			Mode: 0755,
+		},
+		{
+			Node: types.Node{
+				Name:      "test",
+				Directory: "home",
+				User:      1000,
+				Group:     1000,
+			},
+			Mode: 0700,
+		},
+		{
+			Node: types.Node{
+				Name:      ".ssh",
+				Directory: "home/test",
+				User:      1000,
+				Group:     1000,
+			},
+			// explicitly overridden via storage.directories
+			Mode: 0750,
+		},
+		{
+			Node: types.Node{
+				Name:      "foo",
+				Directory: "home/test/.ssh",
+				User:      1000,
+				Group:     1000,
+			},
+			Mode: 0700,
+		},
+		// the mountpoint itself, not the mounted filesystem
+		{
+			Node: types.Node{
+				Name:      "bar",
+				Directory: "home/test/.ssh/foo",
+				User:      0,
+				Group:     0,
+			},
+			Mode: 0755,
+		},
+	})
+	out[0].Partitions.AddDirectories("OEM", []types.Directory{
+		{
+			Node: types.Node{
+				Name:      "",
+				Directory: "",
+				User:      1000,
+				Group:     1000,
+			},
+			Mode: 0700,
+		},
+	})
+
+	return types.Test{
+		Name:             name,
+		In:               in,
+		Out:              out,
+		MntDevices:       mntDevices,
 		Env:              env,
 		Config:           config,
 		ConfigMinVersion: configMinVersion,

--- a/tests/validator.go
+++ b/tests/validator.go
@@ -298,8 +298,9 @@ func validateMode(t *testing.T, path string, mode int) {
 			return
 		}
 
-		if fileInfo.Mode() != os.FileMode(mode) {
-			t.Error("Node Mode does not match", path, os.FileMode(mode), fileInfo.Mode())
+		found := fileInfo.Mode() & ^os.ModeType
+		if found != os.FileMode(mode) {
+			t.Error("Node Mode does not match", path, os.FileMode(mode), found)
 		}
 	}
 }


### PR DESCRIPTION
If Ignition creates a directory within a user's home directory as a result of creating a mountpoint, fix its permissions once the user exists.

Also fix SELinux labeling of a freshly-created ext4 filesystem.

Fixes #1220.