### PR TITLE
config/v3_4_exp: support persisting LUKS open-time options, especially discard

### DIFF
--- a/config/v3_4_experimental/schema/ignition.json
+++ b/config/v3_4_experimental/schema/ignition.json
@@ -274,6 +274,12 @@
             },
             "discard": {
               "type": ["boolean", "null"]
+            },
+            "openOptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [

--- a/config/v3_4_experimental/schema/ignition.json
+++ b/config/v3_4_experimental/schema/ignition.json
@@ -271,6 +271,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "discard": {
+              "type": ["boolean", "null"]
             }
           },
           "required": [

--- a/config/v3_4_experimental/translate/translate.go
+++ b/config/v3_4_experimental/translate/translate.go
@@ -53,11 +53,25 @@ func translateDirectoryEmbedded1(old old_types.DirectoryEmbedded1) (ret types.Di
 	return
 }
 
+func translateLuks(old old_types.Luks) (ret types.Luks) {
+	tr := translate.NewTranslator()
+	tr.Translate(&old.Clevis, &ret.Clevis)
+	tr.Translate(&old.Device, &ret.Device)
+	tr.Translate(&old.KeyFile, &ret.KeyFile)
+	tr.Translate(&old.Label, &ret.Label)
+	tr.Translate(&old.Name, &ret.Name)
+	tr.Translate(&old.Options, &ret.Options)
+	tr.Translate(&old.UUID, &ret.UUID)
+	tr.Translate(&old.WipeVolume, &ret.WipeVolume)
+	return
+}
+
 func Translate(old old_types.Config) (ret types.Config) {
 	tr := translate.NewTranslator()
 	tr.AddCustomTranslator(translateIgnition)
 	tr.AddCustomTranslator(translateDirectoryEmbedded1)
 	tr.AddCustomTranslator(translateFileEmbedded1)
+	tr.AddCustomTranslator(translateLuks)
 	tr.Translate(&old, &ret)
 	return
 }

--- a/config/v3_4_experimental/types/schema.go
+++ b/config/v3_4_experimental/types/schema.go
@@ -111,6 +111,7 @@ type LinkEmbedded1 struct {
 type Luks struct {
 	Clevis     Clevis       `json:"clevis,omitempty"`
 	Device     *string      `json:"device,omitempty"`
+	Discard    *bool        `json:"discard,omitempty"`
 	KeyFile    Resource     `json:"keyFile,omitempty"`
 	Label      *string      `json:"label,omitempty"`
 	Name       string       `json:"name"`

--- a/config/v3_4_experimental/types/schema.go
+++ b/config/v3_4_experimental/types/schema.go
@@ -109,15 +109,16 @@ type LinkEmbedded1 struct {
 }
 
 type Luks struct {
-	Clevis     Clevis       `json:"clevis,omitempty"`
-	Device     *string      `json:"device,omitempty"`
-	Discard    *bool        `json:"discard,omitempty"`
-	KeyFile    Resource     `json:"keyFile,omitempty"`
-	Label      *string      `json:"label,omitempty"`
-	Name       string       `json:"name"`
-	Options    []LuksOption `json:"options,omitempty"`
-	UUID       *string      `json:"uuid,omitempty"`
-	WipeVolume *bool        `json:"wipeVolume,omitempty"`
+	Clevis      Clevis       `json:"clevis,omitempty"`
+	Device      *string      `json:"device,omitempty"`
+	Discard     *bool        `json:"discard,omitempty"`
+	KeyFile     Resource     `json:"keyFile,omitempty"`
+	Label       *string      `json:"label,omitempty"`
+	Name        string       `json:"name"`
+	OpenOptions []OpenOption `json:"openOptions,omitempty"`
+	Options     []LuksOption `json:"options,omitempty"`
+	UUID        *string      `json:"uuid,omitempty"`
+	WipeVolume  *bool        `json:"wipeVolume,omitempty"`
 }
 
 type LuksOption string
@@ -142,6 +143,8 @@ type NodeUser struct {
 	ID   *int    `json:"id,omitempty"`
 	Name *string `json:"name,omitempty"`
 }
+
+type OpenOption string
 
 type Partition struct {
 	GUID               *string `json:"guid,omitempty"`

--- a/docs/configuration-v3_2.md
+++ b/docs/configuration-v3_2.md
@@ -133,7 +133,7 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_label_** (string): the label of the luks device.
     * **_uuid_** (string): the uuid of the luks device.
-    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_options_** (list of strings): any additional options to be passed to `cryptsetup luksFormat`.
     * **_wipeVolume_** (boolean): whether or not to wipe the device before volume creation, see [the documentation on filesystems](operator-notes.md#filesystem-reuse-semantics) for more information.
     * **_clevis_** (object): describes the clevis configuration for the luks device.
       * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.

--- a/docs/configuration-v3_3.md
+++ b/docs/configuration-v3_3.md
@@ -133,7 +133,7 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_label_** (string): the label of the luks device.
     * **_uuid_** (string): the uuid of the luks device.
-    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_options_** (list of strings): any additional options to be passed to `cryptsetup luksFormat`.
     * **_wipeVolume_** (boolean): whether or not to wipe the device before volume creation, see [the documentation on filesystems](operator-notes.md#filesystem-reuse-semantics) for more information.
     * **_clevis_** (object): describes the clevis configuration for the luks device.
       * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.

--- a/docs/configuration-v3_4_experimental.md
+++ b/docs/configuration-v3_4_experimental.md
@@ -135,8 +135,9 @@ The Ignition configuration is a JSON document conforming to the following specif
         * **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
     * **_label_** (string): the label of the luks device.
     * **_uuid_** (string): the uuid of the luks device.
-    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_options_** (list of strings): any additional options to be passed to `cryptsetup luksFormat`.
     * **_discard_** (boolean): whether to issue discard commands to the underlying block device when blocks are freed. Enabling this improves performance and device longevity on SSDs and space utilization on thinly provisioned SAN devices, but leaks information about which disk blocks contain data. If omitted, it defaults to false.
+    * **_openOptions_** (list of strings): any additional options to be passed to `cryptsetup luksOpen`. Supported options will be persistently written to the luks volume.
     * **_wipeVolume_** (boolean): whether or not to wipe the device before volume creation, see [the documentation on filesystems](operator-notes.md#filesystem-reuse-semantics) for more information.
     * **_clevis_** (object): describes the clevis configuration for the luks device.
       * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.

--- a/docs/configuration-v3_4_experimental.md
+++ b/docs/configuration-v3_4_experimental.md
@@ -136,6 +136,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **_label_** (string): the label of the luks device.
     * **_uuid_** (string): the uuid of the luks device.
     * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_discard_** (boolean): whether to issue discard commands to the underlying block device when blocks are freed. Enabling this improves performance and device longevity on SSDs and space utilization on thinly provisioned SAN devices, but leaks information about which disk blocks contain data. If omitted, it defaults to false.
     * **_wipeVolume_** (boolean): whether or not to wipe the device before volume creation, see [the documentation on filesystems](operator-notes.md#filesystem-reuse-semantics) for more information.
     * **_clevis_** (object): describes the clevis configuration for the luks device.
       * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.

--- a/docs/operator-notes.md
+++ b/docs/operator-notes.md
@@ -138,7 +138,7 @@ If a child header has no value, the parent header with the same name will be rem
 
 Ignition has support for creating both purely key-file based LUKS2 devices as well as Tang/TPM2 backed (via clevis) devices.
 
-If a key-file is not specified one will be generated for the device. Key-files will be stored at `/etc/luks/<deviceName>` (this path can be overriden via build flags).
+If a key-file is not specified one will be generated for the device. Key-files will be stored at `/etc/luks/<deviceName>` (this path can be overridden via build flags).
 
 Ignition generates entries in `/etc/crypttab` for each device and expects that the operating system has hooks to be able to unlock the device (e.x.: `systemd-cryptsetup-generator`).
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ nav_order: 9
 
 - Ship aarch64 macOS ignition-validate binary in GitHub release artifacts
 - Allow enabling discard passthrough on LUKS devices _(3.4.0-exp)_
+- Allow specifying arbitrary LUKS open options _(3.4.0-exp)_
 
 ### Changes
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ nav_order: 9
 ### Features
 
 - Ship aarch64 macOS ignition-validate binary in GitHub release artifacts
+- Allow enabling discard passthrough on LUKS devices _(3.4.0-exp)_
 
 ### Changes
 

--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -250,7 +250,7 @@ func (s *stage) createLuks(config types.Config) error {
 
 		// open the device
 		if _, err := s.Logger.LogCmd(
-			exec.Command(distro.CryptsetupCmd(), "luksOpen", devAlias, luks.Name, "--key-file", keyFilePath),
+			exec.Command(distro.CryptsetupCmd(), luksOpenArgs(luks, keyFilePath)...),
 			"opening luks device %v", luks.Name,
 		); err != nil {
 			return fmt.Errorf("opening luks device: %v", err)
@@ -393,10 +393,21 @@ func (s *stage) reuseLuksDevice(luks types.Luks, keyFilePath string) error {
 
 	// open the device to make sure the keyfile is valid
 	if _, err := s.Logger.LogCmd(
-		exec.Command(distro.CryptsetupCmd(), "luksOpen", devAlias, luks.Name, "--key-file", keyFilePath),
+		exec.Command(distro.CryptsetupCmd(), luksOpenArgs(luks, keyFilePath)...),
 		"opening luks device %v", luks.Name,
 	); err != nil {
 		return fmt.Errorf("failed to open device using specified keyfile")
 	}
 	return nil
+}
+
+func luksOpenArgs(luks types.Luks, keyFilePath string) []string {
+	ret := []string{
+		"luksOpen",
+		execUtil.DeviceAlias(*luks.Device),
+		luks.Name,
+		"--key-file",
+		keyFilePath,
+	}
+	return ret
 }

--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -416,7 +416,7 @@ func luksOpenArgs(luks types.Luks, keyFilePath string) []string {
 		luks.Name,
 		"--key-file",
 		keyFilePath,
-		// store presence/absence of --allow-discards
+		// store presence/absence of --allow-discards and open options
 		"--persistent",
 	}
 	if util.IsTrue(luks.Discard) {
@@ -427,6 +427,10 @@ func luksOpenArgs(luks types.Luks, keyFilePath string) []string {
 		// really coming from).
 		// https://github.com/latchset/clevis/issues/286
 		ret = append(ret, "--allow-discards")
+	}
+	for _, opt := range luks.OpenOptions {
+		// support persisting other options too
+		ret = append(ret, string(opt))
 	}
 	return ret
 }


### PR DESCRIPTION
Discard improves performance and longevity on SSDs and space utilization on thinly-provisioned SAN devices, but also leaks information from LUKS.  It's a LUKS open-time option, not a create-time one, so it can't be enabled via the `options` field.  Add a spec field to enable it.

While we're here, add an `openOptions` spec field to allow configuring other options that can be persisted to the LUKS header.  Notably, `--perf-no_read_workqueue` and `--perf-no_write_workqueue` can improve performance.

Since `openOptions` is an escape hatch feature, unlike `discard`, we don't try to implement full option matching in the volume reuse semantics; we just update any reused volume to use the currently specified options.

For https://github.com/coreos/fedora-coreos-tracker/issues/1392.