### PR TITLE
Add KubeVirt support

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -16,6 +16,7 @@ Ignition is currently only supported for the following platforms:
 * [Exoscale] (`exoscale`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Google Cloud] (`gcp`) - Ignition will read its configuration from the instance metadata entry named "user-data". Cloud SSH keys are handled separately.
 * [IBM Cloud] (`ibmcloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
+* [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, or `gs://` schemes to specify a remote config.
 * [Nutanix] (`nutanix`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.
@@ -41,6 +42,7 @@ For most cloud providers, cloud SSH keys and custom network configuration are ha
 [Exoscale]: https://www.exoscale.com/compute/
 [Google Cloud]: https://cloud.google.com/compute
 [IBM Cloud]: https://www.ibm.com/cloud/vpc
+[KubeVirt]: https://kubevirt.io
 [Nutanix]: https://www.nutanix.com/products/ahv
 [OpenStack]: https://www.openstack.org/
 [Equinix Metal]: https://metal.equinix.com/product/

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/ignition/v2/internal/providers/file"
 	"github.com/coreos/ignition/v2/internal/providers/gcp"
 	"github.com/coreos/ignition/v2/internal/providers/ibmcloud"
+	"github.com/coreos/ignition/v2/internal/providers/kubevirt"
 	"github.com/coreos/ignition/v2/internal/providers/noop"
 	"github.com/coreos/ignition/v2/internal/providers/nutanix"
 	"github.com/coreos/ignition/v2/internal/providers/openstack"
@@ -140,6 +141,10 @@ func init() {
 	configs.Register(Config{
 		name:  "ibmcloud",
 		fetch: ibmcloud.FetchConfig,
+	})
+	configs.Register(Config{
+		name:  "kubevirt",
+		fetch: kubevirt.FetchConfig,
 	})
 	configs.Register(Config{
 		name:  "metal",

--- a/internal/providers/kubevirt/kubevirt.go
+++ b/internal/providers/kubevirt/kubevirt.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Red Hat.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The KubeVirt (https://kubevirt.io) provider fetches
+// configuration from the userdata available in the config-drive. It is similar
+// to Openstack and uses the same APIs.
+
+package kubevirt
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/ignition/v2/config/v3_4_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
+
+	"github.com/coreos/vcontext/report"
+)
+
+const (
+	configDriveUserdataPath = "/openstack/latest/user_data"
+)
+
+func FetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := fetchConfigFromDevice(f.Logger, filepath.Join(distro.DiskByLabelDir(), "config-2"))
+	if err != nil {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return (err == nil)
+}
+
+func fetchConfigFromDevice(logger *log.Logger, path string) ([]byte, error) {
+	// There is not always a config drive in kubevirt, but we can limit ignition usage
+	// to VMs with config drives. Block forever if there is none.
+	for !fileExists(path) {
+		logger.Debug("config drive (%q) not found. Waiting...", path)
+		time.Sleep(time.Second)
+	}
+
+	logger.Debug("creating temporary mount point")
+	mnt, err := ioutil.TempDir("", "ignition-configdrive")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.Remove(mnt)
+
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", "auto", path, mnt)
+	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = logger.LogOp(
+			func() error {
+				return ut.UmountPath(mnt)
+			},
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
+
+	mntConfigDriveUserdataPath := filepath.Join(mnt, configDriveUserdataPath)
+	if !fileExists(mntConfigDriveUserdataPath) {
+		return nil, nil
+	}
+
+	return ioutil.ReadFile(mntConfigDriveUserdataPath)
+}


### PR DESCRIPTION
KubeVirt is openstack config-drive compatible and uses the `config-2` label (lower case).

xref https://github.com/coreos/fedora-coreos-tracker/issues/1126

Testing ignition on a fcos machine where kubevirt injected the user-data shows this:

```bash
[core@vmi-fedora ~]$ sudo  /home/core/ignition --platform kubevirt --config-cache ignition.json --state-file state --stage fetch --log-to-stdout
INFO     : Ignition v2.13.0-58-g45429023
INFO     : Stage: fetch
INFO     : no config dir at "/usr/lib/ignition/base.d"
INFO     : no config dir at "/usr/lib/ignition/base.platform.d/kubevirt"
DEBUG    : parsed url from cmdline: ""
INFO     : no config URL provided
INFO     : reading system config file "/usr/lib/ignition/user.ign"
INFO     : no config at "/usr/lib/ignition/user.ign"
DEBUG    : creating temporary mount point
INFO     : op(1): [started]  mounting config drive
DEBUG    : op(1): executing: "mount" "-o" "ro" "-t" "auto" "/dev/disk/by-label/config-2" "/tmp/ignition-configdrive749859965"
INFO     : op(1): [finished] mounting config drive
INFO     : op(2): [started]  unmounting "/dev/disk/by-label/config-2" at "/tmp/ignition-configdrive749859965"
INFO     : op(2): [finished] unmounting "/dev/disk/by-label/config-2" at "/tmp/ignition-configdrive749859965"
DEBUG    : parsing config with SHA512: afca8c4e75ad3338fa48aa686c7bcc33973e6731e793e819d85950a41dfdd7d7b5dde42580ffbcc3bb3b76b9f9d7b438858b1e19380d3cb4a71d807f0823e20e
INFO     : fetch: fetch complete
INFO     : fetch: fetch passed
INFO     : Ignition finished successfully
[core@vmi-fedora ~]$ sudo cat ignition.json 
{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0-experimental"},"kernelArguments":{},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["ssh-rsa AAAAB3N..."]}]},"storage":{},"systemd":{}}
[core@vmi-fedora ~]$ sudo cat state
{"fetchedConfigs":[{"kind":"base","source":"system","referenced":false},{"kind":"base","source":"system","referenced":false},{"kind":"user","source":"kubevirt","referenced":false}],"luksPersistKeyFiles":null,"notatedDirectories":null}
```

If no user-data is present:

```
[core@vmi-fedora ~]$ sudo  /home/core/ignition --platform kubevirt --config-cache ignition.json --state-file state --stage fetch --log-to-stdout
INFO     : Ignition v2.13.0-58-g45429023-dirty
INFO     : Stage: fetch
INFO     : no config dir at "/usr/lib/ignition/base.d"
INFO     : no config dir at "/usr/lib/ignition/base.platform.d/kubevirt"
DEBUG    : parsed url from cmdline: ""
INFO     : no config URL provided
INFO     : reading system config file "/usr/lib/ignition/user.ign"
INFO     : no config at "/usr/lib/ignition/user.ign"
DEBUG    : creating temporary mount point
INFO     : op(1): [started]  mounting config drive
DEBUG    : op(1): executing: "mount" "-o" "ro" "-t" "auto" "/dev/disk/by-label/config-2" "/tmp/ignition-configdrive826956530"
INFO     : op(1): [finished] mounting config drive
INFO     : op(2): [started]  unmounting "/dev/disk/by-label/config-2" at "/tmp/ignition-configdrive826956530"
INFO     : op(2): [finished] unmounting "/dev/disk/by-label/config-2" at "/tmp/ignition-configdrive826956530"
DEBUG    : parsing config with SHA512: cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
INFO     : not a config (empty): provider config was empty, continuing with empty cache config
INFO     : fetch: fetch complete
INFO     : fetch: fetch passed
INFO     : Ignition finished successfully
[core@vmi-fedora ~]$ sudo cat ignition.json 
{"ignition":{"config":{"replace":{"verification":{}}},"proxy":{},"security":{"tls":{}},"timeouts":{},"version":"3.4.0-experimental"},"kernelArguments":{},"passwd":{},"storage":{},"systemd":{}}[core@vmi-fedora ~]$ 
[core@vmi-fedora ~]$ sudo cat state 
{"fetchedConfigs":[{"kind":"base","source":"system","referenced":false}],"luksPersistKeyFiles":null,"notatedDirectories":null}
```

If no config-drive is present it just waits forever:

```
[core@vmi-fedora ~]$ sudo  /home/core/ignition --platform kubevirt --config-cache ignition.json --state-file state --stage fetch --log-to-stdout
INFO     : Ignition v2.13.0-58-g45429023-dirty
INFO     : Stage: fetch
INFO     : no config dir at "/usr/lib/ignition/base.d"
INFO     : no config dir at "/usr/lib/ignition/base.platform.d/kubevirt"
DEBUG    : parsed url from cmdline: ""
INFO     : no config URL provided
INFO     : reading system config file "/usr/lib/ignition/user.ign"
INFO     : no config at "/usr/lib/ignition/user.ign"
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
DEBUG    : config drive ("/dev/disk/by-label/config-2") not found. Waiting...
```
