### PR TITLE
stages/filesystems: use mkfs.fat instead of mkfs.vfat

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -28,7 +28,7 @@ install() {
         groupdel \
         mkfs.btrfs \
         mkfs.ext4 \
-        mkfs.vfat \
+        mkfs.fat \
         mkfs.xfs \
         mkswap \
         sgdisk \

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -50,7 +50,7 @@ var (
 	btrfsMkfsCmd = "mkfs.btrfs"
 	ext4MkfsCmd  = "mkfs.ext4"
 	swapMkfsCmd  = "mkswap"
-	vfatMkfsCmd  = "mkfs.vfat"
+	vfatMkfsCmd  = "mkfs.fat"
 	xfsMkfsCmd   = "mkfs.xfs"
 
 	//zVM programs

--- a/internal/exec/stages/disks/filesystems.go
+++ b/internal/exec/stages/disks/filesystems.go
@@ -186,7 +186,7 @@ func (s stage) createFilesystem(fs types.Filesystem) error {
 		}
 	case "vfat":
 		mkfs = distro.VfatMkfsCmd()
-		// There is no force flag for mkfs.vfat, it always destroys any data on
+		// There is no force flag for mkfs.fat, it always destroys any data on
 		// the device at which it is pointed.
 		if fs.UUID != nil {
 			args = append(args, "-i", canonicalizeFilesystemUUID(*fs.Format, *fs.UUID))

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -276,7 +276,7 @@ func formatPartition(ctx context.Context, partition *types.Partition) error {
 
 	switch partition.FilesystemType {
 	case "vfat":
-		mkfs = "mkfs.vfat"
+		mkfs = "mkfs.fat"
 		label = []string{"-n", partition.FilesystemLabel}
 		uuid = []string{"-i", partition.FilesystemUUID}
 	case "ext2", "ext4":

--- a/tests/positive/filesystems/reformat_filesystem.go
+++ b/tests/positive/filesystems/reformat_filesystem.go
@@ -243,7 +243,7 @@ func makeZFSDisk() []types.Disk {
 // We don't support creating ZFS filesystems, and doing so with zfs-fuse
 // requires the zfs-fuse daemon to be running.  But ZFS also has an unusual
 // property: it has multiple disk labels distributed throughout the disk,
-// and none of mkfs.ext4, mkfs.xfs, or mkfs.vfat clobber them all.  If
+// and none of mkfs.ext4, mkfs.xfs, or mkfs.fat clobber them all.  If
 // blkid or lsblk discover labels of both ZFS and one of those other
 // filesystems, they won't report a filesystem type at all (and blkid will
 // ignore the entire partition), and mount(8) will refuse to mount the FS


### PR DESCRIPTION
Ignition should use mkfs.fat instead of mkfs.vfat because mkfs.vfat is symlink to mkfs.fat and may be absent in some distributions. 
Dosfstools always creates mkfs.fat, but mkfs.vfat is optional (https://github.com/dosfstools/dosfstools/blob/master/src/Makefile.am)