### PR TITLE
Omit `-log-to-stdout` by default, but allow distros to enable it; avoid overriding logger in `resource`

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -32,4 +32,4 @@ After=systemd-udevd.service
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=disks
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=disks ${IGNITION_ARGS}

--- a/dracut/30ignition/ignition-fetch-offline.service
+++ b/dracut/30ignition/ignition-fetch-offline.service
@@ -21,4 +21,4 @@ OnFailureJobMode=isolate
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch-offline
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch-offline ${IGNITION_ARGS}

--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -25,4 +25,4 @@ After=network.target
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch ${IGNITION_ARGS}

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -18,4 +18,4 @@ Before=initrd-parse-etc.service
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files --log-to-stdout
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -18,4 +18,4 @@ Before=initrd-parse-etc.service
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files ${IGNITION_ARGS}

--- a/dracut/30ignition/ignition-kargs.service
+++ b/dracut/30ignition/ignition-kargs.service
@@ -16,7 +16,7 @@ OnFailureJobMode=isolate
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=kargs
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=kargs ${IGNITION_ARGS}
 # MountFlags=slave is so the umount of /boot is guaranteed to happen.
 # /boot will only be mounted for the lifetime of the unit.
 MountFlags=slave

--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -29,5 +29,5 @@ After=ignition-remount-sysroot.service
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=mount
-ExecStop=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=umount
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=mount ${IGNITION_ARGS}
+ExecStop=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=umount ${IGNITION_ARGS}

--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -29,5 +29,5 @@ After=ignition-remount-sysroot.service
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=mount --log-to-stdout
-ExecStop=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=umount --log-to-stdout
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=mount
+ExecStop=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=umount

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -282,11 +282,7 @@ func (f *Fetcher) fetchFromTFTP(u url.URL, dest io.Writer, opts FetchOptions) er
 // FetchFromHTTP fetches a resource from u via HTTP(S) into dest, returning an
 // error if one is encountered.
 func (f *Fetcher) fetchFromHTTP(u url.URL, dest io.Writer, opts FetchOptions) error {
-	// for the case when "config is not valid"
-	// this if necessary if not spawned through kola (e.g. Packet Dashboard)
 	if f.client == nil {
-		logger := log.New(true)
-		f.Logger = &logger
 		if err := f.newHttpClient(); err != nil {
 			return err
 		}


### PR DESCRIPTION
We were inconsistent about which stages logged to syslog and which ones logged to stdout.  Always log to syslog, but add an env var allowing distros to override this via a drop-in.  Also back out some code in `resource` that overrode the global logger.