### PR TITLE
providers/nutanix: Add Nutanix platform

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -17,6 +17,7 @@ Ignition is currently only supported for the following platforms:
 * [Google Cloud] (`gcp`) - Ignition will read its configuration from the instance metadata entry named "user-data". Cloud SSH keys are handled separately.
 * [IBM Cloud] (`ibmcloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, or `gs://` schemes to specify a remote config.
+* [Nutanix] (`nutanix`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.
 * [Equinix Metal] (`packet`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [IBM Power Systems Virtual Server] (`powervs`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/gcp"
 	"github.com/coreos/ignition/v2/internal/providers/ibmcloud"
 	"github.com/coreos/ignition/v2/internal/providers/noop"
+	"github.com/coreos/ignition/v2/internal/providers/nutanix"
 	"github.com/coreos/ignition/v2/internal/providers/openstack"
 	"github.com/coreos/ignition/v2/internal/providers/packet"
 	"github.com/coreos/ignition/v2/internal/providers/powervs"
@@ -143,6 +144,10 @@ func init() {
 	configs.Register(Config{
 		name:  "metal",
 		fetch: noop.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "nutanix",
+		fetch: nutanix.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "openstack",

--- a/internal/providers/cloudstack/cloudstack.go
+++ b/internal/providers/cloudstack/cloudstack.go
@@ -36,9 +36,9 @@ import (
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
 
 	"github.com/coreos/vcontext/report"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -202,7 +202,9 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, label string
 	}
 	defer func() {
 		_ = logger.LogOp(
-			func() error { return unix.Unmount(mnt, 0) },
+			func() error {
+				return ut.UmountPath(mnt)
+			},
 			"unmounting %q at %q", path, mnt,
 		)
 	}()

--- a/internal/providers/ibmcloud/ibmcloud.go
+++ b/internal/providers/ibmcloud/ibmcloud.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
@@ -34,6 +33,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
 
 	"github.com/coreos/vcontext/report"
 )
@@ -104,7 +104,9 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	}
 	defer func() {
 		_ = logger.LogOp(
-			func() error { return syscall.Unmount(mnt, 0) },
+			func() error {
+				return ut.UmountPath(mnt)
+			},
 			"unmounting %q at %q", path, mnt,
 		)
 	}()

--- a/internal/providers/nutanix/nutanix.go
+++ b/internal/providers/nutanix/nutanix.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Red Hat.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Nutanix AHV (https://www.nutanix.com/products/ahv) provider fetches
+// configuration from the userdata available in the config-drive. It is similar
+// to Openstack and uses the same APIs.
+
+package nutanix
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
+
+	"github.com/coreos/vcontext/report"
+)
+
+const (
+	configDriveUserdataPath = "/openstack/latest/user_data"
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := fetchConfigFromDevice(f.Logger, filepath.Join(distro.DiskByLabelDir(), "config-2"))
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return (err == nil)
+}
+
+func fetchConfigFromDevice(logger *log.Logger, path string) ([]byte, error) {
+	// The config drive is always attached, even if there's no user-data passed
+	for !fileExists(path) {
+		logger.Debug("config drive (%q) not found. Waiting...", path)
+		time.Sleep(time.Second)
+	}
+
+	logger.Debug("creating temporary mount point")
+	mnt, err := ioutil.TempDir("", "ignition-configdrive")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.Remove(mnt)
+
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", "auto", path, mnt)
+	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = logger.LogOp(
+			func() error {
+				return ut.UmountPath(mnt)
+			},
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
+
+	mntConfigDriveUserdataPath := filepath.Join(mnt, configDriveUserdataPath)
+	if !fileExists(mntConfigDriveUserdataPath) {
+		return nil, nil
+	}
+
+	return ioutil.ReadFile(mntConfigDriveUserdataPath)
+}

--- a/internal/providers/openstack/openstack.go
+++ b/internal/providers/openstack/openstack.go
@@ -34,9 +34,9 @@ import (
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
 
 	"github.com/coreos/vcontext/report"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -140,7 +140,9 @@ func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string)
 	}
 	defer func() {
 		_ = logger.LogOp(
-			func() error { return unix.Unmount(mnt, 0) },
+			func() error {
+				return ut.UmountPath(mnt)
+			},
 			"unmounting %q at %q", path, mnt,
 		)
 	}()

--- a/internal/providers/powervs/powervs.go
+++ b/internal/providers/powervs/powervs.go
@@ -30,9 +30,9 @@ import (
 	"github.com/coreos/ignition/v2/internal/log"
 	"github.com/coreos/ignition/v2/internal/providers/util"
 	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
 
 	"github.com/coreos/vcontext/report"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -72,7 +72,9 @@ func fetchConfigFromDevice(logger *log.Logger, path string) ([]byte, error) {
 	}
 	defer func() {
 		_ = logger.LogOp(
-			func() error { return unix.Unmount(mnt, 0) },
+			func() error {
+				return ut.UmountPath(mnt)
+			},
 			"unmounting %q at %q", path, mnt,
 		)
 	}()

--- a/internal/util/umount.go
+++ b/internal/util/umount.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// runGetExit runs the command and returns the exit status. It only returns an error when execing
+// the command encounters an error. exec'd programs that exit with non-zero status will not return
+// errors.
+func runGetExit(cmd string, args ...string) (int, string, error) {
+	tmp, err := exec.Command(cmd, args...).CombinedOutput()
+	logs := string(tmp)
+	if err == nil {
+		return 0, logs, nil
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		return -1, logs, err
+	}
+	status := exitErr.ExitCode()
+	return status, logs, nil
+}
+
+func UmountPath(path string) error {
+	// Retry a few times on unmount failure, checking each time whether
+	// the umount actually succeeded but claimed otherwise.  See
+	// https://github.com/coreos/bootengine/commit/8bf46fe78ec5 for more
+	// context.
+	var unmountErr error
+	for i := 0; i < 3; i++ {
+		if unmountErr = unix.Unmount(path, 0); unmountErr == nil {
+			return nil
+		}
+
+		// wait a sec to see if things clear up
+		time.Sleep(time.Second)
+
+		if unmounted, _, err := runGetExit("mountpoint", "-q", path); err != nil {
+			return fmt.Errorf("exec'ing `mountpoint -q %s` failed: %v", path, err)
+		} else if unmounted == 1 {
+			return nil
+		}
+	}
+	return fmt.Errorf("umount failed after 3 tries for %s: %w", path, unmountErr)
+}

--- a/tests/filesystem.go
+++ b/tests/filesystem.go
@@ -103,7 +103,7 @@ func getRootPartition(partitions []*types.Partition) *types.Partition {
 
 func mountPartition(ctx context.Context, p *types.Partition) error {
 	if p.MountPath == "" || p.Device == "" {
-		return fmt.Errorf("Invalid partition for mounting %+v", p)
+		return fmt.Errorf("invalid partition for mounting %+v", p)
 	}
 	_, err := run(ctx, "mount", "-t", p.FilesystemType, p.Device, p.MountPath)
 	return err
@@ -128,7 +128,7 @@ func runGetExit(cmd string, args ...string) (int, string, error) {
 
 func umountPartition(p *types.Partition) error {
 	if p.MountPath == "" || p.Device == "" {
-		return fmt.Errorf("Invalid partition for unmounting %+v", p)
+		return fmt.Errorf("invalid partition for unmounting %+v", p)
 	}
 
 	// Retry a few times on unmount failure, checking each time whether
@@ -236,7 +236,7 @@ func setupDisk(ctx context.Context, disk *types.Disk, diskIndex int, imageSize i
 
 	// Avoid race with kernel by waiting for loopDevice creation to complete
 	if _, err = run(ctx, "udevadm", "settle"); err != nil {
-		return fmt.Errorf("Settling devices: %v", err)
+		return fmt.Errorf("settling devices: %v", err)
 	}
 
 	if err = createPartitionTable(ctx, disk.Device, disk.Partitions); err != nil {
@@ -381,7 +381,7 @@ func createPartitionTable(ctx context.Context, imageFile string, partitions []*t
 	}
 	if len(hybrids) > 0 {
 		if len(hybrids) > 3 {
-			return fmt.Errorf("Can't have more than three hybrids")
+			return fmt.Errorf("can't have more than three hybrids")
 		} else {
 			opts = append(opts, fmt.Sprintf("-h=%s", intJoin(hybrids, ":")))
 		}
@@ -406,7 +406,7 @@ func updateTypeGUID(partition *types.Partition) error {
 
 	partition.TypeGUID = partitionTypes[partition.TypeCode]
 	if partition.TypeGUID == "" {
-		return fmt.Errorf("Unknown TypeCode: %s", partition.TypeCode)
+		return fmt.Errorf("unknown TypeCode: %s", partition.TypeCode)
 	}
 	return nil
 }


### PR DESCRIPTION
xref: https://github.com/coreos/fedora-coreos-tracker/issues/1007
Tested this change on Nutanix AHV and it seems to be working fine.
![nutanix-vm](https://user-images.githubusercontent.com/22043259/142077361-1f0687bb-9b14-4e67-8d32-b6bf3c76889d.png)

```sh
$  ssh core@192.168.2.156
The authenticity of host '192.168.2.156 (192.168.2.156)' can't be established.
ED25519 key fingerprint is SHA256:xxxxxxxx.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.2.156' (ED25519) to the list of known hosts.
Fedora CoreOS 35.20211116.dev.0
Tracker: https://github.com/coreos/fedora-coreos-tracker
Discuss: https://discussion.fedoraproject.org/c/server/coreos/

[core@fcos-ignition-f35-minimal ~]$ 
[core@fcos-ignition-f35-minimal ~]$ cat /proc/cmdline 
BOOT_IMAGE=(hd0,gpt3)/ostree/fedora-coreos-b14045b72b16211ba96b27fd2a0231abfaeff6e287541c781c2a1ffdb25769e9/vmlinuz-5.14.17-301.fc35.x86_64 mitigations=auto,nosmt console=tty0 console=ttyS0,115200n8 ignition.firstboot ostree=/ostree/boot.1/fedora-coreos/b14045b72b16211ba96b27fd2a0231abfaeff6e287541c781c2a1ffdb25769e9/0 ignition.platform.id=nutanix

```
