### PR TITLE
docs: clarify group fields in config specs

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -39,6 +39,7 @@ var (
 	ErrLinkUsedSymlink           = errors.New("link path includes link in config")
 	ErrLinkTargetRequired        = errors.New("link target is required")
 	ErrHardLinkToDirectory       = errors.New("hard link target is a directory")
+	ErrHardLinkSpecifiesOwner    = errors.New("user/group ignored for hard link")
 	ErrDiskDeviceRequired        = errors.New("disk device is required")
 	ErrPartitionNumbersCollide   = errors.New("partition numbers collide")
 	ErrPartitionsOverlap         = errors.New("partitions overlap")

--- a/config/v3_0/types/storage.go
+++ b/config/v3_0/types/storage.go
@@ -66,6 +66,15 @@ func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 				r.AddOnError(c.Append("links", i), errors.ErrHardLinkToDirectory)
 			}
 		}
+		ownerCheck := func(ok bool, path vpath.ContextPath) {
+			if !ok {
+				r.AddOnWarn(path, errors.ErrHardLinkSpecifiesOwner)
+			}
+		}
+		ownerCheck(l1.User.ID == nil, c.Append("links", i, "user", "id"))
+		ownerCheck(l1.User.Name == nil, c.Append("links", i, "user", "name"))
+		ownerCheck(l1.Group.ID == nil, c.Append("links", i, "group", "id"))
+		ownerCheck(l1.Group.Name == nil, c.Append("links", i, "group", "name"))
 	}
 	return
 }

--- a/config/v3_1/types/storage.go
+++ b/config/v3_1/types/storage.go
@@ -66,6 +66,15 @@ func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 				r.AddOnError(c.Append("links", i), errors.ErrHardLinkToDirectory)
 			}
 		}
+		ownerCheck := func(ok bool, path vpath.ContextPath) {
+			if !ok {
+				r.AddOnWarn(path, errors.ErrHardLinkSpecifiesOwner)
+			}
+		}
+		ownerCheck(l1.User.ID == nil, c.Append("links", i, "user", "id"))
+		ownerCheck(l1.User.Name == nil, c.Append("links", i, "user", "name"))
+		ownerCheck(l1.Group.ID == nil, c.Append("links", i, "group", "id"))
+		ownerCheck(l1.Group.Name == nil, c.Append("links", i, "group", "name"))
 	}
 	return
 }

--- a/config/v3_2/types/storage.go
+++ b/config/v3_2/types/storage.go
@@ -66,6 +66,15 @@ func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 				r.AddOnError(c.Append("links", i), errors.ErrHardLinkToDirectory)
 			}
 		}
+		ownerCheck := func(ok bool, path vpath.ContextPath) {
+			if !ok {
+				r.AddOnWarn(path, errors.ErrHardLinkSpecifiesOwner)
+			}
+		}
+		ownerCheck(l1.User.ID == nil, c.Append("links", i, "user", "id"))
+		ownerCheck(l1.User.Name == nil, c.Append("links", i, "user", "name"))
+		ownerCheck(l1.Group.ID == nil, c.Append("links", i, "group", "id"))
+		ownerCheck(l1.Group.Name == nil, c.Append("links", i, "group", "name"))
 	}
 	return
 }

--- a/config/v3_3/types/storage.go
+++ b/config/v3_3/types/storage.go
@@ -70,6 +70,15 @@ func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 				r.AddOnError(c.Append("links", i), errors.ErrHardLinkToDirectory)
 			}
 		}
+		ownerCheck := func(ok bool, path vpath.ContextPath) {
+			if !ok {
+				r.AddOnWarn(path, errors.ErrHardLinkSpecifiesOwner)
+			}
+		}
+		ownerCheck(l1.User.ID == nil, c.Append("links", i, "user", "id"))
+		ownerCheck(l1.User.Name == nil, c.Append("links", i, "user", "name"))
+		ownerCheck(l1.Group.ID == nil, c.Append("links", i, "group", "id"))
+		ownerCheck(l1.Group.Name == nil, c.Append("links", i, "group", "name"))
 	}
 	return
 }

--- a/config/v3_3/types/storage_test.go
+++ b/config/v3_3/types/storage_test.go
@@ -27,13 +27,13 @@ import (
 
 func TestStorageValidate(t *testing.T) {
 	tests := []struct {
-		in  Storage
-		at  path.ContextPath
-		out error
+		in   Storage
+		at   path.ContextPath
+		err  error
+		warn error
 	}{
 		{
-			in:  Storage{},
-			out: nil,
+			in: Storage{},
 		},
 		{
 			in: Storage{
@@ -58,7 +58,6 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
 		},
 		{
 			in: Storage{
@@ -74,7 +73,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrFileUsedSymlink,
+			err: errors.ErrFileUsedSymlink,
 			at:  path.New("", "files", 0),
 		},
 		{
@@ -91,7 +90,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrDirectoryUsedSymlink,
+			err: errors.ErrDirectoryUsedSymlink,
 			at:  path.New("", "directories", 0),
 		},
 		{
@@ -107,7 +106,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrLinkUsedSymlink,
+			err: errors.ErrLinkUsedSymlink,
 			at:  path.New("", "links", 1),
 		},
 		{
@@ -119,7 +118,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrLinkTargetRequired,
+			err: errors.ErrLinkTargetRequired,
 			at:  path.New("", "links", 0, "target"),
 		},
 		{
@@ -131,7 +130,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrLinkTargetRequired,
+			err: errors.ErrLinkTargetRequired,
 			at:  path.New("", "links", 0, "target"),
 		},
 		{
@@ -147,7 +146,6 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
 		},
 		{
 			in: Storage{
@@ -166,15 +164,96 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrHardLinkToDirectory,
+			err: errors.ErrHardLinkToDirectory,
 			at:  path.New("", "links", 0),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							User: NodeUser{
+								ID: util.IntToPtr(10),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "user", "id"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							User: NodeUser{
+								Name: util.StrToPtr("bovik"),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "user", "name"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							Group: NodeGroup{
+								ID: util.IntToPtr(10),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "group", "id"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							Group: NodeGroup{
+								Name: util.StrToPtr("bovik"),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "group", "name"),
 		},
 	}
 
 	for i, test := range tests {
 		r := test.in.Validate(path.ContextPath{})
 		expected := report.Report{}
-		expected.AddOnError(test.at, test.out)
+		expected.AddOnError(test.at, test.err)
+		expected.AddOnWarn(test.at, test.warn)
 		if !reflect.DeepEqual(expected, r) {
 			t.Errorf("#%d: bad report: want %v, got %v", i, expected, r)
 		}

--- a/config/v3_4_experimental/types/storage.go
+++ b/config/v3_4_experimental/types/storage.go
@@ -70,6 +70,15 @@ func (s Storage) Validate(c vpath.ContextPath) (r report.Report) {
 				r.AddOnError(c.Append("links", i), errors.ErrHardLinkToDirectory)
 			}
 		}
+		ownerCheck := func(ok bool, path vpath.ContextPath) {
+			if !ok {
+				r.AddOnWarn(path, errors.ErrHardLinkSpecifiesOwner)
+			}
+		}
+		ownerCheck(l1.User.ID == nil, c.Append("links", i, "user", "id"))
+		ownerCheck(l1.User.Name == nil, c.Append("links", i, "user", "name"))
+		ownerCheck(l1.Group.ID == nil, c.Append("links", i, "group", "id"))
+		ownerCheck(l1.Group.Name == nil, c.Append("links", i, "group", "name"))
 	}
 	return
 }

--- a/config/v3_4_experimental/types/storage_test.go
+++ b/config/v3_4_experimental/types/storage_test.go
@@ -27,13 +27,13 @@ import (
 
 func TestStorageValidate(t *testing.T) {
 	tests := []struct {
-		in  Storage
-		at  path.ContextPath
-		out error
+		in   Storage
+		at   path.ContextPath
+		err  error
+		warn error
 	}{
 		{
-			in:  Storage{},
-			out: nil,
+			in: Storage{},
 		},
 		{
 			in: Storage{
@@ -58,7 +58,6 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
 		},
 		{
 			in: Storage{
@@ -74,7 +73,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrFileUsedSymlink,
+			err: errors.ErrFileUsedSymlink,
 			at:  path.New("", "files", 0),
 		},
 		{
@@ -91,7 +90,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrDirectoryUsedSymlink,
+			err: errors.ErrDirectoryUsedSymlink,
 			at:  path.New("", "directories", 0),
 		},
 		{
@@ -107,7 +106,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrLinkUsedSymlink,
+			err: errors.ErrLinkUsedSymlink,
 			at:  path.New("", "links", 1),
 		},
 		{
@@ -119,7 +118,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrLinkTargetRequired,
+			err: errors.ErrLinkTargetRequired,
 			at:  path.New("", "links", 0, "target"),
 		},
 		{
@@ -131,7 +130,7 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrLinkTargetRequired,
+			err: errors.ErrLinkTargetRequired,
 			at:  path.New("", "links", 0, "target"),
 		},
 		{
@@ -147,7 +146,6 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
 		},
 		{
 			in: Storage{
@@ -166,15 +164,96 @@ func TestStorageValidate(t *testing.T) {
 					},
 				},
 			},
-			out: errors.ErrHardLinkToDirectory,
+			err: errors.ErrHardLinkToDirectory,
 			at:  path.New("", "links", 0),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							User: NodeUser{
+								ID: util.IntToPtr(10),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "user", "id"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							User: NodeUser{
+								Name: util.StrToPtr("bovik"),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "user", "name"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							Group: NodeGroup{
+								ID: util.IntToPtr(10),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "group", "id"),
+		},
+		{
+			in: Storage{
+				Links: []Link{
+					{
+						Node: Node{
+							Path: "/quux",
+							Group: NodeGroup{
+								Name: util.StrToPtr("bovik"),
+							},
+						},
+						LinkEmbedded1: LinkEmbedded1{
+							Target: util.StrToPtr("/foo/bar"),
+							Hard:   util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			warn: errors.ErrHardLinkSpecifiesOwner,
+			at:   path.New("", "links", 0, "group", "name"),
 		},
 	}
 
 	for i, test := range tests {
 		r := test.in.Validate(path.ContextPath{})
 		expected := report.Report{}
-		expected.AddOnError(test.at, test.out)
+		expected.AddOnError(test.at, test.err)
+		expected.AddOnWarn(test.at, test.warn)
 		if !reflect.DeepEqual(expected, r) {
 			t.Errorf("#%d: bad report: want %v, got %v", i, expected, r)
 		}

--- a/docs/configuration-v3_0.md
+++ b/docs/configuration-v3_0.md
@@ -88,10 +88,10 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/configuration-v3_0.md
+++ b/docs/configuration-v3_0.md
@@ -72,9 +72,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -82,18 +82,18 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
 * **_systemd_** (object): describes the desired state of the systemd units.

--- a/docs/configuration-v3_1.md
+++ b/docs/configuration-v3_1.md
@@ -95,9 +95,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -105,18 +105,18 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
 * **_systemd_** (object): describes the desired state of the systemd units.

--- a/docs/configuration-v3_1.md
+++ b/docs/configuration-v3_1.md
@@ -111,10 +111,10 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/configuration-v3_2.md
+++ b/docs/configuration-v3_2.md
@@ -112,10 +112,10 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/configuration-v3_2.md
+++ b/docs/configuration-v3_2.md
@@ -96,9 +96,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -106,18 +106,18 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/configuration-v3_3.md
+++ b/docs/configuration-v3_3.md
@@ -112,10 +112,10 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/configuration-v3_3.md
+++ b/docs/configuration-v3_3.md
@@ -96,9 +96,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -106,18 +106,18 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/configuration-v3_4_experimental.md
+++ b/docs/configuration-v3_4_experimental.md
@@ -114,10 +114,10 @@ The Ignition configuration is a JSON document conforming to the following specif
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
-    * **_user_** (object): specifies the symbolic link's owner.
+    * **_user_** (object): specifies the owner for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the symbolic link's group.
+    * **_group_** (object): specifies the group for a symbolic link. Ignored for hard links.
       * **_id_** (integer): the group ID of the group.
       * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link

--- a/docs/configuration-v3_4_experimental.md
+++ b/docs/configuration-v3_4_experimental.md
@@ -98,9 +98,9 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the file's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the file's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the directory.
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
@@ -108,18 +108,18 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_user_** (object): specifies the directory's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the directory's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
   * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
     * **path** (string): the absolute path to the link
     * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
     * **_user_** (object): specifies the symbolic link's owner.
       * **_id_** (integer): the user ID of the owner.
       * **_name_** (string): the user name of the owner.
-    * **_group_** (object): specifies the group of the owner.
-      * **_id_** (integer): the group ID of the owner.
-      * **_name_** (string): the group name of the owner.
+    * **_group_** (object): specifies the symbolic link's group.
+      * **_id_** (integer): the group ID of the group.
+      * **_name_** (string): the group name of the group.
     * **target** (string): the target path of the link
     * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
   * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,7 @@ nav_order: 9
 
 - Fix reproducibility of systemd preset file in ignition-apply output
 - Clarify spec docs for `files`/`directories`/`links` `group` fields
+- Document that `user`/`group` fields aren't applied to hard links
 
 
 ## Ignition 2.14.0 (12-May-2022)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ nav_order: 9
 ### Changes
 
 - Warn if template for enabled systemd instance unit has no `Install` section
+- Warn if `user`/`group` specified for hard link
 - Install ignition-apply in `/usr/libexec`
 - Convert `NEWS` to Markdown and move to docs site
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,7 +22,7 @@ nav_order: 9
 ### Bug fixes
 
 - Fix reproducibility of systemd preset file in ignition-apply output
-
+- Clarify spec docs for `files`/`directories`/`links` `group` fields
 
 
 ## Ignition 2.14.0 (12-May-2022)


### PR DESCRIPTION
They specify the group that should be applied to the inode, not the primary group of the inode's owner.