### PR TITLE
github: enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
We have a lot of vendored dependencies, which we currently don't update.  Let's fix that.  Hopefully we have enough CI to pick up substantial regressions.

Hold until after release.