### PR TITLE
workflows: build and test ignition-validate on macOS and Windows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,3 +34,25 @@ jobs:
       with:
         version: v1.42.0
         args: -E=gofmt --timeout=30m0s
+  test-validate:
+    name: test ignition-validate
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Build ignition-validate
+      shell: bash
+      run: go build -o ignition-validate github.com/coreos/ignition/v2/validate
+    - name: Test ignition-validate
+      shell: bash
+      run: |
+        go test -timeout 60s -cover \
+            $(go list ./config/... ./validate/...) --race


### PR DESCRIPTION
We ship ignition-validate for macOS and Windows, so let's test that in CI.  Ignition contains a lot of Linux-specific code, so it's not practical to run through the entire `./build` and `./test` flow.  Instead, create a parallel job that builds ignition-validate and runs only those tests that are pertinent to it.