### PR TITLE
Add optionally-installed grub2 code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ install: all
 	ln -sf ../lib/dracut/modules.d/30ignition/ignition $(DESTDIR)/usr/libexec/ignition-apply
 	ln -sf ../lib/dracut/modules.d/30ignition/ignition $(DESTDIR)/usr/libexec/ignition-rmcfg
 
+install-grub-for-bootupd:
+	install -m 0644 -D -t $(DESTDIR)/usr/lib/bootupd/grub2-static/configs.d grub2/ignition.cfg
+
 .PHONY: vendor
 vendor:
 	@go mod vendor

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,8 @@ nav_order: 9
 ### Features
 
 - Support Hetzner Cloud
+- A GRUB configuration suitable for use with https://github.com/coreos/bootupd
+  can now be installed; use `make install-grub-for-bootupd` to install it
 
 ### Changes
 

--- a/grub2/ignition.cfg
+++ b/grub2/ignition.cfg
@@ -1,0 +1,19 @@
+# This GRUB config snippet implements the `ignition.firstboot` semantic using a
+# stamp file in the bootfs. This is used at least on CoreOS-based systems where
+# it's injected by https://github.com/coreos/bootupd.
+
+# Determine if this is a first boot and set the ${ignition_firstboot} variable
+# which is used in the kernel command line.
+set ignition_firstboot=""
+if [ -f "/ignition.firstboot" ]; then
+    # Default networking parameters to be used with Ignition.
+    set ignition_network_kcmdline=''
+
+    # Source in the `ignition.firstboot` file which could override the
+    # above $ignition_network_kcmdline with static networking config.
+    # This override feature is also used by coreos-installer to persist static
+    # networking config provided during install to the first boot of the machine.
+    source "/ignition.firstboot"
+
+    set ignition_firstboot="ignition.firstboot ${ignition_network_kcmdline}"
+fi


### PR DESCRIPTION
This pairs with https://github.com/coreos/bootupd/pull/543 Basically we want bootupd to take care of installing this.  Add the config here (where it more closely arguably belongs) so that it can be optionally installed.

My proposal for at least the Fedora packaging of Ignition is that we unconditionally depend on bootupd and install this, because there's no one there using Ignition who doesn't want bootupd.