### PR TITLE
🇩🇪 Add support for Hetzner cloud

### DIFF
--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/exoscale"
 	"github.com/coreos/ignition/v2/internal/providers/file"
 	"github.com/coreos/ignition/v2/internal/providers/gcp"
+	"github.com/coreos/ignition/v2/internal/providers/hetzner"
 	"github.com/coreos/ignition/v2/internal/providers/ibmcloud"
 	"github.com/coreos/ignition/v2/internal/providers/noop"
 	"github.com/coreos/ignition/v2/internal/providers/openstack"
@@ -135,6 +136,10 @@ func init() {
 	configs.Register(Config{
 		name:  "gcp",
 		fetch: gcp.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "hetzner",
+		fetch: hetzner.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "ibmcloud",

--- a/internal/providers/hetzner/hetzner.go
+++ b/internal/providers/hetzner/hetzner.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The hetzner provider fetches a remote configuration from the
+// hetzner user-data metadata service URL.
+// Documentation: https://docs.hetzner.cloud/#server-metadata
+
+package hetzner
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	userdataUrl = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "hetzner/v1/userdata",
+	}
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataUrl, resource.FetchOptions{})
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}


### PR DESCRIPTION
CoreOS works well on Hetzner's cloud instances with embedded ignition
configurations in `/boot/ignition/config.ign`. Add support for ignition
to pull userdata configurations from Hetzner's metadata service.

Signed-off-by: Major Hayden <major@redhat.com>