### PR TITLE
dependabot: permute the label order to flush Dependabot's config cache

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
   labels:
-  - dependency
   - skip-notes
+  - dependency


### PR DESCRIPTION
This should fix the missing `skip-notes` labels on Dependabot PRs.