### PR TITLE
internal/resource: derive AWS region hint from ARN partition field

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -457,7 +457,7 @@ func (f *Fetcher) fetchFromS3(u url.URL, dest s3target, opts FetchOptions) error
 		region, err = s3manager.GetBucketRegion(ctx, sess, bucket, regionHint)
 		if err != nil {
 			if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
-				return fmt.Errorf("couldn't determine the region for bucket %q: %v", u.Host, err)
+				return fmt.Errorf("couldn't determine the region for bucket %q: %v", bucket, err)
 			}
 			return err
 		}

--- a/internal/resource/url_test.go
+++ b/internal/resource/url_test.go
@@ -246,32 +246,73 @@ func TestFetchOffline(t *testing.T) {
 
 func TestParseARN(t *testing.T) {
 	tests := []struct {
-		url    string
-		bucket string
-		key    string
-		region string
-		err    error
+		url        string
+		bucket     string
+		key        string
+		region     string
+		regionHint string
+		err        error
 	}{
 		{
 			url: "arn:aws:iam:us-west-2:123456789012:resource",
 			err: errors.ErrInvalidS3ARN,
 		},
 		{
-			url:    "arn:aws:s3:::kola-fixtures/resources/anonymous",
+			url:        "arn:aws:s3:::kola-fixtures/resources/anonymous",
+			bucket:     "kola-fixtures",
+			key:        "resources/anonymous",
+			regionHint: "us-east-1",
+		},
+		{
+			url:        "arn:aws-cn:s3:::kola-fixtures/resources/anonymous",
+			bucket:     "kola-fixtures",
+			key:        "resources/anonymous",
+			regionHint: "cn-north-1",
+		},
+		{
+			url:        "arn:aws-us-gov:s3:::kola-fixtures/resources/anonymous",
+			bucket:     "kola-fixtures",
+			key:        "resources/anonymous",
+			regionHint: "us-gov-west-1",
+		},
+		{
+			url:    "arn:invalid:s3:::kola-fixtures/resources/anonymous",
 			bucket: "kola-fixtures",
 			key:    "resources/anonymous",
 		},
 		{
-			url:    "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object",
-			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint/test",
+			url:        "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object",
+			bucket:     "arn:aws:s3:us-west-2:123456789012:accesspoint/test",
+			key:        "object",
+			region:     "us-west-2",
+			regionHint: "us-east-1",
+		},
+		{
+			url:        "arn:aws-cn:s3:cn-northwest-1:123456789012:accesspoint/test/object",
+			bucket:     "arn:aws-cn:s3:cn-northwest-1:123456789012:accesspoint/test",
+			key:        "object",
+			region:     "cn-northwest-1",
+			regionHint: "cn-north-1",
+		},
+		{
+			url:        "arn:aws-us-gov:s3:us-gov-east-1:123456789012:accesspoint/test/object",
+			bucket:     "arn:aws-us-gov:s3:us-gov-east-1:123456789012:accesspoint/test",
+			key:        "object",
+			region:     "us-gov-east-1",
+			regionHint: "us-gov-west-1",
+		},
+		{
+			url:    "arn:invalid:s3:us-west-2:123456789012:accesspoint/test/object",
+			bucket: "arn:invalid:s3:us-west-2:123456789012:accesspoint/test",
 			key:    "object",
 			region: "us-west-2",
 		},
 		{
-			url:    "arn:aws:s3:us-west-2:123456789012:accesspoint/test/path/object",
-			bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint/test",
-			key:    "path/object",
-			region: "us-west-2",
+			url:        "arn:aws:s3:us-west-2:123456789012:accesspoint/test/path/object",
+			bucket:     "arn:aws:s3:us-west-2:123456789012:accesspoint/test",
+			key:        "path/object",
+			region:     "us-west-2",
+			regionHint: "us-east-1",
 		},
 	}
 
@@ -281,10 +322,11 @@ func TestParseARN(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		bucket, key, region, err := f.parseARN(test.url)
+		bucket, key, region, regionHint, err := f.parseARN(test.url)
 		assert.Equal(t, test.err, err, "#%d: bad err", i)
 		assert.Equal(t, test.bucket, bucket, "#%d: bad bucket", i)
 		assert.Equal(t, test.key, key, "#%d: bad key", i)
 		assert.Equal(t, test.region, region, "#%d: bad region", i)
+		assert.Equal(t, test.regionHint, regionHint, "#%d: bad region hint", i)
 	}
 }


### PR DESCRIPTION
For S3 access point ARNs, we derive the access point region from the region field in the ARN, allowing us to query the correct AWS partition.  For regular S3 object ARNs, the region field is not used, so we assume the same partition Ignition is running in, or `aws` if running outside AWS.

However, object ARNs include a valid partition field.  Compute a region hint from that, and use it to ask the partition for the correct bucket region.  That allows object ARNs to reference objects outside the current partition (when running in AWS) or outside the `aws` partition (when running outside AWS).

Followup to #1264.

cc @zeleena 