### PR TITLE
platform: allow provider fetch to save files to write from files stage

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -296,7 +296,7 @@ func (e *Engine) fetchProviderConfig() (types.Config, error) {
 	var err error
 	var providerKey string
 	for _, platformConfig := range platformConfigs {
-		cfg, r, err = platformConfig.Fetch(e.Fetcher)
+		cfg, r, err = platformConfig.Fetch(e.Fetcher, e.State)
 		if err != platform.ErrNoProvider {
 			// successful, or failed on another error
 			providerKey = platformConfig.Name()

--- a/internal/exec/stages/files/files.go
+++ b/internal/exec/stages/files/files.go
@@ -108,6 +108,11 @@ func (s stage) runImpl(config types.Config, isApply bool, applyIgnoreUnsupported
 			return fmt.Errorf("creating crypttab entries: %v", err)
 		}
 
+		// !isApply: we don't support arbitrary providers
+		if err := s.createProviderOutputFiles(); err != nil {
+			return fmt.Errorf("creating provider state files: %v", err)
+		}
+
 		// !isApply: we support running Ignition multiple times
 		if err := s.createResultFile(); err != nil {
 			return fmt.Errorf("creating result file: %v", err)

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -131,6 +131,22 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 	return nil
 }
 
+// createProviderOutputFiles writes out any files saved in state by
+// provider fetch.
+func (s *stage) createProviderOutputFiles() error {
+	var entries []filesystemEntry
+	for _, file := range s.State.ProviderOutputFiles {
+		path, err := s.JoinPath(file.Path)
+		if err != nil {
+			return fmt.Errorf("calculating path for %q: %w", file.Path, err)
+		}
+		entry := fileEntry(file)
+		entry.Path = path
+		entries = append(entries, entry)
+	}
+	return s.createEntries(entries)
+}
+
 // createResultFile creates a report recording some details about the
 // Ignition run.
 func (s *stage) createResultFile() error {

--- a/internal/providers/util/file.go
+++ b/internal/providers/util/file.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
+
+	"github.com/vincent-petithory/dataurl"
+)
+
+// MakeProviderOutputFile is a helper function to create an output File for
+// FetchWithFiles.
+func MakeProviderOutputFile(path string, mode int, data []byte) types.File {
+	url := dataurl.EncodeBytes(data)
+	return types.File{
+		Node: types.Node{
+			Path: path,
+			// Ignition is not designed to run twice, but don't
+			// introduce a hard failure if it does
+			Overwrite: util.BoolToPtr(true),
+		},
+		FileEmbedded1: types.FileEmbedded1{
+			Contents: types.Resource{
+				Source: &url,
+			},
+			Mode: &mode,
+		},
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
 )
 
 type State struct {
@@ -35,6 +37,10 @@ type State struct {
 	// created by the mount stage so the files stage can chown them
 	// when creating users.
 	NotatedDirectories []string `json:"notatedDirectories"`
+	// Files generated during provider config fetch, to be written to
+	// the filesystem during files stage.  This is for special
+	// circumstances only.
+	ProviderOutputFiles []types.File `json:"providerOutputFiles"`
 }
 
 type FetchedConfig struct {


### PR DESCRIPTION
The Hyper-V provider will need to write out state for `hv_kvp_daemon`.  Add a way for provider fetch functions to return `[]types.File` which will be saved in `State` and written out during files stage.  Also add a utility function a provider can use to create a `types.File`.

Since this functionality should not be used by most providers, avoid adding an extra argument or return value to every fetch function.  Instead, define an alternative fetch function that will be used if declared in the registration.

Tested synthetically by modifying the `qemu` provider.