### PR TITLE
Add persistence mechanism between stages; write result report to provisioned system

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -74,8 +74,7 @@ var (
 	// ".ssh/authorized_keys" ("false").
 	writeAuthorizedKeysFragment = "true"
 
-	luksInitramfsKeyFilePath = "/run/ignition/luks-keyfiles/"
-	luksRealRootKeyFilePath  = "/etc/luks/"
+	luksRealRootKeyFilePath = "/etc/luks/"
 )
 
 func DiskByIDDir() string       { return diskByIDDir }
@@ -113,8 +112,7 @@ func CryptsetupCmd() string { return cryptsetupCmd }
 
 func KargsCmd() string { return kargsCmd }
 
-func LuksInitramfsKeyFilePath() string { return luksInitramfsKeyFilePath }
-func LuksRealRootKeyFilePath() string  { return luksRealRootKeyFilePath }
+func LuksRealRootKeyFilePath() string { return luksRealRootKeyFilePath }
 
 func SelinuxRelabel() bool  { return bakedStringToBool(selinuxRelabel) && !BlackboxTesting() }
 func BlackboxTesting() bool { return bakedStringToBool(blackboxTesting) }

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -27,8 +27,9 @@ var (
 	diskByLabelDir    = "/dev/disk/by-label"
 	diskByPartUUIDDir = "/dev/disk/by-partuuid"
 
-	// File paths
+	// initrd file paths
 	kernelCmdlinePath = "/proc/cmdline"
+	bootIDPath        = "/proc/sys/kernel/random/boot_id"
 	// initramfs directory containing distro-provided base config
 	systemConfigDir = "/usr/lib/ignition"
 
@@ -74,7 +75,9 @@ var (
 	// ".ssh/authorized_keys" ("false").
 	writeAuthorizedKeysFragment = "true"
 
+	// Special file paths in the real root
 	luksRealRootKeyFilePath = "/etc/luks/"
+	resultFilePath          = "/var/lib/ignition/result.json"
 )
 
 func DiskByIDDir() string       { return diskByIDDir }
@@ -82,6 +85,7 @@ func DiskByLabelDir() string    { return diskByLabelDir }
 func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
 
 func KernelCmdlinePath() string { return kernelCmdlinePath }
+func BootIDPath() string        { return bootIDPath }
 func SystemConfigDir() string   { return fromEnv("SYSTEM_CONFIG_DIR", systemConfigDir) }
 
 func GroupaddCmd() string { return groupaddCmd }
@@ -113,6 +117,7 @@ func CryptsetupCmd() string { return cryptsetupCmd }
 func KargsCmd() string { return kargsCmd }
 
 func LuksRealRootKeyFilePath() string { return luksRealRootKeyFilePath }
+func ResultFilePath() string          { return resultFilePath }
 
 func SelinuxRelabel() bool  { return bakedStringToBool(selinuxRelabel) && !BlackboxTesting() }
 func BlackboxTesting() bool { return bakedStringToBool(blackboxTesting) }

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -40,6 +40,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/cmdline"
 	"github.com/coreos/ignition/v2/internal/providers/system"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 	"github.com/coreos/ignition/v2/internal/util"
 
 	"github.com/coreos/vcontext/report"
@@ -69,6 +70,7 @@ type Engine struct {
 	Root           string
 	PlatformConfig platform.Config
 	Fetcher        *resource.Fetcher
+	State          *state.State
 	fetchedConfigs []fetchedConfig
 }
 
@@ -138,7 +140,7 @@ func (e Engine) Run(stageName string) error {
 	defer e.Logger.PopPrefix()
 
 	fullConfig := latest.Merge(baseConfig, latest.Merge(systemBaseConfig, cfg))
-	err = stages.Get(stageName).Create(e.Logger, e.Root, *e.Fetcher).Run(fullConfig)
+	err = stages.Get(stageName).Create(e.Logger, e.Root, *e.Fetcher, e.State).Run(fullConfig)
 	if err == resource.ErrNeedNet && stageName == "fetch-offline" {
 		err = e.signalNeedNet()
 		if err != nil {

--- a/internal/exec/stages/disks/disks.go
+++ b/internal/exec/stages/disks/disks.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 	"github.com/coreos/ignition/v2/internal/systemd"
 )
 
@@ -41,12 +42,13 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, f resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: util.Util{
 			DestDir: root,
 			Logger:  logger,
 			Fetcher: f,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/stages/fetch/fetch.go
+++ b/internal/exec/stages/fetch/fetch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 )
 
 const (
@@ -36,11 +37,12 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: util.Util{
 			DestDir: root,
 			Logger:  logger,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/stages/fetch_offline/fetch-offline.go
+++ b/internal/exec/stages/fetch_offline/fetch-offline.go
@@ -28,6 +28,7 @@ import (
 	executil "github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 	"github.com/coreos/ignition/v2/internal/util"
 )
 
@@ -41,11 +42,12 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, _ resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: executil.Util{
 			DestDir: root,
 			Logger:  logger,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 )
 
 const (
@@ -41,12 +42,13 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, f resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: util.Util{
 			DestDir: root,
 			Logger:  logger,
 			Fetcher: f,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -87,6 +87,10 @@ func (s stage) Run(config types.Config) error {
 		return fmt.Errorf("creating crypttab entries: %v", err)
 	}
 
+	if err := s.createResultFile(); err != nil {
+		return fmt.Errorf("creating result file: %v", err)
+	}
+
 	if err := s.relabelFiles(); err != nil {
 		return fmt.Errorf("failed to handle relabeling: %v", err)
 	}

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -44,7 +44,6 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 	s.Logger.PushPrefix("createCrypttabEntries")
 	defer s.Logger.PopPrefix()
 
-	mode := 0600
 	path, err := s.JoinPath("/etc/crypttab")
 	if err != nil {
 		return fmt.Errorf("building crypttab filepath: %v", err)
@@ -54,7 +53,7 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 			Path: path,
 		},
 		types.FileEmbedded1{
-			Mode: &mode,
+			Mode: cutil.IntToPtr(0600),
 		},
 	}
 	extrafiles := []filesystemEntry{}
@@ -89,7 +88,7 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 					Contents: types.Resource{
 						Source: &contentsUri,
 					},
-					Mode: &mode,
+					Mode: cutil.IntToPtr(0600),
 				},
 			})
 		}
@@ -102,7 +101,6 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 	// already exist) to be mode 0700 rather than auto-creating it at the default directory
 	// permission
 	if len(extrafiles) > 0 {
-		dirMode := 0700
 		realpath, err := s.JoinPath(distro.LuksRealRootKeyFilePath())
 		if err != nil {
 			return fmt.Errorf("building keyfile dir path: %v", err)
@@ -117,7 +115,7 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 							Path: realpath,
 						},
 						types.DirectoryEmbedded1{
-							Mode: &dirMode,
+							Mode: cutil.IntToPtr(0700),
 						},
 					},
 				}, extrafiles...)

--- a/internal/exec/stages/kargs/kargs.go
+++ b/internal/exec/stages/kargs/kargs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 )
 
 const (
@@ -36,12 +37,13 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, f resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: util.Util{
 			DestDir: root,
 			Logger:  logger,
 			Fetcher: f,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 )
 
 const (
@@ -45,11 +46,12 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, f resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: util.Util{
 			DestDir: root,
 			Logger:  logger,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/stages/stages.go
+++ b/internal/exec/stages/stages.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/registry"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 )
 
 // Stage is responsible for actually executing a stage of the configuration.
@@ -30,7 +31,7 @@ type Stage interface {
 // StageCreator is responsible for instantiating a particular stage given a
 // logger and root path under the root partition.
 type StageCreator interface {
-	Create(logger *log.Logger, root string, f resource.Fetcher) Stage
+	Create(logger *log.Logger, root string, f resource.Fetcher, state *state.State) Stage
 	Name() string
 }
 

--- a/internal/exec/stages/umount/umount.go
+++ b/internal/exec/stages/umount/umount.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/exec/util"
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 
 	"golang.org/x/sys/unix"
 )
@@ -41,11 +42,12 @@ func init() {
 
 type creator struct{}
 
-func (creator) Create(logger *log.Logger, root string, f resource.Fetcher) stages.Stage {
+func (creator) Create(logger *log.Logger, root string, f resource.Fetcher, state *state.State) stages.Stage {
 	return &stage{
 		Util: util.Util{
 			DestDir: root,
 			Logger:  logger,
+			State:   state,
 		},
 	}
 }

--- a/internal/exec/util/util.go
+++ b/internal/exec/util/util.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/ignition/v2/internal/state"
 )
 
 // Util encapsulates logging and destdir indirection for the util methods.
@@ -27,6 +28,7 @@ type Util struct {
 	DestDir string // directory prefix to use in applying fs paths.
 	Fetcher resource.Fetcher
 	*log.Logger
+	State *state.State
 }
 
 // SplitPath splits /a/b/c/d into [a, b, c, d]

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,11 +23,20 @@ import (
 )
 
 type State struct {
+	// Information about configs fetched by the fetch stages.  Used
+	// when writing the result file in files stage.
+	FetchedConfigs []FetchedConfig `json:"fetchedConfigs"`
 	// Key files generated during LUKS setup in disks stage, which need
 	// to be written out during files stage.  files stage removes them
 	// from state afterward to avoid leaking the keys into the running
 	// system.
 	LuksPersistKeyFiles map[string]string `json:"luksPersistKeyFiles"`
+}
+
+type FetchedConfig struct {
+	Kind       string `json:"kind"`
+	Source     string `json:"source"`
+	Referenced bool   `json:"referenced"`
 }
 
 func Load(path string) (State, error) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,6 +23,11 @@ import (
 )
 
 type State struct {
+	// Key files generated during LUKS setup in disks stage, which need
+	// to be written out during files stage.  files stage removes them
+	// from state afterward to avoid leaking the keys into the running
+	// system.
+	LuksPersistKeyFiles map[string]string `json:"luksPersistKeyFiles"`
 }
 
 func Load(path string) (State, error) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,56 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type State struct {
+}
+
+func Load(path string) (State, error) {
+	data, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		// valid; return empty struct
+		return State{}, nil
+	} else if err != nil {
+		return State{}, fmt.Errorf("reading state file: %w", err)
+	}
+	var state State
+	if err = json.Unmarshal(data, &state); err != nil {
+		return State{}, fmt.Errorf("parsing state file: %w", err)
+	}
+	return state, nil
+}
+
+func (s *State) Save(path string) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("serializing state file: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating directory for state file: %w", err)
+	}
+	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
+	}
+	return nil
+}

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -155,7 +155,8 @@ func runIgnition(t *testing.T, ctx context.Context, stage, root, cwd string, app
 	args := []string{"-platform", "file", "-stage", stage,
 		"-root", root, "-log-to-stdout",
 		"-config-cache", filepath.Join(cwd, "ignition.json"),
-		"-neednet", filepath.Join(cwd, "neednet")}
+		"-neednet", filepath.Join(cwd, "neednet"),
+		"-state-file", filepath.Join(cwd, "state")}
 	cmd := exec.CommandContext(ctx, "ignition", args...)
 	if cmd == nil {
 		return fmt.Errorf("exec.CommandContext() returned nil")


### PR DESCRIPTION
Increasingly, we need to persist small bits of state between stages.  Add a general mechanism for this, which serializes a struct to a JSON file in `/run` at the end of each stage and loads it at the beginning of the next stage.  For now, use the mechanism to record the fetched-config summaries that are reported to the journal, plus LUKS keyfiles for the files stage.

Additionally, use this functionality to write a JSON file to `/var/lib/ignition/result.json` that contains the provisioning timestamp and a flag indicating whether a user config was used.  The idea is to move [this functionality](https://github.com/coreos/fedora-coreos-config/blob/29f74c49793798a86e54bb4fadafc85275b3f871/overlay.d/05core/usr/libexec/coreos-ignition-firstboot-complete#L28-L47) upstream, allowing distros to display summary information about how provisioning went.

The state mechanism is intended to be an internal API that can change without warning.  The result file format is intended to be reasonably stable, but since it's easy to add compatibility hacks when writing it, I don't think we need to be overly careful when adding things to the format.

It'd be great if we could eventually use the status file to replace the structured journal entries, since the latter seems like a fairly awkward and obscure interface.  It's unclear how much of a compatibility issue that would pose, though.