### PR TITLE
disks: don't clobber LUKS1 volumes; fix spurious logs during LUKS volume reuse

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Avoid logging spurious error when a LUKS volume wasn't previously formatted
 - Fix reproducibility of systemd preset file in ignition-apply output
 - Clarify spec docs for `files`/`directories`/`links` `group` fields
 - Document that `user`/`group` fields aren't applied to hard links

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Don't overwrite LUKS1 volume when `storage.luks.wipeVolume` is false
 - Avoid logging spurious error when a LUKS volume wasn't previously formatted
 - Fix reproducibility of systemd preset file in ignition-apply output
 - Clarify spec docs for `files`/`directories`/`links` `group` fields


### PR DESCRIPTION
Ignition has never supported LUKS1, so we can't ever try to reuse a LUKS1 volume created by Ignition.  However, a LUKS1 volume may have been created outside of Ignition, in which case we would conclude that the volume was not LUKS and clobber it, causing data loss.  Detect this case and fail instead.

Also, if the partition wasn't previously formatted as a LUKS volume, cryptsetup is supposed to exit non-zero; that's why we're calling it.  The resulting log message was always spurious, but is now more visible since Ignition errors are shown by c-l-h-m.