### PR TITLE
config/v3_4_exp: minor schema fixes

### DIFF
--- a/config/v3_4_experimental/schema/ignition.json
+++ b/config/v3_4_experimental/schema/ignition.json
@@ -141,7 +141,10 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "version"
+      ]
     },
     "storage": {
       "type": "object",

--- a/config/v3_4_experimental/schema/ignition.json
+++ b/config/v3_4_experimental/schema/ignition.json
@@ -125,7 +125,7 @@
             "noProxy": {
               "type": "array",
               "items": {
-                "type": ["string", "null"]
+                "type": "string"
               }
             }
           }

--- a/config/v3_4_experimental/types/schema.go
+++ b/config/v3_4_experimental/types/schema.go
@@ -83,7 +83,7 @@ type Ignition struct {
 	Proxy    Proxy          `json:"proxy,omitempty"`
 	Security Security       `json:"security,omitempty"`
 	Timeouts Timeouts       `json:"timeouts,omitempty"`
-	Version  string         `json:"version,omitempty"`
+	Version  string         `json:"version"`
 }
 
 type IgnitionConfig struct {


### PR DESCRIPTION
Fix some schema nits that shouldn't affect Ignition, but might affect other language generators that want to read the schema (such as schemafy for [ignition-config-rs](https://github.com/coreos/ignition-config-rs)).