### PR TITLE
copr: mark git checkout as safe

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,5 +1,7 @@
 srpm:
 	dnf install -y git
+	# similar to https://github.com/actions/checkout/issues/760, but for COPR
+	git config --global --add safe.directory '*'
 	curl -LOf https://src.fedoraproject.org/rpms/ignition/raw/rawhide/f/ignition.spec
 	version=$$(git describe --always --tags | sed -e 's,-,\.,g' -e 's,^v,,'); \
 	git archive --format=tar --prefix=ignition-$$version/ HEAD | gzip > ignition-$$version.tar.gz; \


### PR DESCRIPTION
Recent git became more strict wrt git repos in parent dirs owned by
other users. This broke our COPR builds due to the git checkout being
created by a different user and mounted in. We need to explicitly mark
the repo as safe.

For more information, see:
https://github.com/actions/checkout/issues/760