### PR TITLE
internal/resource: fix S3 access point object ARNs

### DIFF
--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -591,8 +591,9 @@ func (f *Fetcher) parseARN(arnURL string) (string, string, string, string, error
 
 	// Determine if the ARN is for an access point or a bucket.
 	if strings.HasPrefix(s3arn.Resource, "accesspoint/") {
-		// urlSplit must consist of arn, name of accesspoint, and key
-		if len(urlSplit) < 3 {
+		// urlSplit must consist of arn, name of accesspoint, "object",
+		// and key
+		if len(urlSplit) < 4 || urlSplit[2] != "object" {
 			return "", "", "", "", configErrors.ErrInvalidS3ARN
 		}
 
@@ -601,7 +602,7 @@ func (f *Fetcher) parseARN(arnURL string) (string, string, string, string, error
 		// For more information about access point ARNs, see Using access points
 		// https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html
 		bucket := strings.Join(urlSplit[:2], "/")
-		key := strings.Join(urlSplit[2:], "/")
+		key := strings.Join(urlSplit[3:], "/")
 		return bucket, key, s3arn.Region, regionHint, nil
 	}
 	// urlSplit must consist of name of bucket and key

--- a/internal/resource/url_test.go
+++ b/internal/resource/url_test.go
@@ -206,7 +206,7 @@ func TestFetchOffline(t *testing.T) {
 		// arn url specifying s3 access point
 		{
 			in: in{
-				url: "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object",
+				url: "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object/name",
 			},
 			out: out{err: ErrNeedNet},
 		},
@@ -258,6 +258,14 @@ func TestParseARN(t *testing.T) {
 			err: errors.ErrInvalidS3ARN,
 		},
 		{
+			url: "arn:aws:s3:us-east-1:123456789012:accesspoint/test/object",
+			err: errors.ErrInvalidS3ARN,
+		},
+		{
+			url: "arn:aws:s3:us-east-1:123456789012:accesspoint/test/name",
+			err: errors.ErrInvalidS3ARN,
+		},
+		{
 			url:        "arn:aws:s3:::kola-fixtures/resources/anonymous",
 			bucket:     "kola-fixtures",
 			key:        "resources/anonymous",
@@ -281,34 +289,34 @@ func TestParseARN(t *testing.T) {
 			key:    "resources/anonymous",
 		},
 		{
-			url:        "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object",
+			url:        "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object/name",
 			bucket:     "arn:aws:s3:us-west-2:123456789012:accesspoint/test",
-			key:        "object",
+			key:        "name",
 			region:     "us-west-2",
 			regionHint: "us-east-1",
 		},
 		{
-			url:        "arn:aws-cn:s3:cn-northwest-1:123456789012:accesspoint/test/object",
+			url:        "arn:aws-cn:s3:cn-northwest-1:123456789012:accesspoint/test/object/name",
 			bucket:     "arn:aws-cn:s3:cn-northwest-1:123456789012:accesspoint/test",
-			key:        "object",
+			key:        "name",
 			region:     "cn-northwest-1",
 			regionHint: "cn-north-1",
 		},
 		{
-			url:        "arn:aws-us-gov:s3:us-gov-east-1:123456789012:accesspoint/test/object",
+			url:        "arn:aws-us-gov:s3:us-gov-east-1:123456789012:accesspoint/test/object/name",
 			bucket:     "arn:aws-us-gov:s3:us-gov-east-1:123456789012:accesspoint/test",
-			key:        "object",
+			key:        "name",
 			region:     "us-gov-east-1",
 			regionHint: "us-gov-west-1",
 		},
 		{
-			url:    "arn:invalid:s3:us-west-2:123456789012:accesspoint/test/object",
+			url:    "arn:invalid:s3:us-west-2:123456789012:accesspoint/test/object/name",
 			bucket: "arn:invalid:s3:us-west-2:123456789012:accesspoint/test",
-			key:    "object",
+			key:    "name",
 			region: "us-west-2",
 		},
 		{
-			url:        "arn:aws:s3:us-west-2:123456789012:accesspoint/test/path/object",
+			url:        "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object/path/object",
 			bucket:     "arn:aws:s3:us-west-2:123456789012:accesspoint/test",
 			key:        "path/object",
 			region:     "us-west-2",


### PR DESCRIPTION
ARNs have a static `/object/` path component between the access point name and the object path.  Remove it when parsing ARNs.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html

cc @zeleena 