### PR TITLE
stages/files: filter out non-existent paths before relabeling

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,8 +8,8 @@ nav_order: 9
 
 ### Breaking changes
 
-- The dracut module is not automatically included in initramfs images anymore,
-  see distributor notes for details.
+- Only include dracut module in initramfs if requested (see distributor notes
+  for details)
 
 ### Features
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,11 +13,16 @@ nav_order: 9
 
 ### Features
 
+
+
 ### Changes
 
 - Require Go 1.20+
 
 ### Bug fixes
+
+- Fix failure when config only disables units already disabled
+
 
 ## Ignition 2.17.0 (2023-11-20)
 


### PR DESCRIPTION
The code that handles systemd unit enablement via preset will no op if
disabling a systemd unit that is already disabled, which means that we
wouldn't create a preset file in that case. But we did mark the preset
file as needing relabeling unconditionally. Since `setfiles` errors out
if you pass it a path that doesn't exist, this would break boot.

Fix this by filtering out all entries that don't exist right before we
call `setfiles`. Another approach would've been to only mark the file
for relabeling if we actually did write the file, but this is more
complex than it seems because the relabeling logic needs to know what
is the first component in the path that had to be created. So we'd need
logic both before and after file creation.

This isn't user-reported; we hit this in a CI test.