### PR TITLE
providers/proxmoxve: Add Proxmox VE provider

### DIFF
--- a/internal/providers/proxmoxve/proxmoxve.go
+++ b/internal/providers/proxmoxve/proxmoxve.go
@@ -1,0 +1,130 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The OpenStack provider fetches configurations from the userdata available in
+// both the config-drive as well as the network metadata service. Whichever
+// responds first is the config that is used.
+// NOTE: This provider is still EXPERIMENTAL.
+
+package proxmoxve
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
+
+	"github.com/coreos/vcontext/report"
+)
+
+const (
+	cidataPath  = "/user-data"
+	deviceLabel = "cidata"
+)
+
+func init() {
+	platform.Register(
+		platform.Provider{
+			Name:  "proxmoxve",
+			Fetch: fetchConfig,
+		},
+	)
+}
+
+func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	var data []byte
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	dispatch := func(name string, fn func() ([]byte, error)) {
+		raw, err := fn()
+		if err != nil {
+			switch err {
+			case context.Canceled:
+			case context.DeadlineExceeded:
+				f.Logger.Err("timed out while fetching config from %s", name)
+			default:
+				f.Logger.Err("failed to fetch config from %s: %v", name, err)
+			}
+			return
+		}
+
+		data = raw
+		cancel()
+	}
+
+	go dispatch(
+		"config drive (cidata)", func() ([]byte, error) {
+			return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), deviceLabel))
+		},
+	)
+
+	<-ctx.Done()
+	if ctx.Err() == context.DeadlineExceeded {
+		f.Logger.Info("cidata drive was not available in time. Continuing without a config...")
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return (err == nil)
+}
+
+func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string) ([]byte, error) {
+	for !fileExists(path) {
+		logger.Debug("config drive (%q) not found. Waiting...", path)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	logger.Debug("creating temporary mount point")
+	mnt, err := os.MkdirTemp("", "ignition-configdrive")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.Remove(mnt)
+
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", "auto", path, mnt)
+	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = logger.LogOp(
+			func() error {
+				return ut.UmountPath(mnt)
+			},
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
+
+	if !fileExists(filepath.Join(mnt, cidataPath)) {
+		return nil, nil
+	}
+
+	return os.ReadFile(filepath.Join(mnt, cidataPath))
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/openstack"
 	_ "github.com/coreos/ignition/v2/internal/providers/packet"
 	_ "github.com/coreos/ignition/v2/internal/providers/powervs"
+	_ "github.com/coreos/ignition/v2/internal/providers/proxmoxve"
 	_ "github.com/coreos/ignition/v2/internal/providers/qemu"
 	_ "github.com/coreos/ignition/v2/internal/providers/scaleway"
 	_ "github.com/coreos/ignition/v2/internal/providers/virtualbox"


### PR DESCRIPTION
This is just ripped from providers/ibmcloud with strings changed, and I honestly didn't try building yet (as I wanted to just upload something before I forget to get the ball rolling...) but it _should_ work, at least in a basic sense, because the ibmcloud image works on Proxmox VE as-is!

...with a few fun caveat: ignition must be supplied as cloud-init (`nocloud`) data. This means that to do it "the Proxmox way" you need to:

1. Enable snippets on a Proxmox storage provider that supports them (such as a local folder or an NFS mount).
2. Upload your Ignition file to the snippets storage (for example, `/var/lib/vz/snippets/example.ign` if you simply enable Snippets on the stock `local` filesystem storage provider)
3. Use the `qm` cli command, or the Proxmox VE API, to set custom cloud-init data to the uploaded ignition file (for example, `ssh root@pve.example.com qm set 30001 -cicustom user=local:snippets/butane.ign`

OR

1. Create an ISO file with the volume label `cidata` and a file `/user-data` with the contents of your ignition data. (This is manually creating the cloud-init ISO, and may work on other hypervisors with a proxmoxve image)
2. Upload the ISO file to ISO storage for your Proxmox server
3. Set an optical drive on your virtual machine to that ISO file.

The above manual way can be automated in Go by consuming the [go-proxmox](https://github.com/luthermonson/go-proxmox) module and calling the [`VirtualMachine.CloudInit()`](https://pkg.go.dev/github.com/luthermonson/go-proxmox#VirtualMachine.CloudInit) method, as done in my experimental [gomox](https://github.com/perchnet/gomox) cli utility