### PR TITLE
ci: add testing with Go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     name: test build
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
@@ -30,13 +30,13 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42.0
+        version: v1.45.0
         args: -E=gofmt --timeout=30m0s
   test-validate:
     name: test ignition-validate
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/config/v3_1/types/headers_test.go
+++ b/config/v3_1/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/config/v3_2/types/headers_test.go
+++ b/config/v3_2/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/config/v3_3/types/headers_test.go
+++ b/config/v3_3/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }

--- a/config/v3_4_experimental/types/headers_test.go
+++ b/config/v3_4_experimental/types/headers_test.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
@@ -133,7 +132,7 @@ func TestValidHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value"}) || !equal(parseHeaders[strings.Title("header2")], []string{"header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value"}) || !equal(parseHeaders["Header2"], []string{"header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }
@@ -154,7 +153,7 @@ func TestDuplicateHeadersParse(t *testing.T) {
 	if err != nil {
 		t.Errorf("error during parsing valid headers: %v", err)
 	}
-	if !equal(parseHeaders[strings.Title("header1")], []string{"header1value", "header2value"}) {
+	if !equal(parseHeaders["Header1"], []string{"header1value", "header2value"}) {
 		t.Errorf("parsed HTTP headers values are wrong")
 	}
 }


### PR DESCRIPTION
Update `golangci-lint` to version v1.45.0 which has support for go 1.18