### PR TITLE
providers/gcp: access GCP metadata service by IP address

### DIFF
--- a/internal/providers/gcp/gcp.go
+++ b/internal/providers/gcp/gcp.go
@@ -31,7 +31,7 @@ import (
 var (
 	userdataUrl = url.URL{
 		Scheme: "http",
-		Host:   "metadata.google.internal",
+		Host:   "169.254.169.254",
 		Path:   "computeMetadata/v1/instance/attributes/user-data",
 	}
 	metadataHeaderKey = "Metadata-Flavor"


### PR DESCRIPTION
There have been two hostname poisoning attacks against `metadata.google.internal`.  As a precaution, access it by IP address
instead, since the IP is documented anyway.

Addresses https://github.com/coreos/fedora-coreos-tracker/issues/891.