### PR TITLE
WIP: ensure user's .ssh dir exists and has right owner and permissions

### DIFF
--- a/internal/as_user/as_user.go
+++ b/internal/as_user/as_user.go
@@ -31,8 +31,8 @@ import (
 )
 
 // TODO(vc): do this at akd.Open() and make our own typed user struct.
-// getIds extracts the uid and guid as integers from a user.User.
-func getIds(u *user.User) (C.int, C.int, error) {
+// GetIds extracts the uid and guid as integers from a user.User.
+func GetIds(u *user.User) (C.int, C.int, error) {
 	uid, err := strconv.Atoi(u.Uid)
 	if err != nil {
 		return -1, -1, fmt.Errorf("invalid uid: %v", err)
@@ -47,7 +47,7 @@ func getIds(u *user.User) (C.int, C.int, error) {
 
 // OpenFile reimplements os.OpenFile but switching euid/egid first if necessary.
 func OpenFile(u *user.User, name string, flags int, perm uint32) (*os.File, error) {
-	uid, gid, err := getIds(u)
+	uid, gid, err := GetIds(u)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func OpenFile(u *user.User, name string, flags int, perm uint32) (*os.File, erro
 
 // MkdirAll reimplements os.MkdirAll but switching euid/egid first if necessary.
 func MkdirAll(u *user.User, path string, perm uint32) error {
-	uid, gid, err := getIds(u)
+	uid, gid, err := GetIds(u)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func MkdirAll(u *user.User, path string, perm uint32) error {
 
 // Rename reimplements os.Rename but switching euid/egid first if necessary.
 func Rename(u *user.User, oldpath, newpath string) error {
-	uid, gid, err := getIds(u)
+	uid, gid, err := GetIds(u)
 	if err != nil {
 		return err
 	}

--- a/internal/exec/util/file.go
+++ b/internal/exec/util/file.go
@@ -158,7 +158,7 @@ func (u Util) SetPermissions(mode *int, node types.Node) error {
 		}
 	}
 
-	defaultUid, defaultGid, _ := getFileOwnerAndMode(node.Path)
+	defaultUid, defaultGid, _ := GetFileOwnerAndMode(node.Path)
 	uid, gid, err := u.ResolveNodeUidAndGid(node, defaultUid, defaultGid)
 	if err != nil {
 		return fmt.Errorf("failed to determine correct uid and gid for %s: %v", node.Path, err)
@@ -314,7 +314,7 @@ func FilesystemIsEmpty(dirpath string) (bool, error) {
 // getFileOwner will return the uid and gid for the file at a given path. If the
 // file doesn't exist, or some other error is encountered when running stat on
 // the path, 0, 0, and 0 will be returned.
-func getFileOwnerAndMode(path string) (int, int, os.FileMode) {
+func GetFileOwnerAndMode(path string) (int, int, os.FileMode) {
 	info := unix.Stat_t{}
 	if err := unix.Stat(path, &info); err != nil {
 		return 0, 0, 0


### PR DESCRIPTION
On s390x with SecureExecution qcow2 image (https://github.com/coreos/coreos-assembler/pull/2822) Ignition fails with : 
```
INFO     : files: ensureUsers: op(3): [started]  adding ssh keys to user "core"
CRITICAL : files: ensureUsers: op(3): [failed]   adding ssh keys to user "core": failed to set SSH key: permission denied
```

Most probably smth is wrong with `cosa` PRs, but for now this is enough to continue with SecureExecution  