### PR TITLE
providers/virtualbox: read config from `/Ignition/Config` guest property

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -21,6 +21,7 @@ Ignition is currently only supported for the following platforms:
 * [Equinix Metal] (`packet`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [IBM Power Systems Virtual Server] (`powervs`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [QEMU] (`qemu`) - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device (available in QEMU 2.4.0 and higher).
+* [VirtualBox] (`virtualbox`) - Use the VirtualBox guest property `/Ignition/Config` to provide the config to the virtual machine.
 * [VMware] (`vmware`) - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Vultr] (`vultr`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [zVM] (`zvm`) - Ignition will read its configuration from the reader device directly. The vmur program is necessary, which requires the vmcp and vmur kernel module as prerequisite, and the corresponding z/VM virtual unit record devices (in most cases 000c as reader, 000d as punch) must be set online.
@@ -43,6 +44,7 @@ For most cloud providers, cloud SSH keys and custom network configuration are ha
 [Equinix Metal]: https://metal.equinix.com/product/
 [IBM Power Systems Virtual Server]: https://www.ibm.com/products/power-virtual-server
 [QEMU]: https://www.qemu.org/
+[VirtualBox]: https://www.virtualbox.org/
 [VMware]: https://www.vmware.com/
 [Vultr]: https://www.vultr.com/products/cloud-compute/
 [zVM]: http://www.vm.ibm.com/overview/

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -23,8 +23,7 @@ import (
 // -X github.com/coreos/ignition/v2/internal/distro.mdadmCmd=/opt/bin/mdadm
 var (
 	// Device node directories and paths
-	diskByLabelDir    = "/dev/disk/by-label"
-	diskByPartUUIDDir = "/dev/disk/by-partuuid"
+	diskByLabelDir = "/dev/disk/by-label"
 
 	// initrd file paths
 	kernelCmdlinePath = "/proc/cmdline"
@@ -79,8 +78,7 @@ var (
 	resultFilePath          = "/etc/.ignition-result.json"
 )
 
-func DiskByLabelDir() string    { return diskByLabelDir }
-func DiskByPartUUIDDir() string { return diskByPartUUIDDir }
+func DiskByLabelDir() string { return diskByLabelDir }
 
 func KernelCmdlinePath() string { return kernelCmdlinePath }
 func BootIDPath() string        { return bootIDPath }

--- a/internal/providers/virtualbox/virtualbox.c
+++ b/internal/providers/virtualbox/virtualbox.c
@@ -1,0 +1,208 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <linux/vboxguest.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include "virtualbox.h"
+
+static void _cleanup_close(int *fd) {
+	if (*fd != -1) {
+		close(*fd);
+	}
+}
+#define _cleanup_close_ __attribute__((cleanup(_cleanup_close)))
+
+static void _cleanup_free(void *ptr) {
+	free(*(void **)ptr);
+}
+#define _cleanup_free_ __attribute__((cleanup(_cleanup_free)))
+
+static void init_header(struct vbg_ioctl_hdr *hdr, size_t size_in, size_t size_out) {
+	hdr->size_in = sizeof(*hdr) + size_in;
+	hdr->version = VBG_IOCTL_HDR_VERSION;
+	hdr->type = VBG_IOCTL_HDR_TYPE_DEFAULT;
+	hdr->size_out = sizeof(*hdr) + size_out;
+}
+
+static int version_info(int fd) {
+	struct vbg_ioctl_driver_version_info msg = {
+		.u = {
+			.in = {
+				.req_version = 0x00010000,
+				.min_version = 0x00010000,
+			},
+		},
+	};
+	init_header(&msg.hdr, sizeof(msg.u.in), sizeof(msg.u.out));
+	if (ioctl(fd, VBG_IOCTL_DRIVER_VERSION_INFO, &msg)) {
+		return VERR_GENERAL_FAILURE;
+	}
+	return msg.hdr.rc;
+}
+
+static int connect(int fd, uint32_t *client_id) {
+	struct vbg_ioctl_hgcm_connect msg = {
+		.u = {
+			.in = {
+				.loc = {
+					.type = VMMDEV_HGCM_LOC_LOCALHOST_EXISTING,
+					.u = {
+						.localhost = {
+							.service_name = "VBoxGuestPropSvc",
+						},
+					},
+				},
+			},
+		},
+	};
+	init_header(&msg.hdr, sizeof(msg.u.in), sizeof(msg.u.out));
+	if (ioctl(fd, VBG_IOCTL_HGCM_CONNECT, &msg)) {
+		return VERR_GENERAL_FAILURE;
+	}
+	if (msg.hdr.rc != VINF_SUCCESS) {
+		return msg.hdr.rc;
+	}
+	*client_id = msg.u.out.client_id;
+	return VINF_SUCCESS;
+}
+
+static int get_prop(int fd, uint32_t client_id, const char *name, void **value, size_t *size) {
+	// init header
+	size_t msg_size = sizeof(struct vbg_ioctl_hgcm_call) + 4 * sizeof(struct vmmdev_hgcm_function_parameter64);
+	struct vbg_ioctl_hgcm_call _cleanup_free_ *msg = calloc(1, msg_size);
+	// init_header re-adds the size of msg->hdr
+	init_header(&msg->hdr, msg_size - sizeof(msg->hdr), msg_size - sizeof(msg->hdr));
+	msg->client_id = client_id;
+	msg->function = 1;     // GUEST_PROP_FN_GET_PROP
+	msg->timeout_ms = -1;  // inf
+	msg->interruptible = 1;
+	msg->parm_count = 4;
+
+	// init arguments
+	char ch;
+	struct vmmdev_hgcm_function_parameter64 *params = (void *) (msg + 1);
+	// property name (in)
+	params[0].type = VMMDEV_HGCM_PARM_TYPE_LINADDR_IN;
+	params[0].u.pointer.size = strlen(name) + 1;
+	params[0].u.pointer.u.linear_addr = (uintptr_t) name;
+	// property value (out)
+	params[1].type = VMMDEV_HGCM_PARM_TYPE_LINADDR;
+	params[1].u.pointer.size = 1;
+	params[1].u.pointer.u.linear_addr = (uintptr_t) &ch;
+	// property timestamp (out)
+	params[2].type = VMMDEV_HGCM_PARM_TYPE_64BIT;
+	// property size (out)
+	params[3].type = VMMDEV_HGCM_PARM_TYPE_32BIT;
+
+	// get value size
+	if (ioctl(fd, VBG_IOCTL_HGCM_CALL_64(msg_size), msg)) {
+		return VERR_GENERAL_FAILURE;
+	}
+	switch (msg->hdr.rc) {
+	case VINF_SUCCESS:
+	case VERR_BUFFER_OVERFLOW:
+		// allocate buffer
+		; // labels can't point to declarations
+		size_t buf_size = params[3].u.value32;
+		void _cleanup_free_ *buf = malloc(buf_size);
+		params[1].u.pointer.size = buf_size;
+		params[1].u.pointer.u.linear_addr = (uintptr_t) buf;
+
+		// get value
+		if (ioctl(fd, VBG_IOCTL_HGCM_CALL_64(msg_size), msg)) {
+			return VERR_GENERAL_FAILURE;
+		}
+		if (msg->hdr.rc != VINF_SUCCESS) {
+			return msg->hdr.rc;
+		}
+		*value = buf;
+		buf = NULL;
+		*size = buf_size;
+		return VINF_SUCCESS;
+	case VERR_NOT_FOUND:
+		*value = NULL;
+		*size = 0;
+		return VINF_SUCCESS;
+	default:
+		return msg->hdr.rc;
+	}
+}
+
+static int disconnect(int fd, uint32_t client_id) {
+	struct vbg_ioctl_hgcm_disconnect msg = {
+		.u = {
+			.in = {
+				.client_id = client_id,
+			},
+		},
+	};
+	init_header(&msg.hdr, sizeof(msg.u.in), 0);
+	if (ioctl(fd, VBG_IOCTL_HGCM_DISCONNECT, &msg)) {
+		return VERR_GENERAL_FAILURE;
+	}
+	return msg.hdr.rc;
+}
+
+int virtualbox_get_guest_property(char *name, void **value, size_t *size) {
+	// clear any previous garbage in errno for error returns
+	errno = 0;
+
+	// open character device
+	int _cleanup_close_ fd = open("/dev/vboxguest", O_RDWR | O_CLOEXEC);
+	if (fd == -1) {
+		return VERR_GENERAL_FAILURE;
+	}
+
+	// negotiate protocol version
+	int ret = version_info(fd);
+	if (ret != VINF_SUCCESS) {
+		return ret;
+	}
+
+	// connect to property service
+	uint32_t client_id;
+	ret = connect(fd, &client_id);
+	if (ret != VINF_SUCCESS) {
+		return ret;
+	}
+
+	// get property
+	ret = get_prop(fd, client_id, name, value, size);
+	if (ret != VINF_SUCCESS) {
+		disconnect(fd, client_id);
+		return ret;
+	}
+
+	// disconnect
+	ret = disconnect(fd, client_id);
+	if (ret != VINF_SUCCESS) {
+		// we could ignore the failure, but better to make sure bugs
+		// are noticed
+		free(*value);
+		*value = NULL;
+		return ret;
+	}
+
+	// for clarity, ensure the Go error return is nil
+	errno = 0;
+	return 0;
+}

--- a/internal/providers/virtualbox/virtualbox.go
+++ b/internal/providers/virtualbox/virtualbox.go
@@ -1,4 +1,4 @@
-// Copyright 2017 CoreOS, Inc.
+// Copyright 2021 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The virtualbox provider fetches the configuration from raw data on a partition
-// with the GUID 99570a8a-f826-4eb0-ba4e-9dd72d55ea13
+// The virtualbox provider fetches the configuration from the /Ignition/Config
+// guest property.
 
 package virtualbox
 
+// We want at least this warning, since the default C behavior of
+// assuming int foo(int) is totally broken.
+
+// #cgo CFLAGS: -Werror=implicit-function-declaration
+// #include <linux/vbox_err.h>
+// #include <stdlib.h>
+// #include "virtualbox.h"
+import "C"
+
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
-	"path/filepath"
+	"fmt"
+	"unsafe"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
 	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
-	"github.com/coreos/ignition/v2/internal/distro"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
 
@@ -33,19 +40,53 @@ import (
 )
 
 const (
-	partUUID = "99570a8a-f826-4eb0-ba4e-9dd72d55ea13"
+	configProperty         = "/Ignition/Config"
+	configEncodingProperty = "/Ignition/Config/Encoding"
 )
 
 func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
-	f.Logger.Debug("Attempting to read config drive")
-	rawConfig, err := ioutil.ReadFile(filepath.Join(distro.DiskByPartUUIDDir(), partUUID))
-	if os.IsNotExist(err) {
-		f.Logger.Info("Path to ignition config does not exist, assuming no config")
-		return types.Config{}, report.Report{}, errors.ErrEmpty
-	} else if err != nil {
-		f.Logger.Err("Error reading ignition config: %v", err)
+	f.Logger.Debug("reading Ignition config from VirtualBox guest property")
+
+	// for forward compatibility, check an encoding property analogous
+	// to vmware's ignition.config.data.encoding, and fail if it's
+	// present and non-empty
+	encoding, err := fetchProperty(configEncodingProperty)
+	if err != nil {
 		return types.Config{}, report.Report{}, err
 	}
-	trimmedConfig := bytes.TrimRight(rawConfig, "\x00")
-	return util.ParseConfig(f.Logger, trimmedConfig)
+	if len(encoding) > 0 {
+		return types.Config{}, report.Report{}, fmt.Errorf("unsupported %q value %q", configEncodingProperty, encoding)
+	}
+
+	config, err := fetchProperty(configProperty)
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+	if config == nil {
+		f.Logger.Info("VirtualBox guest property %q does not exist; assuming no config", configProperty)
+		return types.Config{}, report.Report{}, errors.ErrEmpty
+	}
+	return util.ParseConfig(f.Logger, config)
+}
+
+func fetchProperty(name string) ([]byte, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	buf := unsafe.Pointer(nil)
+	defer C.free(buf)
+	var size C.size_t
+
+	ret, errno := C.virtualbox_get_guest_property(cName, &buf, &size)
+	if ret != C.VINF_SUCCESS {
+		if ret == C.VERR_GENERAL_FAILURE && errno != nil {
+			return nil, fmt.Errorf("fetching VirtualBox guest property %q: %w", name, errno)
+		}
+		// see <linux/vbox_err.h>
+		return nil, fmt.Errorf("fetching VirtualBox guest property %q: error %d", name, ret)
+	}
+	if buf == nil {
+		return nil, nil
+	}
+	// properties are double-NUL-terminated
+	return bytes.TrimRight(C.GoBytes(buf, C.int(size)), "\x00"), nil
 }

--- a/internal/providers/virtualbox/virtualbox.h
+++ b/internal/providers/virtualbox/virtualbox.h
@@ -1,0 +1,20 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IGNITION_VIRTUALBOX_H
+#define IGNITION_VIRTUALBOX_H
+
+int virtualbox_get_guest_property(char *name, void **value, size_t *size);
+
+#endif

--- a/test
+++ b/test
@@ -73,8 +73,7 @@ if [ -z "${platforms}" ]; then
 fi
 for id in ${platforms}; do
     case "${id}" in
-    file) ;;       # Undocumented platform ID for testing
-    virtualbox) ;; # Discouraged for now
+    file) ;;  # Undocumented platform ID for testing
     *)
         if ! grep -qF "\`${id}\`" docs/supported-platforms.md; then
             echo "Undocumented platform ID: $id" >&2


### PR DESCRIPTION
VirtualBox supports "guest properties", which are persistent UTF-8 key-value pairs accessible from both the host and guest.  Property values were originally limited to 128 bytes, and the VirtualBox codebase still contains vestiges of that limit, such as fixed-size buffers in some client code.  The limit is no longer enforced by the VirtualBox core; it seems to have been removed in [r21629](https://www.virtualbox.org/changeset?reponame=vbox&new=21629%40trunk%2Fsrc&old=21628%40trunk%2Fsrc) in 2009.

Read Ignition configs from an `/Ignition/Config` guest property by talking directly to the upstream vboxguest kernel module via `/dev/vboxguest`.  Ignition configs can be attached to a VM with something like this command:

    VBoxManage guestproperty set vm-name /Ignition/Config "$(cat config.ign)"

When using this approach (rather than the VirtualBox XPCOM API), configs are subject to these limits:

| OS | Limit | Cause |
| - | - | - |
| Linux | 128 KiB | `MAX_ARG_STRLEN` |
| macOS | 256 KiB | `ARG_MAX` |
| Windows bash | 32 KiB | `UNICODE_STRING.MaximumLength` |
| Windows cmd.exe or PowerShell | 8 KiB | |

(The limits are actually slightly lower for various reasons.)

For forward compatibility, check that the `/Ignition/Config/Encoding` property is missing or empty.  In the future we might want to support alternate encodings (e.g. `gzip+base64`), similar to the VMware provider.

Drop support for the old magic partition GUID.  It was implemented for the old Container Linux Vagrant provider, which was never widely deployed.  It isn't practical for hand-crafting a config drive, since it requires creating a disk image with a partition table and then inserting the config into a partition, and I'm not aware of any active users in the wild.

Fixes https://github.com/coreos/ignition/issues/629.