### PR TITLE
templates: skip vendoring the new version in favor of dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -47,6 +47,3 @@ GitHub release:
 Quay release:
   - [ ] Visit the [Quay tags page](https://quay.io/repository/coreos/ignition-validate?tab=tags) and wait for a versioned tag to appear
   - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
-
-Housekeeping:
- - [ ] Vendor the new Ignition version in [mantle](https://github.com/coreos/coreos-assembler/tree/main/mantle)


### PR DESCRIPTION
No need to vendor the new Ignition version in mantle after [this](https://github.com/coreos/coreos-assembler/pull/2529) PR