### PR TITLE
sgdisk: Run partx after partition changes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,7 +10,11 @@ nav_order: 9
 
 ### Features
 
+- Support partitioning disk with mounted partitions
+
 ### Changes
+
+- The Dracut module now installs partx
 
 ### Bug fixes
 

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -39,6 +39,7 @@ install() {
         mkfs.fat \
         mkfs.xfs \
         mkswap \
+        partx \
         sgdisk \
         useradd \
         userdel \

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -36,6 +36,7 @@ var (
 	groupdelCmd  = "groupdel"
 	mdadmCmd     = "mdadm"
 	mountCmd     = "mount"
+	partxCmd     = "partx"
 	sgdiskCmd    = "sgdisk"
 	modprobeCmd  = "modprobe"
 	udevadmCmd   = "udevadm"
@@ -92,6 +93,7 @@ func GroupaddCmd() string  { return groupaddCmd }
 func GroupdelCmd() string  { return groupdelCmd }
 func MdadmCmd() string     { return mdadmCmd }
 func MountCmd() string     { return mountCmd }
+func PartxCmd() string     { return partxCmd }
 func SgdiskCmd() string    { return sgdiskCmd }
 func ModprobeCmd() string  { return modprobeCmd }
 func UdevadmCmd() string   { return udevadmCmd }


### PR DESCRIPTION
- disks: Refuse to modify disks/partitions in use
    
    When a partition or the whole disk is in use, sgdisk should not execute
    the destructive operation.
    Add a check that errors out when a disk in use or a partition in use is
    to be destroyed.
- sgdisk: Run partx after partition changes
    
    The sgdisk tool does not update the kernel partition table with BLKPG in
    contrast to other similar tools but only uses BLKRRPART which fails as
    soon as one partition of the disk is mounted.
    Update the kernel partition table with partx when we know that a
    partition of the disk is in use.