### PR TITLE
Add support for Azure gen2 VMs

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -23,7 +23,6 @@ import (
 // -X github.com/coreos/ignition/v2/internal/distro.mdadmCmd=/opt/bin/mdadm
 var (
 	// Device node directories and paths
-	diskByIDDir       = "/dev/disk/by-id"
 	diskByLabelDir    = "/dev/disk/by-label"
 	diskByPartUUIDDir = "/dev/disk/by-partuuid"
 
@@ -78,7 +77,6 @@ var (
 	luksRealRootKeyFilePath  = "/etc/luks/"
 )
 
-func DiskByIDDir() string       { return diskByIDDir }
 func DiskByLabelDir() string    { return diskByLabelDir }
 func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
 

--- a/internal/exec/util/blkid.h
+++ b/internal/exec/util/blkid.h
@@ -27,10 +27,12 @@ typedef enum {
 	RESULT_NO_PARTITION_TABLE,
 	RESULT_BAD_INDEX,
 	RESULT_GET_PARTLIST_FAILED,
+	RESULT_GET_CACHE_FAILED,
 	RESULT_DISK_HAS_NO_TYPE,
 	RESULT_DISK_NOT_GPT,
 	RESULT_BAD_PARAMS,
 	RESULT_OVERFLOW,
+	RESULT_MAX_BLOCK_DEVICES,
 	RESULT_NO_TOPO,
 	RESULT_NO_SECTOR_SIZE,
 	RESULT_BAD_SECTOR_SIZE,
@@ -48,6 +50,14 @@ struct partition_info {
 	int number;
 };
 
+#define MAX_BLOCK_DEVICES 10
+#define MAX_BLOCK_DEVICE_PATH_LEN 50
+
+struct block_device_list {
+	char path[MAX_BLOCK_DEVICES][MAX_BLOCK_DEVICE_PATH_LEN];
+	int count;
+};
+
 result_t blkid_lookup(const char *device, bool allow_ambivalent, const char *field_name, char buf[], size_t buf_len);
 
 result_t blkid_get_num_partitions(const char *device, int *ret);
@@ -57,5 +67,6 @@ result_t blkid_get_logical_sector_size(const char *device, int *ret_sector_size)
 // WARNING part_num may not be what you expect. see the .c file's comment for why
 result_t blkid_get_partition(const char *device, int part_num, struct partition_info *info);
 
-#endif // _BLKID_H_
+result_t blkid_get_block_devices(const char *fstype, struct block_device_list *device);
 
+#endif // _BLKID_H_

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
-	"github.com/coreos/ignition/v2/internal/distro"
 	execUtil "github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/providers/util"
@@ -35,8 +34,7 @@ import (
 )
 
 const (
-	configDeviceID = "ata-Virtual_CD"
-	configPath     = "/CustomData.bin"
+	configPath = "/CustomData.bin"
 )
 
 // These constants come from <cdrom.h>.
@@ -66,29 +64,51 @@ func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 // FetchFromOvfDevice has the return signature of platform.NewFetcher. It is
 // wrapped by this and AzureStack packages.
 func FetchFromOvfDevice(f *resource.Fetcher, ovfFsTypes []string) (types.Config, report.Report, error) {
-	devicePath := filepath.Join(distro.DiskByIDDir(), configDeviceID)
-
 	logger := f.Logger
-	logger.Debug("waiting for config DVD...")
-	waitForCdrom(logger, devicePath)
-
-	fsType, err := checkOvfFsType(logger, devicePath, ovfFsTypes)
-	if err != nil {
-		return types.Config{}, report.Report{}, err
+	checkedDevices := make(map[string]struct{})
+	for {
+		for _, ovfFsType := range ovfFsTypes {
+			devices, err := execUtil.GetBlockDevices(ovfFsType)
+			if err != nil {
+				return types.Config{}, report.Report{}, fmt.Errorf("failed to retrieve block devices with FSTYPE=%q: %v", ovfFsType, err)
+			}
+			for _, dev := range devices {
+				_, checked := checkedDevices[dev]
+				// verify that this is a CD-ROM drive. This helps
+				// to avoid reading data from an arbitrary block
+				// device attached to the VM by the user.
+				if !checked && isCdromPresent(logger, dev) {
+					rawConfig, err := getRawConfig(f, dev, ovfFsType)
+					if err != nil {
+						logger.Debug("failed to retrieve config from device %q: %v", dev, err)
+					} else {
+						return util.ParseConfig(logger, rawConfig)
+					}
+				}
+				checkedDevices[dev] = struct{}{}
+			}
+		}
+		// wait for the actual config drive to appear
+		// if it's not shown up yet
+		time.Sleep(time.Second)
 	}
+}
 
+// getRawConfig returns the config by mounting the given block device
+func getRawConfig(f *resource.Fetcher, devicePath string, fstype string) ([]byte, error) {
+	logger := f.Logger
 	mnt, err := ioutil.TempDir("", "ignition-azure")
 	if err != nil {
-		return types.Config{}, report.Report{}, fmt.Errorf("failed to create temp directory: %v", err)
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
 	}
 	defer os.Remove(mnt)
 
 	logger.Debug("mounting config device")
 	if err := logger.LogOp(
-		func() error { return unix.Mount(devicePath, mnt, fsType, unix.MS_RDONLY, "") },
+		func() error { return unix.Mount(devicePath, mnt, fstype, unix.MS_RDONLY, "") },
 		"mounting %q at %q", devicePath, mnt,
 	); err != nil {
-		return types.Config{}, report.Report{}, fmt.Errorf("failed to mount device %q at %q: %v", devicePath, mnt, err)
+		return nil, fmt.Errorf("failed to mount device %q at %q: %v", devicePath, mnt, err)
 	}
 	defer func() {
 		_ = logger.LogOp(
@@ -97,23 +117,23 @@ func FetchFromOvfDevice(f *resource.Fetcher, ovfFsTypes []string) (types.Config,
 		)
 	}()
 
+	// detect the config drive by looking for a file which is always present
+	logger.Debug("checking for config drive")
+	if _, err := os.Stat(filepath.Join(mnt, "ovf-env.xml")); err != nil {
+		return nil, fmt.Errorf("device %q does not appear to be a config drive: %v", devicePath, err)
+	}
+
 	logger.Debug("reading config")
 	rawConfig, err := ioutil.ReadFile(filepath.Join(mnt, configPath))
 	if err != nil && !os.IsNotExist(err) {
-		return types.Config{}, report.Report{}, fmt.Errorf("failed to read config: %v", err)
+		return nil, fmt.Errorf("failed to read config from device %q: %v", devicePath, err)
 	}
-
-	return util.ParseConfig(logger, rawConfig)
+	return rawConfig, nil
 }
 
-func waitForCdrom(logger *log.Logger, devicePath string) {
-	for !isCdromPresent(logger, devicePath) {
-		time.Sleep(time.Second)
-	}
-}
-
+// isCdromPresent verifies if the given config drive is CD-ROM
 func isCdromPresent(logger *log.Logger, devicePath string) bool {
-	logger.Debug("opening config device")
+	logger.Debug("opening config device: %q", devicePath)
 	device, err := os.Open(devicePath)
 	if err != nil {
 		logger.Info("failed to open config device: %v", err)
@@ -121,7 +141,7 @@ func isCdromPresent(logger *log.Logger, devicePath string) bool {
 	}
 	defer device.Close()
 
-	logger.Debug("getting drive status")
+	logger.Debug("getting drive status for %q", devicePath)
 	status, _, errno := unix.Syscall(
 		unix.SYS_IOCTL,
 		uintptr(device.Fd()),
@@ -145,17 +165,4 @@ func isCdromPresent(logger *log.Logger, devicePath string) bool {
 	}
 
 	return (status == CDS_DISC_OK)
-}
-
-func checkOvfFsType(logger *log.Logger, devicePath string, fsTypes []string) (string, error) {
-	fs, err := execUtil.GetFilesystemInfo(devicePath, false)
-	if err != nil {
-		return fs.Type, fmt.Errorf("failed to detect filesystem on ovf device %q: %v", devicePath, err)
-	}
-	for _, f := range fsTypes {
-		if f == fs.Type {
-			return fs.Type, nil
-		}
-	}
-	return fs.Type, fmt.Errorf("filesystem %q is not a supported ovf device", fs.Type)
 }


### PR DESCRIPTION
Fixes #1194 

This patch adds support for Azure gen2 VMs in Ignition. For the safer side, this PR also handles a case where a bunch of block devices has the `FSTYPE` set to `udf`, and accordingly, pick the right device that has an ignition config.

With gen2 settings:
```
[    5.661976] systemd[1]: Finished Ignition (setup user config).
[    5.665860] systemd[1]: Starting Ignition (fetch-offline)...
[    5.672347] ignition[570]: Ignition v2.10.1-51-g3679fd11
[    5.676259] ignition[570]: Stage: fetch-offline
[    5.679908] ignition[570]: reading system config file "/usr/lib/ignition/base.d/00-core.ign"
[    5.684961] ignition[570]: reading system config file "/usr/lib/ignition/base.d/30-afterburn-sshkeys-core.ign"
[    5.690933] ignition[570]: reading system config file "/usr/lib/ignition/base.platform.d/azure/20-azure-nm-cloud-setup.ign"
[    5.697446] ignition[570]: no config URL provided
[    5.701096] ignition[570]: reading system config file "/usr/lib/ignition/user.ign"
[    5.706075] ignition[570]: no config at "/usr/lib/ignition/user.ign"
[    5.846085] ignition[575]: VM configured with gen2 settings
[    5.846251] ignition[570]: drive status: OK
[    5.856919] ignition[570]: op(1): [started]  mounting "/dev/sr0" at "/tmp/ignition-azure924173817"
[    5.875422] UDF-fs: INFO Mounting volume 'UDF Volume', timestamp 2021/07/01 00:00 (1000)
[    5.881968] ignition[570]: op(1): [finished] mounting "/dev/sr0" at "/tmp/ignition-azure924173817"
[    5.889419] systemd[1]: tmp-ignition\x2dazure924173817.mount: Deactivated successfully.
```