### PR TITLE
providers/qemu: optimize fw_cfg read size and add progress reporting

### DIFF
--- a/internal/providers/qemu/qemu_fwcfg.go
+++ b/internal/providers/qemu/qemu_fwcfg.go
@@ -22,9 +22,12 @@
 package qemu
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
 	"github.com/coreos/ignition/v2/internal/providers/util"
@@ -34,22 +37,64 @@ import (
 )
 
 const (
-	firmwareConfigPath = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
+	firmwareConfigPath     = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
+	firmwareConfigSizePath = "/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/size"
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	// load qemu_fw_cfg module
 	_, err := f.Logger.LogCmd(exec.Command("modprobe", "qemu_fw_cfg"), "loading QEMU firmware config module")
 	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}
 
-	data, err := ioutil.ReadFile(firmwareConfigPath)
+	// get size of firmware blob, if it exists
+	sizeBytes, err := ioutil.ReadFile(firmwareConfigSizePath)
 	if os.IsNotExist(err) {
 		f.Logger.Info("QEMU firmware config was not found. Ignoring...")
+		return util.ParseConfig(f.Logger, []byte{})
 	} else if err != nil {
-		f.Logger.Err("couldn't read QEMU firmware config: %v", err)
+		f.Logger.Err("couldn't read QEMU firmware config size: %v", err)
+		return types.Config{}, report.Report{}, err
+	}
+	size, err := strconv.Atoi(strings.TrimSpace(string(sizeBytes)))
+	if err != nil {
+		f.Logger.Err("couldn't parse QEMU firmware config size: %v", err)
 		return types.Config{}, report.Report{}, err
 	}
 
+	// Read firmware blob.  We need to make as few, large read() calls as
+	// possible, since the qemu_fw_cfg kernel module takes O(offset)
+	// time for each read syscall.  ioutil.ReadFile() would eventually
+	// converge on the correct read size (one page) but we can do
+	// better, and without reallocating.
+	// Leave an extra guard byte to check for EOF
+	data := make([]byte, 0, size+1)
+	fh, err := os.Open(firmwareConfigPath)
+	if err != nil {
+		f.Logger.Err("couldn't open QEMU firmware config: %v", err)
+		return types.Config{}, report.Report{}, err
+	}
+	defer fh.Close()
+	for len(data) < size {
+		// if size is correct, we will never call this at an offset
+		// where it would return io.EOF
+		n, err := fh.Read(data[len(data):cap(data)])
+		if err != nil {
+			f.Logger.Err("couldn't read QEMU firmware config: %v", err)
+			return types.Config{}, report.Report{}, err
+		}
+		data = data[:len(data)+n]
+	}
+	if len(data) > size {
+		// overflowed into guard byte
+		f.Logger.Err("missing EOF reading QEMU firmware config")
+		return types.Config{}, report.Report{}, errors.New("missing EOF")
+	}
+	// If size is not at a page boundary, we know we're at EOF because
+	// the guard byte was not filled.  If size is at a page boundary,
+	// trust that firmwareConfigSizePath was telling the truth to avoid
+	// incurring an extra read call to check for EOF.  We're at the end
+	// of the file so the extra read would be maximally expensive.
 	return util.ParseConfig(f.Logger, data)
 }


### PR DESCRIPTION
The kernel returns a maximum of 4096 bytes at a time, and firmware reads [take](https://github.com/torvalds/linux/blob/0ee7c3e25d8c28845fceb4dd1c3cb5f50b9c45a9/drivers/firmware/qemu_fw_cfg.c#L150-L151) O(offset) time, so we should try to optimize our read syscalls.  `ioutil.ReadFile()` eventually converges to an I/O size &ge; 4096 bytes but we can do it immediately and without repeatedly reallocating the buffer.  This saves 8 read operations at the beginning of the config (where it doesn't affect performance very much).

In addition, if reading the config takes more than 10 seconds, tell the user what is happening and start providing regular progress reports.

Closes https://github.com/coreos/ignition/issues/1259.