### PR TITLE
workflows: `apt-get update` before installing packages

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
     - name: Install libblkid-dev
-      run: sudo apt-get install libblkid-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libblkid-dev
     - name: Run tests
       run: ./test
     - name: Run linter


### PR DESCRIPTION
Old package versions can be removed from the mirror, which could cause job failures.