### PR TITLE
docs: improve rendering of specification files on GH pages

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,9 @@
+#spec-docs ~ ul {
+  ul {
+    border-left: 1px solid $grey-lt-300;
+  }
+
+  li::before {
+    margin-left: -0.8em;
+  }
+}

--- a/docs/configuration-v3_0.md
+++ b/docs/configuration-v3_0.md
@@ -8,6 +8,8 @@ nav_order: 49
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+
 * **ignition** (object): metadata about the configuration itself.
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.0.0`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (object): options related to the configuration.

--- a/docs/configuration-v3_1.md
+++ b/docs/configuration-v3_1.md
@@ -8,6 +8,8 @@ nav_order: 48
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+
 * **ignition** (object): metadata about the configuration itself.
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.1.0`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (object): options related to the configuration.

--- a/docs/configuration-v3_2.md
+++ b/docs/configuration-v3_2.md
@@ -8,6 +8,8 @@ nav_order: 47
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+
 * **ignition** (object): metadata about the configuration itself.
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.2.0`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (object): options related to the configuration.

--- a/docs/configuration-v3_3.md
+++ b/docs/configuration-v3_3.md
@@ -8,6 +8,8 @@ nav_order: 46
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+
 * **ignition** (object): metadata about the configuration itself.
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.3.0`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (object): options related to the configuration.

--- a/docs/configuration-v3_4.md
+++ b/docs/configuration-v3_4.md
@@ -8,6 +8,8 @@ nav_order: 45
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+
 * **ignition** (object): metadata about the configuration itself.
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.4.0`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (object): options related to the configuration.

--- a/docs/configuration-v3_5_experimental.md
+++ b/docs/configuration-v3_5_experimental.md
@@ -10,6 +10,8 @@ _NOTE_: This pre-release version of the specification is experimental and is sub
 
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+
 * **ignition** (object): metadata about the configuration itself.
   * **version** (string): the semantic version number of the spec. The spec version must be compatible with the latest version (`3.5.0-experimental`). Compatibility requires the major versions to match and the spec version be less than or equal to the latest version. `-experimental` versions compare less than the final version with the same number, and previous experimental versions are not accepted.
   * **_config_** (object): options related to the configuration.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ nav_order: 9
 
 ### Changes
 
+- Improve rendering of spec docs on docs site
 
 ### Bug fixes
 

--- a/internal/doc/header.md
+++ b/internal/doc/header.md
@@ -12,3 +12,5 @@ _NOTE_: This pre-release version of the specification is experimental and is sub
 {{ end -}}
 The Ignition configuration is a JSON document conforming to the following specification, with **_italicized_** entries being optional:
 
+<div id="spec-docs"></div>
+


### PR DESCRIPTION
As discussed in coreos/butane#183 the rendering changes for the specification files also apply to Ignition.