### PR TITLE
internal/exec: print newline after Ignition config on failure

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -143,7 +143,7 @@ func (e Engine) Run(stageName string) error {
 			// Nothing else to do with this error
 			fmt.Fprintf(os.Stderr, "Could not marshal full config: %v\n", jsonerr)
 		} else {
-			fmt.Fprintf(os.Stderr, "Full config:\n%s", string(tmp))
+			fmt.Fprintf(os.Stderr, "Full config:\n%s\n", string(tmp))
 		}
 		return err
 	}


### PR DESCRIPTION
Otherwise the next message merges with the last close-brace.