### PR TITLE
config/doc: replace `unless:` with `Generate()` callback function

### DIFF
--- a/config/doc/generate.go
+++ b/config/doc/generate.go
@@ -45,14 +45,6 @@ func (gen generator) descendNode(node DocNode, typ reflect.Type, path []string) 
 			continue
 		}
 		// possibly skip
-		skip, err := child.Skip.matches(gen.vers)
-		if err != nil {
-			return err
-		}
-		if util.IsTrue(skip) {
-			delete(fieldsByTag, child.Name)
-			continue
-		}
 		if gen.ignore != nil && gen.ignore(append(path, child.Name)) {
 			delete(fieldsByTag, child.Name)
 			continue

--- a/config/doc/generate.go
+++ b/config/doc/generate.go
@@ -23,7 +23,12 @@ import (
 	"github.com/coreos/ignition/v2/config/util"
 )
 
-func descendNode(vers VariantVersions, node DocNode, typ reflect.Type, level int, w io.Writer) error {
+type generator struct {
+	vers VariantVersions
+	w    io.Writer
+}
+
+func (gen generator) descendNode(node DocNode, typ reflect.Type, level int) error {
 	if typ.Kind() != reflect.Struct {
 		return fmt.Errorf("not a struct: %v (%v)", typ.Name(), typ.Kind())
 	}
@@ -39,7 +44,7 @@ func descendNode(vers VariantVersions, node DocNode, typ reflect.Type, level int
 			continue
 		}
 		// possibly skip
-		skip, err := child.Skip.matches(vers)
+		skip, err := child.Skip.matches(gen.vers)
 		if err != nil {
 			return err
 		}
@@ -48,7 +53,7 @@ func descendNode(vers VariantVersions, node DocNode, typ reflect.Type, level int
 			continue
 		}
 		// check if the field is required
-		required, err := child.required(vers)
+		required, err := child.required(gen.vers)
 		if err != nil {
 			return nil
 		}
@@ -60,15 +65,15 @@ func descendNode(vers VariantVersions, node DocNode, typ reflect.Type, level int
 		if !*required {
 			optional = "_"
 		}
-		desc, err := child.renderDescription(vers)
+		desc, err := child.renderDescription(gen.vers)
 		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(w, "%s* **%s%s%s** (%s): %s\n", strings.Repeat("  ", level), optional, child.Name, optional, typeName(field.Type), desc); err != nil {
+		if _, err := fmt.Fprintf(gen.w, "%s* **%s%s%s** (%s): %s\n", strings.Repeat("  ", level), optional, child.Name, optional, typeName(field.Type), desc); err != nil {
 			return err
 		}
 		// recurse
-		if err := descend(vers, child, field.Type, level+1, w); err != nil {
+		if err := gen.descend(child, field.Type, level+1); err != nil {
 			return err
 		}
 		// delete from map to keep track of fields we've seen
@@ -81,20 +86,20 @@ func descendNode(vers VariantVersions, node DocNode, typ reflect.Type, level int
 	return nil
 }
 
-func descend(vers VariantVersions, node DocNode, typ reflect.Type, level int, w io.Writer) error {
+func (gen generator) descend(node DocNode, typ reflect.Type, level int) error {
 	kind := typ.Kind()
 	switch {
 	case util.IsPrimitive(kind):
 		return nil
 	case kind == reflect.Struct:
-		return descendNode(vers, node, typ, level, w)
+		return gen.descendNode(node, typ, level)
 	case kind == reflect.Slice, kind == reflect.Ptr:
-		return descend(vers, node, typ.Elem(), level, w)
+		return gen.descend(node, typ.Elem(), level)
 	case kind == reflect.Map:
 		if !util.IsPrimitive(typ.Key().Kind()) {
 			return fmt.Errorf("%v is map with non-primitive key type %v", typ.Name(), typ.Key())
 		}
-		return descend(vers, node, typ.Elem(), level, w)
+		return gen.descend(node, typ.Elem(), level)
 	default:
 		return fmt.Errorf("%v has kind %v", typ.Name(), kind)
 	}

--- a/config/doc/generate.go
+++ b/config/doc/generate.go
@@ -24,8 +24,9 @@ import (
 )
 
 type generator struct {
-	vers VariantVersions
-	w    io.Writer
+	vers   VariantVersions
+	ignore IgnoreFunc
+	w      io.Writer
 }
 
 func (gen generator) descendNode(node DocNode, typ reflect.Type, path []string) error {
@@ -49,6 +50,10 @@ func (gen generator) descendNode(node DocNode, typ reflect.Type, path []string) 
 			return err
 		}
 		if util.IsTrue(skip) {
+			delete(fieldsByTag, child.Name)
+			continue
+		}
+		if gen.ignore != nil && gen.ignore(append(path, child.Name)) {
 			delete(fieldsByTag, child.Name)
 			continue
 		}

--- a/config/doc/schema.go
+++ b/config/doc/schema.go
@@ -94,7 +94,7 @@ func (comps Components) Generate(vers VariantVersions, config any, w io.Writer) 
 		vers: vers,
 		w:    w,
 	}
-	return gen.descendNode(root, reflect.TypeOf(config), 0)
+	return gen.descendNode(root, reflect.TypeOf(config), nil)
 }
 
 func (comps Components) resolve() (DocNode, error) {

--- a/config/doc/schema.go
+++ b/config/doc/schema.go
@@ -43,7 +43,6 @@ type DocNode struct {
 	Description string      `yaml:"desc"`
 	Required    *bool       `yaml:"required"`
 	RequiredIf  Constraints `yaml:"required-if"`
-	Skip        Constraints `yaml:"unless"`
 	Transforms  []Transform `yaml:"transforms"`
 	Children    []DocNode   `yaml:"children"`
 
@@ -249,7 +248,6 @@ func (node *DocNode) merge(override DocNode) error {
 		node.Required = nil
 		node.RequiredIf = append(node.RequiredIf, override.RequiredIf...)
 	}
-	node.Skip = append(node.Skip, override.Skip...)
 	node.Transforms = append(node.Transforms, override.Transforms...)
 	if override.Component != "" {
 		node.Component = override.Component

--- a/config/doc/schema.go
+++ b/config/doc/schema.go
@@ -71,6 +71,9 @@ type Constraint struct {
 
 type VariantVersions map[string]semver.Version
 
+// takes a slice of path elements, returns whether to ignore the subtree
+type IgnoreFunc func([]string) bool
+
 func IgnitionComponents() (Components, error) {
 	return ParseComponents(bytes.NewBuffer(ignitionDocs))
 }
@@ -85,14 +88,15 @@ func ParseComponents(r io.Reader) (Components, error) {
 	return comps, nil
 }
 
-func (comps Components) Generate(vers VariantVersions, config any, w io.Writer) error {
+func (comps Components) Generate(vers VariantVersions, config any, ignore IgnoreFunc, w io.Writer) error {
 	root, err := comps.resolve()
 	if err != nil {
 		return err
 	}
 	gen := generator{
-		vers: vers,
-		w:    w,
+		vers:   vers,
+		ignore: ignore,
+		w:      w,
 	}
 	return gen.descendNode(root, reflect.TypeOf(config), nil)
 }

--- a/config/doc/schema.go
+++ b/config/doc/schema.go
@@ -90,7 +90,11 @@ func (comps Components) Generate(vers VariantVersions, config any, w io.Writer) 
 	if err != nil {
 		return err
 	}
-	return descendNode(vers, root, reflect.TypeOf(config), 0, w)
+	gen := generator{
+		vers: vers,
+		w:    w,
+	}
+	return gen.descendNode(root, reflect.TypeOf(config), 0)
 }
 
 func (comps Components) resolve() (DocNode, error) {

--- a/internal/doc/main.go
+++ b/internal/doc/main.go
@@ -106,7 +106,7 @@ func generate(dir string) error {
 		vers := doc.VariantVersions{
 			doc.IGNITION_VARIANT: ver,
 		}
-		if err := comps.Generate(vers, c.config, f); err != nil {
+		if err := comps.Generate(vers, c.config, nil, f); err != nil {
 			return fmt.Errorf("generating doc for %s: %w", c.version, err)
 		}
 	}


### PR DESCRIPTION
Allow the `Generate()` caller to specify a callback that receives a slice of path components and returns true if the subtree should be ignored.  This will allow Butane to integrate its field filtering logic into doc generation, rather than separately hardcoding `unless:` directives into the doc YAML.

This is an API change but not a breaking one, since `config/doc` hasn't shipped in a release.