### PR TITLE
providers/hetzner: add support for Hetzner Cloud

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ nav_order: 9
 
 ### Features
 
+- Support Hetzner Cloud
 
 ### Changes
 

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -15,6 +15,7 @@ Ignition is currently only supported for the following platforms:
 * [DigitalOcean] (`digitalocean`) - Ignition will read its configuration from the droplet userdata. Cloud SSH keys and network configuration are handled separately.
 * [Exoscale] (`exoscale`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Google Cloud] (`gcp`) - Ignition will read its configuration from the instance metadata entry named "user-data". Cloud SSH keys are handled separately.
+* [Hetzner Cloud] (`hetzner`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Microsoft Hyper-V] (`hyperv`) - Ignition will read its configuration from the `ignition.config` key in pool 0 of the Hyper-V Data Exchange Service (KVP). Values are limited to approximately 1 KiB of text, so Ignition can also read and concatenate multiple keys named `ignition.config.0`, `ignition.config.1`, and so on.
 * [IBM Cloud] (`ibmcloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
@@ -42,6 +43,7 @@ For most cloud providers, cloud SSH keys and custom network configuration are ha
 [DigitalOcean]: https://www.digitalocean.com/products/droplets/
 [Exoscale]: https://www.exoscale.com/compute/
 [Google Cloud]: https://cloud.google.com/compute
+[Hetzner Cloud]: https://www.hetzner.com/cloud
 [Microsoft Hyper-V]: https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/
 [IBM Cloud]: https://www.ibm.com/cloud/vpc
 [KubeVirt]: https://kubevirt.io

--- a/internal/providers/hetzner/hetzner.go
+++ b/internal/providers/hetzner/hetzner.go
@@ -1,0 +1,54 @@
+// Copyright 2023 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The hetzner provider fetches a remote configuration from the Hetzner Cloud
+// user-data metadata service URL.
+
+package hetzner
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	userdataURL = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "hetzner/v1/userdata",
+	}
+)
+
+func init() {
+	platform.Register(platform.Provider{
+		Name:  "hetzner",
+		Fetch: fetchConfig,
+	})
+}
+
+func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataURL, resource.FetchOptions{})
+
+	if err != nil && err != resource.ErrNotFound {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/exoscale"
 	_ "github.com/coreos/ignition/v2/internal/providers/file"
 	_ "github.com/coreos/ignition/v2/internal/providers/gcp"
+	_ "github.com/coreos/ignition/v2/internal/providers/hetzner"
 	_ "github.com/coreos/ignition/v2/internal/providers/hyperv"
 	_ "github.com/coreos/ignition/v2/internal/providers/ibmcloud"
 	_ "github.com/coreos/ignition/v2/internal/providers/kubevirt"


### PR DESCRIPTION
* Add Hetzner Cloud as a provider
* Userdata endpoint is http://169.254.169.254/hetzner/v1/userdata

---

Figured out this is actually trivial, so here's a PR.

Supersedes #667 and #1262 which I cannot push commits to.

Relates: https://github.com/coreos/fedora-coreos-tracker/issues/1324