### PR TITLE
disks: fix reuse of statically keyed LUKS volume

### DIFF
--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -156,6 +156,13 @@ func (s *stage) createLuks(config types.Config) error {
 				}
 			}
 		}
+		// store the key to be persisted into the real root
+		// do this here so device reuse works correctly
+		key, err := ioutil.ReadFile(keyFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to read keyfile %q: %w", keyFilePath, err)
+		}
+		s.State.LuksPersistKeyFiles[luks.Name] = dataurl.EncodeBytes(key)
 
 		if !util.IsTrue(luks.WipeVolume) {
 			// If the volume isn't forcefully being created, then we need
@@ -329,13 +336,7 @@ func (s *stage) createLuks(config types.Config) error {
 			); err != nil {
 				return fmt.Errorf("removing key file from luks device: %v", err)
 			}
-		} else {
-			// store the key to be persisted into the real root
-			key, err := ioutil.ReadFile(keyFilePath)
-			if err != nil {
-				return fmt.Errorf("failed to read keyfile %q: %w", keyFilePath, err)
-			}
-			s.State.LuksPersistKeyFiles[luks.Name] = dataurl.EncodeBytes(key)
+			delete(s.State.LuksPersistKeyFiles, luks.Name)
 		}
 	}
 


### PR DESCRIPTION
We need to persist a volume's keyfile to the real root even if we take the early `continue` when reusing the volume.  Rather than copying code, enable persistence up front and then disable it afterward if we decide not to persist the key.

Fixes error:

    CRITICAL : Ignition failed: creating crypttab entries: missing persisted keyfile for [...]

Fixes: https://github.com/coreos/ignition/issues/1305
Fixes: 65e9c1611128 ("stages/disks: use State to persist keyfiles for files stage")