### PR TITLE
internal/exec/util: check if unit exists before disabling

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,7 @@ Starting with this release, ignition-validate binaries are signed with the
 - Document that `hash` fields describe decompressed data
 - Clarify documentation of `passwordHash` fields
 - Correctly document Tang `advertisement` field as optional
+- Fix failure disabling nonexistent unit with systemd ≥ 252
 
 ### Test changes
 

--- a/internal/exec/util/unit.go
+++ b/internal/exec/util/unit.go
@@ -153,6 +153,12 @@ func (ut Util) EnableUnit(enabledUnit string) error {
 }
 
 func (ut Util) DisableUnit(disabledUnit string) error {
+	// check if the unit is currently enabled to see if we need to disable it
+	// if it's not enabled or does not exist, we don't need to do anything
+	args := []string{"--root", ut.DestDir, "is-enabled", disabledUnit}
+	if err := exec.Command(distro.SystemctlCmd(), args...).Run(); err != nil {
+		return nil
+	}
 	// We need to delete any enablement symlinks for a unit before sending it to a
 	// preset directive. This will help to disable that unit completely.
 	// For more information: https://github.com/coreos/fedora-coreos-tracker/issues/392


### PR DESCRIPTION
Ignition depends on `systemctl disable` for disabling units. Currently
if the unit does not exist `systemctl disable` exits 1; however, before
systemd 252 `systemctl disable` exits 0 if `--root` is specified. Since
Ignition depends on systemctl's exit code the new behavior caused a
regression, causing the unit.remove.symlinks blackbox test to fail with:

    removing enablement symlink(s) for "enoent.service": cannot remove symlink(s) for enoent.service: exit status 1: "Failed to disable unit, unit enoent.service does not exist.\n"

Before disabling a unit, use `systemctl is-enabled` to verify that the
unit exists and is enabled.

Fixes coreos#1614.
