### PR TITLE
Continue with empty config on missing QEMU device

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,7 @@ nav_order: 9
 - Install ignition-apply in `/usr/libexec`
 - Convert `NEWS` to Markdown and move to docs site
 - Fail if files/links/dirs conflict with systemd units or dropins
+- Continue with empty config if QEMU blockdev is missing
 - Require Go 1.18+
 
 ### Bug fixes

--- a/internal/providers/qemu/qemu_blockdev.go
+++ b/internal/providers/qemu/qemu_blockdev.go
@@ -83,7 +83,8 @@ func fetchConfigFromBlockDevice(logger *log.Logger) ([]byte, error) {
 			return nil, err
 		}
 	case <-time.After(blockDeviceTimeout):
-		return nil, fmt.Errorf("timed out after %v waiting for block device %q to appear", blockDeviceTimeout, ignitionBlockDevicePath)
+		logger.Info("timed out after %v waiting for block device %q to appear. Ignoring...", blockDeviceTimeout, ignitionBlockDevicePath)
+		return util.ParseConfig(logger, []byte{})
 	}
 
 	return bytes.TrimRight(data, "\x00"), nil


### PR DESCRIPTION
The two QEMU provider implementations (fwcfg for platforms with native support and blockdev for the others) have slightly different behaviour: If fwcfg doesn't contain any configuration, it will just skip ("QEMU firmware config was not found. Ignoring..."). The blockdev provider would error out if it can't read the configuration.

Change the behavior of the blockdev provider to match the fwcfg one and continue with an empty configuration if the device is not there.