### PR TITLE
docs/getting-started: mention Ignition running on the first boot

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ nav_order: 3
 1. TOC
 {:toc}
 
-Ignition is a low-level system configuration utility. The Ignition executable is part of the temporary initial root filesystem, the *initramfs*. When Ignition runs, it finds configuration data in a named location for a given environment, such as a file or URL, and applies it to the machine before `switch_root` is called to pivot to the machine's root filesystem.
+Ignition is a low-level system configuration utility. The Ignition executable is part of the temporary initial root filesystem, the *initramfs*. When Ignition runs [on the first boot][firstboot], it finds configuration data in a named location for a given environment, such as a file or URL, and applies it to the machine before `switch_root` is called to pivot to the machine's root filesystem.
 
 Ignition uses a JSON configuration file to represent the set of changes to be made. The format of this config is detailed [in the specification][configspec] and the [MIME type][mime] is registered with IANA. One of the most important parts of this config is the version number. This **must** match the version number accepted by Ignition. If the config version isn't accepted by Ignition, Ignition will fail to run and the machine will not boot. This can be seen by inspecting the console output of the failed machine. For more information, check out the [troubleshooting section][troubleshooting].
 
@@ -65,6 +65,7 @@ Ignition is not typically run more than once during a machine's lifetime in a gi
 [conditions]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionFirstBoot=
 [configspec]: specs.md
 [examples]: examples.md
+[firstboot]: rationale.md#ignition-runs-only-on-the-first-boot
 [mime]: http://www.iana.org/assignments/media-types/application/vnd.coreos.ignition+json
 [operator-notes]: operator-notes.md
 [releases]: https://github.com/coreos/ignition/releases


### PR DESCRIPTION
`index.md` and `rationale.md` both mention this, but `getting-started.md` currently doesn't, except when discussing systemd services in the troubleshooting section.  Add a mention and reference for anyone who starts with the getting-started guide.

Alternative to https://github.com/coreos/ignition/pull/1206.