### PR TITLE
dependabot: configure PR label; increase maximum PR count

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  open-pull-requests-limit: 10
+  labels:
+  - dependency


### PR DESCRIPTION
Allow 10 outstanding PRs, matching most of our other projects.