### PR TITLE
internal/exec/util: rename FindFirstMissingDirForFile and tweak docs

### DIFF
--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -470,13 +470,13 @@ func (s *stage) relabelDirsForFile(path string) error {
 		return nil
 	}
 
-	missing_dir, err := util.FindFirstMissingDirForFile(path)
+	missing_path, err := util.FindFirstMissingPathComponent(path)
 	if err != nil {
 		return err
 	}
 
 	// trim off prefix since this needs to be relative to the sysroot
-	s.relabel(missing_dir[len(s.DestDir):])
+	s.relabel(missing_path[len(s.DestDir):])
 	return nil
 }
 

--- a/internal/exec/stages/mount/mount.go
+++ b/internal/exec/stages/mount/mount.go
@@ -118,7 +118,7 @@ func (s stage) mountFs(fs types.Filesystem) error {
 	var firstMissing string
 	if distro.SelinuxRelabel() {
 		var err error
-		firstMissing, err = util.FindFirstMissingDirForFile(path)
+		firstMissing, err = util.FindFirstMissingPathComponent(path)
 		if err != nil {
 			return err
 		}

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -242,9 +242,9 @@ func MkdirForFile(path string) error {
 	return os.MkdirAll(filepath.Dir(path), DefaultDirectoryPermissions)
 }
 
-// FindFirstMissingDirForFile returns the first component which was found to be
-// missing for the path.
-func FindFirstMissingDirForFile(path string) (string, error) {
+// FindFirstMissingPathComponent returns the path up to the first component
+// which was found to be missing, or the whole path if it already exists.
+func FindFirstMissingPathComponent(path string) (string, error) {
 	entry := path
 	dir := filepath.Dir(path)
 	for {


### PR DESCRIPTION
It actually returns a path, not a component. Also, it can return the
path itself if just the final component is missing or if it already
exists. Let's tweak the docstring and use the term "component" in its
name to be clearer.