### PR TITLE
fetch-offline: add reconition for `ClevisCustom`'s `NeedsNetwork` field.

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,6 +29,7 @@ nav_order: 9
 - Clarify spec docs for `files`/`directories`/`links` `group` fields
 - Document that `user`/`group` fields aren't applied to hard links
 - Fix version string in ignition-validate release container
+- Request network when custom Clevis config has `needsNetwork` set
 
 
 ## Ignition 2.14.0 (12-May-2022)

--- a/internal/exec/stages/fetch_offline/fetch-offline.go
+++ b/internal/exec/stages/fetch_offline/fetch-offline.go
@@ -84,6 +84,7 @@ func configNeedsNet(cfg *types.Config) (bool, error) {
 func configNeedsNetRecurse(v reflect.Value) (bool, error) {
 	t := v.Type()
 	k := t.Kind()
+
 	switch {
 	case cfgutil.IsPrimitive(k):
 		return false, nil
@@ -91,6 +92,11 @@ func configNeedsNetRecurse(v reflect.Value) (bool, error) {
 		return sourceNeedsNet(v.Interface().(types.Resource))
 	case t == reflect.TypeOf(types.Tang{}):
 		return true, nil
+	case t == reflect.TypeOf(types.ClevisCustom{}):
+		cc := v.Interface().(types.ClevisCustom)
+		if cc.NeedsNetwork != nil {
+			return *cc.NeedsNetwork, nil
+		}
 	case k == reflect.Struct:
 		for i := 0; i < v.NumField(); i += 1 {
 			if needsNet, err := configNeedsNetRecurse(v.Field(i)); err != nil {

--- a/internal/exec/stages/fetch_offline/fetch_offline_test.go
+++ b/internal/exec/stages/fetch_offline/fetch_offline_test.go
@@ -31,6 +31,22 @@ func checkNeedsNet(t *testing.T, cfg *types.Config) bool {
 
 func TestConfigNotNeedsNet(t *testing.T) {
 	tests := []types.Config{
+		// Test ClevisCustom NeedsNetwork set to false
+		{
+			Storage: types.Storage{
+				Luks: []types.Luks{
+					{
+						Name:   "foobar",
+						Device: util.StrToPtr("foo"),
+						Clevis: types.Clevis{
+							Custom: types.ClevisCustom{
+								NeedsNetwork: util.BoolToPtr(false),
+							},
+						},
+					},
+				},
+			},
+		},
 		// Source with no URL
 		{
 			Ignition: types.Ignition{
@@ -90,6 +106,22 @@ func TestConfigNeedsNet(t *testing.T) {
 				Config: types.IgnitionConfig{
 					Replace: types.Resource{
 						Source: util.StrToPtr("http://example.com/config.ign"),
+					},
+				},
+			},
+		},
+		// CustomClevis with NeedsNetwork set to true
+		{
+			Storage: types.Storage{
+				Luks: []types.Luks{
+					{
+						Name:   "foobar",
+						Device: util.StrToPtr("foo"),
+						Clevis: types.Clevis{
+							Custom: types.ClevisCustom{
+								NeedsNetwork: util.BoolToPtr(true),
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Resolves #1473, add a check for attributes that trigger networking to be inclusive of `ClevisCustom`'s `NeedNetwork` field.