### PR TITLE
docs/operator-notes: Note paths that should not be used b/c of switch_root

### DIFF
--- a/docs/operator-notes.md
+++ b/docs/operator-notes.md
@@ -62,6 +62,14 @@ If `wipeFilesystem` is set to false, Ignition will then attempt to reuse the exi
 
 When resolving paths, Ignition follows symlinks on all but the last element of a path. This ensures existing symlinks on a filesystem can be overwritten while still following symlinks as expected. When writing files, links, or directories, Ignition does not allow following symlinks outside the specified filesystem. When writing files, links, or directories on the `root` filesystem, Ignition follows symlinks as if it were executing in that root; a symlink to `/etc` is followed to `/etc` on the `root` filesystem. When writing files, links, or directories to any other filesystem, Ignition fails if it tries to follow a symlink outside that filesystem.
 
+## Making changes to `/proc`, `/sys`, `/dev`, `/tmp` or `/run`
+
+To create files, directories or symlinks in `/proc`, `/sys` or `/dev`, you should use [sysctl.d config files](https://www.mankier.com/5/sysctl.d) or [udev rules](https://www.mankier.com/7/udev).
+
+Similarly, to make changes under the `/tmp` or `/run` paths, you should use [tmpfiles.d config files](https://www.mankier.com/5/tmpfiles.d).
+
+Those paths are expected to be mount points for temporary (`/tmp`) or virtual (`/proc`, `/sys`, `/dev`) filesystems and at the time Ignition runs, none of those paths are mounted. Using Ignition to write to those paths will thus not have the desired effect.
+
 ## SELinux
 
 Ignition fully supports distributions which have [SELinux][selinux] enabled. It requires that the distribution ships the [`setfiles`][setfiles] utility. The kernel must be at least v5.5 or alternatively have [this patch](https://lore.kernel.org/selinux/20190912133007.27545-1-jlebon@redhat.com/T/#u) backported.


### PR DESCRIPTION
I learned this the hard way (see https://github.com/flatcar/Flatcar/discussions/1152), and thought it would be useful to have in the documentation.

Feedback and edits welcome!