### PR TITLE
engine: don't hardcode neednet path

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -145,7 +145,7 @@ func (e Engine) Run(stageName string) error {
 		tmp, jsonerr := json.MarshalIndent(fullConfig, "", "  ")
 		if jsonerr != nil {
 			// Nothing else to do with this error
-			fmt.Fprintf(os.Stderr, "Could not marshal full config: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Could not marshal full config: %v\n", jsonerr)
 		} else {
 			fmt.Fprintf(os.Stderr, "Full config:\n%s", string(tmp))
 		}

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -453,7 +453,7 @@ func SignalNeedNet() error {
 	return nil
 }
 
-func (e Engine) logReport(r report.Report) {
+func (e *Engine) logReport(r report.Report) {
 	for _, entry := range r.Entries {
 		switch entry.Kind {
 		case report.Error:

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -112,7 +112,7 @@ func (e Engine) Run(stageName string) error {
 	// configuring the S3RegionHint when running on AWS.
 	err = e.PlatformConfig.InitFunc()(e.Fetcher)
 	if err == resource.ErrNeedNet && stageName == "fetch-offline" {
-		err = SignalNeedNet()
+		err = signalNeedNet()
 		if err != nil {
 			e.Logger.Crit("failed to signal neednet: %v", err)
 		}
@@ -123,7 +123,7 @@ func (e Engine) Run(stageName string) error {
 
 	cfg, err := e.acquireConfig(stageName)
 	if err == resource.ErrNeedNet && stageName == "fetch-offline" {
-		err = SignalNeedNet()
+		err = signalNeedNet()
 		if err != nil {
 			e.Logger.Crit("failed to signal neednet: %v", err)
 		}
@@ -139,7 +139,15 @@ func (e Engine) Run(stageName string) error {
 	defer e.Logger.PopPrefix()
 
 	fullConfig := latest.Merge(baseConfig, latest.Merge(systemBaseConfig, cfg))
-	if err = stages.Get(stageName).Create(e.Logger, e.Root, *e.Fetcher).Run(fullConfig); err != nil {
+	err = stages.Get(stageName).Create(e.Logger, e.Root, *e.Fetcher).Run(fullConfig)
+	if err == resource.ErrNeedNet && stageName == "fetch-offline" {
+		err = signalNeedNet()
+		if err != nil {
+			e.Logger.Crit("failed to signal neednet: %v", err)
+		}
+		// fall through
+	}
+	if err != nil {
 		// e.Logger could be nil
 		fmt.Fprintf(os.Stderr, "%s failed\n", stageName)
 		tmp, jsonerr := json.MarshalIndent(fullConfig, "", "  ")
@@ -441,7 +449,7 @@ func (e *Engine) fetchReferencedConfig(cfgRef types.Resource) (types.Config, err
 	return cfg, nil
 }
 
-func SignalNeedNet() error {
+func signalNeedNet() error {
 	if err := executil.MkdirForFile(needNetPath); err != nil {
 		return err
 	}

--- a/internal/exec/stages/fetch_offline/fetch-offline.go
+++ b/internal/exec/stages/fetch_offline/fetch-offline.go
@@ -24,7 +24,6 @@ import (
 
 	cfgutil "github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
-	"github.com/coreos/ignition/v2/internal/exec"
 	"github.com/coreos/ignition/v2/internal/exec/stages"
 	executil "github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
@@ -67,7 +66,7 @@ func (s stage) Run(cfg types.Config) error {
 	if needsNet, err := configNeedsNet(&cfg); err != nil {
 		return err
 	} else if needsNet {
-		return exec.SignalNeedNet()
+		return resource.ErrNeedNet
 	}
 	return nil
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -39,6 +39,7 @@ func main() {
 		clearCache   bool
 		configCache  string
 		fetchTimeout time.Duration
+		needNet      string
 		platform     platform.Name
 		root         string
 		stage        stages.Name
@@ -49,6 +50,7 @@ func main() {
 	flag.BoolVar(&flags.clearCache, "clear-cache", false, "clear any cached config")
 	flag.StringVar(&flags.configCache, "config-cache", "/run/ignition.json", "where to cache the config")
 	flag.DurationVar(&flags.fetchTimeout, "fetch-timeout", exec.DefaultFetchTimeout, "initial duration for which to wait for config")
+	flag.StringVar(&flags.needNet, "neednet", "/run/ignition/neednet", "flag file to write from fetch-offline if networking is needed")
 	flag.Var(&flags.platform, "platform", fmt.Sprintf("current platform. %v", platform.Names()))
 	flag.StringVar(&flags.root, "root", "/", "root of the filesystem")
 	flag.Var(&flags.stage, "stage", fmt.Sprintf("execution stage. %v", stages.Names()))
@@ -94,6 +96,7 @@ func main() {
 		Root:           flags.root,
 		FetchTimeout:   flags.fetchTimeout,
 		Logger:         &logger,
+		NeedNet:        flags.needNet,
 		ConfigCache:    flags.configCache,
 		PlatformConfig: platformConfig,
 		Fetcher:        &fetcher,

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -153,7 +153,9 @@ func umountPartition(p *types.Partition) error {
 // returns true if no error, false if error
 func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, appendEnv []string) error {
 	args := []string{"-platform", "file", "-stage", stage,
-		"-root", root, "-log-to-stdout", "--config-cache", filepath.Join(cwd, "ignition.json")}
+		"-root", root, "-log-to-stdout",
+		"-config-cache", filepath.Join(cwd, "ignition.json"),
+		"-neednet", filepath.Join(cwd, "neednet")}
 	cmd := exec.CommandContext(ctx, "ignition", args...)
 	if cmd == nil {
 		return fmt.Errorf("exec.CommandContext() returned nil")


### PR DESCRIPTION
Traditionally we expose paths in `/run` as command-line options, which helps with testing.