### PR TITLE
dracut: include tpm2_createpolicy

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -48,7 +48,8 @@ install() {
         clevis-luks-common-functions \
         clevis-luks-unlock \
         pwmake \
-        tpm2_create
+        tpm2_create \
+        tpm2_createpolicy
 
     # Required by s390x's z/VM installation.
     # Supporting https://github.com/coreos/ignition/pull/865


### PR DESCRIPTION
When creating luks devices with custom tpm2 policies, clevis-encrypt-tpm2
expects a symlink "tpm2_createpolicy" in the ramdisk. As Clevis dracut module
only embeds the decryption related tools, we need to add tpm2_createpolicy
ourselves.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1255