### PR TITLE
Add support for Hyper-V platform

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Starting with this release, ignition-validate binaries are signed with the
 
 ### Features
 
+- Support Hyper-V platform
 
 ### Changes
 

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -15,6 +15,7 @@ Ignition is currently only supported for the following platforms:
 * [DigitalOcean] (`digitalocean`) - Ignition will read its configuration from the droplet userdata. Cloud SSH keys and network configuration are handled separately.
 * [Exoscale] (`exoscale`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Google Cloud] (`gcp`) - Ignition will read its configuration from the instance metadata entry named "user-data". Cloud SSH keys are handled separately.
+* [Microsoft Hyper-V] (`hyperv`) - Ignition will read its configuration from the `ignition.config` key in pool 0 of the Hyper-V Data Exchange Service (KVP). Values are limited to approximately 1 KiB of text, so Ignition can also read and concatenate multiple keys named `ignition.config.0`, `ignition.config.1`, and so on.
 * [IBM Cloud] (`ibmcloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, `arn:`, or `gs://` schemes to specify a remote config.
@@ -41,6 +42,7 @@ For most cloud providers, cloud SSH keys and custom network configuration are ha
 [DigitalOcean]: https://www.digitalocean.com/products/droplets/
 [Exoscale]: https://www.exoscale.com/compute/
 [Google Cloud]: https://cloud.google.com/compute
+[Microsoft Hyper-V]: https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/
 [IBM Cloud]: https://www.ibm.com/cloud/vpc
 [KubeVirt]: https://kubevirt.io
 [Nutanix]: https://www.nutanix.com/products/ahv

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -96,3 +96,8 @@ install() {
     # needed for openstack config drive support
     inst_rules 60-cdrom_id.rules
 }
+
+installkernel() {
+     # required by hyperv platform to read kvp from the kernel
+     instmods -c hv_utils
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/aws/aws-sdk-go v1.44.284
 	github.com/beevik/etree v1.2.0
+	github.com/containers/libhvee v0.2.0
 	github.com/coreos/go-semver v0.3.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/coreos/vcontext v0.0.0-20230201181013-d72178a18687

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/containers/libhvee v0.2.0 h1:6h7LdSvBt176oIdMXKkgxdoT/IVP+o/gkwgyjWzvEAo=
+github.com/containers/libhvee v0.2.0/go.mod h1:Zr2Qhnl5THW/HQjF1o8HmxXWjvHfJb8fvd0ThTzHMys=
 github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb h1:rmqyI19j3Z/74bIRhuC59RB442rXUazKNueVpfJPxg4=
 github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb/go.mod h1:rcFZM3uxVvdyNmsAV2jopgPD1cs5SPWJWU5dOz2LUnw=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=

--- a/internal/providers/hyperv/kvp.go
+++ b/internal/providers/hyperv/kvp.go
@@ -1,0 +1,106 @@
+// Copyright 2023 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hyperv
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/containers/libhvee/pkg/kvp"
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+	"github.com/coreos/vcontext/report"
+)
+
+const singleKey = "ignition.config"
+
+// Prefix for multiple config fragments to reassemble.  The suffix is a
+// sequential integer starting from 0.
+const splitKeyPrefix = "ignition.config."
+
+func init() {
+	platform.Register(platform.Provider{
+		Name:           "hyperv",
+		FetchWithFiles: fetchConfig,
+	})
+}
+
+func fetchConfig(f *resource.Fetcher) ([]types.File, types.Config, report.Report, error) {
+	var kvpFiles []types.File
+
+	// To read key-value pairs from the Windows host, the hv_util kernel
+	// module must be loaded to create the kernel device
+	_, err := f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "hv_utils"), "loading hv_utils kernel module")
+	if err != nil {
+		return nil, types.Config{}, report.Report{}, fmt.Errorf("loading hv_utils kernel module: %w", err)
+	}
+
+	keyValuePairs, err := kvp.GetKeyValuePairs()
+	if err != nil {
+		return nil, types.Config{}, report.Report{}, fmt.Errorf("reading key-value pairs: %w", err)
+	}
+
+	var ign string
+	kv, err := keyValuePairs[kvp.DefaultKVPPoolID].GetValueByKey(singleKey)
+	if err == nil {
+		f.Logger.Debug("found single KVP key")
+		ign = kv.Value
+	} else if err != kvp.ErrKeyNotFound {
+		return nil, types.Config{}, report.Report{}, fmt.Errorf("looking up single KVP key: %w", err)
+	}
+
+	if ign == "" {
+		ign, err = keyValuePairs.GetSplitKeyValues(splitKeyPrefix, kvp.DefaultKVPPoolID)
+		if err == nil {
+			f.Logger.Debug("found concatenated KVP keys")
+		} else if err != kvp.ErrNoKeyValuePairsFound {
+			return nil, types.Config{}, report.Report{}, fmt.Errorf("reassembling split config: %w", err)
+		}
+	}
+
+	// hv_kvp_daemon writes pools to the filesystem in /var/lib/hyperv.
+	// We've already read the pool data, and the host won't send it again
+	// on this boot, so we need to write the files ourselves.
+	for poolID := range keyValuePairs {
+		// hv_kvp_daemon writes the pool files with mode 644 in a
+		// directory with mode 755.  This isn't safe for us, since
+		// it leaks the config to non-root users, including on
+		// subsequent boots.
+		// - There's no API that lets us delete the KVPs from the host.
+		// - We could filter out the KVPs when writing the pools,
+		//   but if hv_kvp_daemon runs on subsequent boots, it could
+		//   re-add them.
+		// - The caller doesn't give us a way to create directory
+		//   entries, only files; and we probably shouldn't set
+		//   restrictive permissions on /var/lib/hyperv because it
+		//   hypothetically might be used for other purposes.
+		// Avoid the issue by setting the files to mode 600.
+		// hv_kvp_daemon won't change the mode afterward.
+		poolPath := filepath.Join(kvp.DefaultKVPFilePath, fmt.Sprintf("%s%d", kvp.DefaultKVPBaseName, poolID))
+		kvpFiles = append(kvpFiles, util.MakeProviderOutputFile(poolPath, 0600, keyValuePairs.EncodePoolFile(poolID)))
+	}
+
+	if ign == "" {
+		return kvpFiles, types.Config{}, report.Report{}, errors.ErrEmpty
+	}
+
+	c, r, err := util.ParseConfig(f.Logger, []byte(ign))
+	return kvpFiles, c, r, err
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/exoscale"
 	_ "github.com/coreos/ignition/v2/internal/providers/file"
 	_ "github.com/coreos/ignition/v2/internal/providers/gcp"
+	_ "github.com/coreos/ignition/v2/internal/providers/hyperv"
 	_ "github.com/coreos/ignition/v2/internal/providers/ibmcloud"
 	_ "github.com/coreos/ignition/v2/internal/providers/kubevirt"
 	_ "github.com/coreos/ignition/v2/internal/providers/metal"

--- a/vendor/github.com/containers/libhvee/LICENSE
+++ b/vendor/github.com/containers/libhvee/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/containers/libhvee/pkg/kvp/config.go
+++ b/vendor/github.com/containers/libhvee/pkg/kvp/config.go
@@ -1,0 +1,143 @@
+package kvp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var (
+	// ErrUnableToWriteToKVP is used when we are unable to write to the kernel
+	// device for hyperv
+	ErrUnableToWriteToKVP = errors.New("failed to write to hv_kvp")
+	// ErrUnableToReadFromKVP is used when we are unable to read from the kernel
+	// device for hyperv
+	ErrUnableToReadFromKVP = errors.New("failed to read from hv_kvp")
+	// ErrNoKeyValuePairsFound means we were unable to find key-value pairs as passed
+	// from the hyperv host to this guest.
+	ErrNoKeyValuePairsFound = errors.New("unable to find kvp keys")
+	// ErrKeyNotFound means we could not find the key in information read
+	ErrKeyNotFound = errors.New("unable to find key")
+)
+
+const (
+	// Timeout amount of time in ms to poll the hyperv kernel device
+	Timeout                   = 1000
+	OpRegister1               = 100
+	HvSOk                     = 0
+	HvEFail                   = 0x80004005
+	HvKvpExchangeMaxValueSize = 2048
+	HvKvpExchangeMaxKeySize   = 512
+	OpSet                     = 1
+	// KernelDevice is the hyperv kernel device used for communicating key-value pairs
+	// on hyperv between the host and guest
+	KernelDevice = "/dev/vmbus/hv_kvp"
+	// DefaultKVPPoolID is where Windows host write to for Linux VMs
+	DefaultKVPPoolID               = 0
+	DefaultKVPBaseName             = ".kvp_pool_"
+	DefaultKVPFilePath             = "/var/lib/hyperv"
+	DefaultKVPFileWritePermissions = 0644
+)
+
+type hvKvpExchgMsgValue struct {
+	valueType uint32
+	keySize   uint32
+	valueSize uint32
+	key       [HvKvpExchangeMaxKeySize]uint8
+	value     [HvKvpExchangeMaxValueSize]uint8
+}
+
+type hvKvpMsgSet struct {
+	data hvKvpExchgMsgValue
+}
+
+type hvKvpHdr struct {
+	operation uint8
+	pool      uint8
+	pad       uint16
+}
+
+type hvKvpMsg struct {
+	kvpHdr hvKvpHdr
+	kvpSet hvKvpMsgSet
+	// unused is needed to get to the same struct size as the C version.
+	unused [4856]byte
+}
+
+type hvKvpMsgRet struct {
+	error  int
+	kvpSet hvKvpMsgSet
+	// unused is needed to get to the same struct size as the C version.
+	unused [4856]byte
+}
+
+type PoolID uint8
+
+type ValuePair struct {
+	Key   string
+	Value string
+}
+
+type ValuePairs []ValuePair
+
+func (vp ValuePairs) GetValueByKey(key string) (ValuePair, error) {
+	for _, vp := range vp {
+		if key == vp.Key {
+			return vp, nil
+		}
+	}
+	return ValuePair{}, ErrKeyNotFound
+}
+
+type KeyValuePair map[PoolID]ValuePairs
+
+func (kv KeyValuePair) EncodePoolFile(poolID PoolID) (poolFile []byte) {
+	poolEntries, exists := kv[poolID]
+	if !exists {
+		return
+	}
+	for _, entry := range poolEntries {
+		// These have to be padded with nulls
+		emptyKey := make([]byte, HvKvpExchangeMaxKeySize)
+		emptyVal := make([]byte, HvKvpExchangeMaxValueSize)
+		_ = copy(emptyKey, entry.Key)
+		_ = copy(emptyVal, entry.Value)
+		poolFile = append(poolFile, emptyKey...)
+		poolFile = append(poolFile, emptyVal...)
+	}
+	return
+}
+
+func (kv KeyValuePair) append(poolID PoolID, key, value string) {
+	vps, exists := kv[poolID]
+	vp := ValuePair{
+		Key:   key,
+		Value: value,
+	}
+	if !exists {
+		kv[poolID] = ValuePairs{vp}
+		return
+	}
+	kv[poolID] = append(vps, vp)
+}
+
+func (kv KeyValuePair) WriteToFS(path string) error {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+	for poolID := range kv {
+		fqWritePath := filepath.Join(path, fmt.Sprintf("%s%d", DefaultKVPBaseName, poolID))
+		if len(kv[poolID]) < 1 {
+			// need to set permissions so ...
+			if err := os.WriteFile(fqWritePath, []byte{}, DefaultKVPFileWritePermissions); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.WriteFile(fqWritePath, kv.EncodePoolFile(poolID), DefaultKVPFileWritePermissions); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/containers/libhvee/pkg/kvp/kvp.go
+++ b/vendor/github.com/containers/libhvee/pkg/kvp/kvp.go
@@ -1,0 +1,144 @@
+//go:build linux
+
+package kvp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// readKvpData reads all key-value pairs from the hyperv kernel device and creates
+// a map representation of them
+func readKvpData() (KeyValuePair, error) {
+	ret := make(KeyValuePair)
+	for i := 0; i < 5; i++ {
+		// We need to seed the poolids
+		ret[PoolID(i)] = ValuePairs{}
+	}
+	kvp, err := unix.Open(KernelDevice, unix.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(kvp)
+
+	var (
+		hvMsg    hvKvpMsg
+		hvMsgRet hvKvpMsgRet
+	)
+
+	const sizeOf = int(unsafe.Sizeof(hvMsg))
+
+	var (
+		asByteSlice    = (*(*[sizeOf]byte)(unsafe.Pointer(&hvMsg)))[:]
+		retAsByteSlice = (*(*[sizeOf]byte)(unsafe.Pointer(&hvMsgRet)))[:]
+	)
+
+	hvMsg.kvpHdr.operation = OpRegister1
+
+	l, err := unix.Write(kvp, asByteSlice)
+	if err != nil {
+		return nil, err
+	}
+	if l != sizeOf {
+		return nil, ErrUnableToWriteToKVP
+	}
+
+next:
+	for {
+		var pfd unix.PollFd
+		pfd.Fd = int32(kvp)
+		pfd.Events = unix.POLLIN
+		pfd.Revents = 0
+
+		howMany, err := unix.Poll([]unix.PollFd{pfd}, Timeout)
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			return nil, err
+		}
+
+		if howMany == 0 {
+			return ret, nil
+		}
+
+		l, err := unix.Read(kvp, asByteSlice)
+		if err != nil {
+			if err == unix.EAGAIN || err == unix.EINTR || err == unix.EWOULDBLOCK {
+				continue
+			}
+			return nil, err
+		}
+		if l != sizeOf {
+			return nil, ErrUnableToReadFromKVP
+		}
+
+		switch hvMsg.kvpHdr.operation {
+		case OpRegister1:
+			continue next
+		case OpSet:
+			// on the next two variables, we are cutting the last byte because otherwise
+			// it is padded and key lookups fail
+			key := hvMsg.kvpSet.data.key[:hvMsg.kvpSet.data.keySize-1]
+			value := hvMsg.kvpSet.data.value[:hvMsg.kvpSet.data.valueSize-1]
+
+			poolID := PoolID(hvMsg.kvpHdr.pool)
+			ret.append(poolID, string(key), string(value))
+
+			hvMsgRet.error = HvSOk
+		default:
+			hvMsgRet.error = HvEFail
+		}
+
+		l, err = unix.Write(kvp, retAsByteSlice)
+		if err != nil {
+			return nil, err
+		}
+		if l != sizeOf {
+			return nil, ErrUnableToWriteToKVP
+		}
+	}
+}
+
+// GetKeyValuePairs reads the key value pairs from the wmi hyperv kernel device
+// and returns them in map form.  the map value is a ValuePair which contains
+// the value string and the poolid
+func GetKeyValuePairs() (KeyValuePair, error) {
+	return readKvpData()
+}
+
+// GetSplitKeyValues reassembles split KVPs from a key prefix and pool_id and
+// returns the assembled split value.
+func (kv KeyValuePair) GetSplitKeyValues(key string, pool PoolID) (string, error) {
+	var (
+		parts   []string
+		counter = 0
+	)
+
+	for {
+		wantKey := fmt.Sprintf("%s%d", key, counter)
+		entries, exists := kv[pool]
+		if !exists {
+			// No entries for the pool
+			break
+		}
+		entry, err := entries.GetValueByKey(wantKey)
+		if err != nil {
+			if errors.Is(err, ErrKeyNotFound) {
+				break
+			}
+
+			return "", err
+		}
+		parts = append(parts, entry.Value)
+		counter++
+	}
+	if len(parts) < 1 {
+		return "", ErrNoKeyValuePairsFound
+	}
+	return strings.Join(parts, ""), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,6 +76,9 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beevik/etree v1.2.0
 ## explicit; go 1.13
 github.com/beevik/etree
+# github.com/containers/libhvee v0.2.0
+## explicit; go 1.18
+github.com/containers/libhvee/pkg/kvp
 # github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb
 ## explicit; go 1.18
 github.com/coreos/go-json


### PR DESCRIPTION
Read the Ignition config from the Hyper-V Data Exchange Service ("KVP"), which can be configured on the host via WMI.

KVP on Linux is normally handled by a combination of a kernel module (`hv_utils`) and a daemon shipped with the kernel source (`hv_kvp_daemon`).  The latter writes world-readable files to `/var/lib/hyperv`; these contain an array of binary structs.  The host-guest protocol has the guest OS as the passive peer; `hv_kvp_daemon` connects and is sent all the host's key-value pairs.

We don't want to require `hv_kvp_daemon` as a dependency, so we use a pure Go reimplementation (libhvee) that supports just enough of the protocol to receive the KVPs.  However, if we disconnect and then `hv_kvp_daemon` reconnects later, the host won't re-send the KVPs, so we also need to save them to `/var/lib/hyperv` in the same format used by the daemon.  Unlike the daemon, we set the files to mode 600, since the Ignition config is potentially sensitive; the daemon does not change the permissions of existing files.

Small configs can be stored in the `ignition.config` KVP.  However, individual values have severe length limitations (~1 KiB of UTF-8), so we also support concatenating `ignition.config.0`, `ignition.config.1`, etc.  to form a larger config.

See also:
- https://github.com/coreos/fedora-coreos-tracker/issues/1411
- https://github.com/coreos/fedora-coreos-tracker/issues/1424