### PR TITLE
stages/files: drop support for runtime systemd units

### DIFF
--- a/internal/exec/util/path.go
+++ b/internal/exec/util/path.go
@@ -22,18 +22,6 @@ func SystemdUnitsPath() string {
 	return filepath.Join("etc", "systemd", "system")
 }
 
-func SystemdRuntimeUnitsPath() string {
-	return filepath.Join("run", "systemd", "system")
-}
-
-func SystemdRuntimeUnitWantsPath(unitName string) string {
-	return filepath.Join("run", "systemd", "system", unitName+".wants")
-}
-
 func SystemdDropinsPath(unitName string) string {
 	return filepath.Join("etc", "systemd", "system", unitName+".d")
-}
-
-func SystemdRuntimeDropinsPath(unitName string) string {
-	return filepath.Join("run", "systemd", "system", unitName+".d")
 }


### PR DESCRIPTION
It's been unused since #846.

This effectively reverts af98f37ffdeb.