### PR TITLE
examples: reboot with `--force`

### DIFF
--- a/examples/ignition-kargs-helper
+++ b/examples/ignition-kargs-helper
@@ -47,5 +47,5 @@ kernelopts="$(echo "$kernelopts" | sed -e 's,^[[:space:]]*,,' -e 's,[[:space:]]*
 if [[ "$kernelopts" != "$orig_kernelopts" ]]; then
     sed -i "s|^\(kernelopts=\).*|\1$kernelopts|" $grubcfg
 
-    systemctl reboot
+    systemctl reboot --force
 fi


### PR DESCRIPTION
Without `--force`, the boot process races with service shutdown, leaving enough time for the disks stage to start.  With `--force`, systemd immediately kills processes, unmounts filesystems, and reboots.