### PR TITLE
dracut: make `hv_utils` module optional

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,13 @@ nav_order: 9
 
 
 
+## Ignition 2.16.2 (2023-07-12)
+
+### Bug fixes
+
+- Fix Dracut module installation on arches other than x86 and aarch64
+
+
 ## Ignition 2.16.1 (2023-07-10)
 
 ### Bug fixes

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -99,5 +99,5 @@ install() {
 
 installkernel() {
      # required by hyperv platform to read kvp from the kernel
-     instmods -c hv_utils
+     instmods hv_utils
 }


### PR DESCRIPTION
It only exists on x86 and aarch64.  The conventional way to handle this is to omit the `-c` flag, silently ignoring installation failures.

Fixes https://github.com/coreos/ignition/issues/1671.  Fixes #1555.