### PR TITLE
workflows: build and push `ignition-validate` container from GH Actions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,11 +3,16 @@ name: Container
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
 permissions:
   contents: read
+
+# avoid races when pushing containers built from main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   build-container:
@@ -16,5 +21,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build container image
-        run: podman build -f Dockerfile.validate .
+      - name: Build and push container
+        uses: coreos/actions-lib/build-container@main
+        with:
+          credentials: ${{ secrets.QUAY_AUTH }}
+          file: Dockerfile.validate
+          push: quay.io/coreos/ignition-validate
+          # Speed up PR CI by skipping arm64
+          pr-arches: amd64

--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:35 AS builder
-RUN dnf install -y golang git
+RUN dnf install -y golang git-core
 RUN mkdir /ignition-validate
 COPY . /ignition-validate
 WORKDIR /ignition-validate

--- a/build_for_container
+++ b/build_for_container
@@ -27,6 +27,5 @@ export GO11MODULE=on
 export CGO_ENABLED=0
 export GOFLAGS='-mod=vendor'
 export GOOS=linux
-export GOARCH=amd64
 
 go build -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/ignition-validate ${REPO_PATH}/validate


### PR DESCRIPTION
Quay builds are amd64-only and haven't been especially reliable.  Use GitHub Actions to build both amd64 and arm64 containers for the main branch and for tags, and push them to Quay.  Continue building but not pushing containers on PR.  Requires the `QUAY_AUTH` repo secret to be set to a Docker credential.

Ideally we would cross-build the arm64 container by having the Dockerfile specify `FROM --platform=$BUILDPLATFORM` for the builder container and set `GOARCH=$TARGETARCH`.  However, Buildah < 1.24.1 doesn't support `--platform` in FROM.  Build in emulation for now, and skip arm64 in PRs to speed up CI.

Fixes #1321.