### PR TITLE
internal/resource: enable DualStack for S3 connections

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -464,7 +464,7 @@ func (f *Fetcher) fetchFromS3WithCreds(ctx context.Context, dest s3target, input
 		return err
 	}
 
-	awsConfig := aws.NewConfig().WithHTTPClient(httpClient)
+	awsConfig := aws.NewConfig().WithHTTPClient(httpClient).WithUseDualStack(true)
 	s3Client := s3.New(sess, awsConfig)
 	downloader := s3manager.NewDownloaderWithClient(s3Client)
 	if _, err := downloader.DownloadWithContext(ctx, dest, input); err != nil {


### PR DESCRIPTION
DualStack endpoints allows IPv6 connections to AWS S3 buckets. This is need for IPv6 native subnets.

Fixes #1340