### PR TITLE
dracut: Fix invalid use of ln_r

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -11,8 +11,9 @@ install_ignition_unit() {
     local target="${1:-ignition-complete.target}"; shift
     local instantiated="${1:-$unit}"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$instantiated"
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    $SYSTEMCTL -q --root="$initdir" add-requires "$target" "$instantiated" || exit 1
 }
 
 install() {


### PR DESCRIPTION
ln_r expects an absolute path as first argument, passing a relative path
instead behaves as if it was relative to /. That behaviour lead to dangling
symlinks in the .target.requires directory.

Use the same method as dracut's own modules.