### PR TITLE
Bump minimum Go version to 1.20

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ nav_order: 11
 1. TOC
 {:toc}
 
-A Go 1.19+ [environment](https://golang.org/doc/install) and the `blkid.h` headers are required.
+A Go 1.20+ [environment](https://golang.org/doc/install) and the `blkid.h` headers are required.
 
 ```sh
 # Debian/Ubuntu

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,8 @@ nav_order: 9
 
 ### Changes
 
+- Require Go 1.20+
+
 ### Bug fixes
 
 ## Ignition 2.17.0 (2023-11-20)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/ignition/v2
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
With go 1.19 being EOL bump to 1.20