### PR TITLE
exec/util: fix infinite loop in `Depth()` if `-root` is relative

### DIFF
--- a/internal/exec/util/path_sort.go
+++ b/internal/exec/util/path_sort.go
@@ -20,7 +20,7 @@ import (
 
 func Depth(path string) uint {
 	var count uint = 0
-	for p := filepath.Clean(path); p != "/"; count++ {
+	for p := filepath.Clean(path); p != "/" && p != "."; count++ {
 		p = filepath.Dir(p)
 	}
 	return count


### PR DESCRIPTION
If the `-root` command-line argument isn't an absolute path, and the files stage tries to write a file, we get stuck in an infinite loop in `Depth()`.  Ignition shouldn't normally be invoked this way, but it might occur during manual debugging.  Avoid the infinite loop.