### PR TITLE
workflows: move container build to dedicated job

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,20 @@
+name: Container
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-container:
+    name: Build container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Build container image
+        run: podman build -f Dockerfile.validate .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,8 +27,6 @@ jobs:
       run: sudo apt-get install libblkid-dev
     - name: Run tests
       run: ./test
-    - name: Validate container build
-      run: docker build -f Dockerfile.validate .
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
       with:


### PR DESCRIPTION
The container build doesn't care about the selected version of Go in the host, so there's no point in running it three times.  Move the container build to a separate job, matching Butane CI.

Also switch from docker to podman.