### PR TITLE
Makefile: install `/usr/libexec/ignition-apply`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ install: all
 	install -m 0755 -D -t $(DESTDIR)/usr/lib/dracut/modules.d/30ignition bin/$(GOARCH)/ignition
 	install -m 0755 -D -t $(DESTDIR)/usr/bin bin/$(GOARCH)/ignition-validate
 	install -m 0755 -d $(DESTDIR)/usr/libexec
+	ln -sf ../lib/dracut/modules.d/30ignition/ignition $(DESTDIR)/usr/libexec/ignition-apply
 	ln -sf ../lib/dracut/modules.d/30ignition/ignition $(DESTDIR)/usr/libexec/ignition-rmcfg
 
 .PHONY: vendor


### PR DESCRIPTION
Don't put `ignition-apply` in `/usr/bin` because it's still fairly experimental, but do avoid requiring callers to create the symlink themselves.

cc @prestist 