### PR TITLE
merge.go: drop Compression field if nil in child

### DIFF
--- a/config/merge/merge.go
+++ b/config/merge/merge.go
@@ -240,6 +240,10 @@ func mergeStruct(parent reflect.Value, parentPath path.ContextPath, child reflec
 			resultField.Set(mergeStruct(parentField.Elem(), parentFieldPath, childField.Elem(), childFieldPath, resultFieldPath, transcript).Addr())
 			transcribeOne(parentFieldPath, resultFieldPath, transcript)
 			transcribeOne(childFieldPath, resultFieldPath, transcript)
+		case kind == reflect.Ptr && childField.IsNil() && fieldMeta.Name == "Compression":
+			// if a child's Compression field is nil, since it may have uncompressed
+			// Source that gets copied to result, Compression should not be set in
+			// result even if it's set in parent
 		case kind == reflect.Ptr && childField.IsNil():
 			resultField.Set(parentField)
 			transcribe(parentFieldPath, resultFieldPath, resultField, fieldMeta, transcript)

--- a/config/merge/merge_test.go
+++ b/config/merge/merge_test.go
@@ -1338,6 +1338,71 @@ func TestMerge(t *testing.T) {
 				{path.New(TAG_CHILD, "kernelArguments"), path.New(TAG_RESULT, "kernelArguments")},
 			}},
 		},
+
+		// when compressed and un-compressed files are merged, out does not have Compression field
+		{
+			in1: types.Config{
+				Storage: types.Storage{
+					Files: []types.File{
+						{
+							Node: types.Node{
+								Path: "/a",
+							},
+							FileEmbedded1: types.FileEmbedded1{
+								Contents: types.Resource{
+									Source:      util.StrToPtr("data:"),
+									Compression: util.StrToPtr("gzip"),
+								},
+							},
+						},
+					},
+				},
+			},
+			in2: types.Config{
+				Storage: types.Storage{
+					Files: []types.File{
+						{
+							Node: types.Node{
+								Path: "/a",
+							},
+							FileEmbedded1: types.FileEmbedded1{
+								Contents: types.Resource{
+									Source: util.StrToPtr("data:hello world"),
+								},
+							},
+						},
+					},
+				},
+			},
+			out: types.Config{
+				Storage: types.Storage{
+					Files: []types.File{
+						{
+							Node: types.Node{
+								Path: "/a",
+							},
+							FileEmbedded1: types.FileEmbedded1{
+								Contents: types.Resource{
+									Source: util.StrToPtr("data:hello world"),
+								},
+							},
+						},
+					},
+				},
+			},
+			transcript: Transcript{[]Mapping{
+				{path.New(TAG_CHILD, "storage", "files", 0, "path"), path.New(TAG_RESULT, "storage", "files", 0, "path")},
+				{path.New(TAG_CHILD, "storage", "files", 0, "contents", "source"), path.New(TAG_RESULT, "storage", "files", 0, "contents", "source")},
+				{path.New(TAG_PARENT, "storage", "files", 0, "contents"), path.New(TAG_RESULT, "storage", "files", 0, "contents")},
+				{path.New(TAG_CHILD, "storage", "files", 0, "contents"), path.New(TAG_RESULT, "storage", "files", 0, "contents")},
+				{path.New(TAG_PARENT, "storage", "files", 0), path.New(TAG_RESULT, "storage", "files", 0)},
+				{path.New(TAG_CHILD, "storage", "files", 0), path.New(TAG_RESULT, "storage", "files", 0)},
+				{path.New(TAG_PARENT, "storage", "files"), path.New(TAG_RESULT, "storage", "files")},
+				{path.New(TAG_CHILD, "storage", "files"), path.New(TAG_RESULT, "storage", "files")},
+				{path.New(TAG_PARENT, "storage"), path.New(TAG_RESULT, "storage")},
+				{path.New(TAG_CHILD, "storage"), path.New(TAG_RESULT, "storage")},
+			}},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
If a child's Compression field is nil, since it may have uncompressed
Source that gets copied to result, Compression should not be set in
result even if it's set in parent

Fixes coreos/butane#332