### PR TITLE
Sync repo templates ⚙

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -67,7 +67,7 @@ RHCOS packaging for the current RHCOS development release:
    - Run `go-mods-to-bundled-provides.py | sort` while inside of the `ignition` directory you ran `./tag_release` from & copy output into spec file in `# Main package provides` section
    - Update changelog
  - [ ] Run `spectool -g -S ignition.spec`
- - [ ] Run `kinit your_account@REDHAT.COM`
+ - [ ] Run `kinit your_account@IPA.REDHAT.COM`
  - [ ] Run `rhpkg new-sources $(spectool -S ignition.spec | sed 's:.*/::')`
  - [ ] PR the changes
  - [ ] Get the PR reviewed and merge it


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/repo-templates/actions/workflows/sync.yml) ([source](https://github.com/coreos/repo-templates/blob/main/.github/workflows/sync.yml)).

Sync with coreos/repo-templates@2902a8e3787263aa1792992aa39a7c24a0d89ea9.