### PR TITLE
workflows: include Git tag in container `--version`

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          # fetch tags so the compiled-in version number is useful
+          fetch-depth: 0
       - name: Build and push container
         uses: coreos/actions-lib/build-container@main
         with:


### PR DESCRIPTION
Fetch Git tags so the output of `--version` for the ignition-validate container isn't just a commit hash.