### PR TITLE
Add vsock modules into ramdisk

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -103,5 +103,7 @@ installkernel() {
 
      # required by applehv platform to read ignition file through vsock
      instmods -c vsock
+     instmods -c vmw_vsock_virtio_transport_common
+     instmods -c vmw_vsock_virtio_transport
 }
 


### PR DESCRIPTION
A review comment to #1696 suggested I see if I could eliminate a pair of modules needed in the ramdisk to consume an ignition file over vsock. In doing the testing, I experienced a false positive; unfortunately, I have determined they are in fact needed and this PR asks to add them again.