### PR TITLE
internal/resource: support S3 access point URLs

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -99,6 +99,7 @@ var (
 	ErrEngineConfiguration             = errors.New("engine incorrectly configured")
 
 	// AWS S3 specific errors
+	ErrInvalidS3ARN             = errors.New("invalid S3 ARN format")
 	ErrInvalidS3ObjectVersionId = errors.New("invalid S3 object VersionId")
 
 	// Obsolete errors, left here for ABI compatibility

--- a/config/v3_4_experimental/types/url_test.go
+++ b/config/v3_4_experimental/types/url_test.go
@@ -67,6 +67,62 @@ func TestURLValidate(t *testing.T) {
 			nil,
 		},
 		{
+			util.StrToPtr("Arn:"),
+			errors.ErrInvalidS3ARN,
+		},
+		{
+			util.StrToPtr("arn:aws:iam:us-west-2:123456789012:resource"),
+			errors.ErrInvalidS3ARN,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:::bucket-name-but-no-key"),
+			errors.ErrInvalidS3ARN,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:accesspoint"),
+			errors.ErrInvalidS3ARN,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:accesspoint/"),
+			errors.ErrInvalidS3ARN,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:accesspoint/accesspoint-name-but-no-bucket"),
+			errors.ErrInvalidS3ARN,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:bucket-name/object-key"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:bucket-name/object-key?versionId=aVersionHash"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:accesspoint/accesspoint-name/object"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:accesspoint/accesspoint-name/some/nested/object"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:us-west-2:123456789012:accesspoint/accesspoint-name/object?versionId=aVersionHash"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:::bucket-name/object-key"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:::bucket-name/some/nested/object"),
+			nil,
+		},
+		{
+			util.StrToPtr("arn:aws:s3:::bucket-name/object-key?versionId=aVersionHash"),
+			nil,
+		},
+		{
 			util.StrToPtr("gs://bucket/object"),
 			nil,
 		},

--- a/docs/configuration-v3_4_experimental.md
+++ b/docs/configuration-v3_4_experimental.md
@@ -14,7 +14,7 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.4.0-experimental`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
-      * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `arn`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -22,7 +22,7 @@ The Ignition configuration is a JSON document conforming to the following specif
       * **_verification_** (object): options related to the verification of the config.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_replace_** (object): the config that will replace the current.
-      * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `arn`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_compression_** (string): the type of compression used on the config (null or gzip). Compression cannot be used with S3.
       * **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
@@ -35,7 +35,7 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_security_** (object): options relating to network security.
     * **_tls_** (object): options relating to TLS when fetching resources over `https`.
       * **_certificateAuthorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`.
-        * **source** (string): the URL of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+        * **source** (string): the URL of the certificate bundle (in PEM format). The bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `arn`, `gs`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
         * **_compression_** (string): the type of compression used on the certificate (null or gzip). Compression cannot be used with S3.
         * **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
           * **name** (string): the header name.
@@ -80,7 +80,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents.source` must be specified if `overwrite` is true. Defaults to false.
     * **_contents_** (object): options related to the contents of the file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, `arn`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created.
       * **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
         * **_value_** (string): the header contents.
@@ -88,7 +88,7 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `arn`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
         * **_value_** (string): the header contents.
@@ -127,7 +127,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
     * **_keyFile_** (string): options related to the contents of the key file.
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
-      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `arn`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       * **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
         * **name** (string): the header name.
         * **_value_** (string): the header contents.

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -17,7 +17,7 @@ Ignition is currently only supported for the following platforms:
 * [Google Cloud] (`gcp`) - Ignition will read its configuration from the instance metadata entry named "user-data". Cloud SSH keys are handled separately.
 * [IBM Cloud] (`ibmcloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
-* Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, or `gs://` schemes to specify a remote config.
+* Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, `arn:`, or `gs://` schemes to specify a remote config.
 * [Nutanix] (`nutanix`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.
 * [Equinix Metal] (`packet`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.

--- a/internal/resource/url_test.go
+++ b/internal/resource/url_test.go
@@ -194,6 +194,20 @@ func TestFetchOffline(t *testing.T) {
 			},
 			out: out{err: ErrNeedNet},
 		},
+		// arn url specifying bucket
+		{
+			in: in{
+				url: "arn:aws:s3:::kola-fixtures/resources/anonymous",
+			},
+			out: out{err: ErrNeedNet},
+		},
+		// arn url specifying s3 access point
+		{
+			in: in{
+				url: "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object",
+			},
+			out: out{err: ErrNeedNet},
+		},
 		// gs url
 		{
 			in: in{
@@ -223,6 +237,80 @@ func TestFetchOffline(t *testing.T) {
 		}
 		if test.out.err == nil && !reflect.DeepEqual(test.out.data, result) {
 			t.Errorf("#%d: expected output %+v, got %+v", i, test.out.data, result)
+			continue
+		}
+	}
+}
+
+func TestParseARN(t *testing.T) {
+	type in struct {
+		url string
+	}
+	type out struct {
+		bucket string
+		key    string
+		region string
+		err    error
+	}
+	tests := []struct {
+		in  in
+		out out
+	}{
+		{
+			in: in{
+				"arn:aws:iam:us-west-2:123456789012:resource",
+			},
+			out: out{
+				err: errors.ErrInvalidS3ARN,
+			},
+		},
+		{
+			in: in{
+				"arn:aws:s3:::kola-fixtures/resources/anonymous",
+			},
+			out: out{
+				bucket: "kola-fixtures", key: "resources/anonymous",
+			},
+		},
+		{
+			in: in{
+				"arn:aws:s3:us-west-2:123456789012:accesspoint/test/object",
+			},
+			out: out{
+				bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint/test", key: "object", region: "us-west-2",
+			},
+		},
+		{
+			in: in{
+				"arn:aws:s3:us-west-2:123456789012:accesspoint/test/path/object",
+			},
+			out: out{
+				bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint/test", key: "path/object", region: "us-west-2",
+			},
+		},
+	}
+
+	logger := log.New(true)
+	f := Fetcher{
+		Logger: &logger,
+	}
+
+	for i, test := range tests {
+		bucket, key, region, err := f.parseARN(test.in.url)
+		if !reflect.DeepEqual(test.out.err, err) {
+			t.Errorf("#%d: fetching URL: expected error %+v, got %+v", i, test.out.err, err)
+			continue
+		}
+		if test.out.err == nil && !reflect.DeepEqual(test.out.bucket, bucket) {
+			t.Errorf("#%d: expected output %+v, got %+v", i, test.out.bucket, bucket)
+			continue
+		}
+		if test.out.err == nil && !reflect.DeepEqual(test.out.key, key) {
+			t.Errorf("#%d: expected output %+v, got %+v", i, test.out.key, key)
+			continue
+		}
+		if test.out.err == nil && !reflect.DeepEqual(test.out.region, region) {
+			t.Errorf("#%d: expected output %+v, got %+v", i, test.out.region, region)
 			continue
 		}
 	}


### PR DESCRIPTION
Support S3 access point URLs in ARN format as a source.
This allows valid, opaque S3 URLs such as
`s3:arn:aws:s3:us-west-2:123456789012:accesspoint/test/object`
Being able to use this format will allow S3 URLs on different
partitions and lays the foundation to potentially support
multi-region access points in the future.

Fixes https://github.com/coreos/ignition/issues/1091
Signed-off-by: Zeleena Kearney <zeleenak@lyft.com>