### PR TITLE
providers: add scaleway

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ nav_order: 9
 
 ### Features
 
+- Support Scaleway
 
 
 ### Changes

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -26,6 +26,7 @@ Ignition is currently only supported for the following platforms:
 * [Equinix Metal] (`packet`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [IBM Power Systems Virtual Server] (`powervs`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [QEMU] (`qemu`) - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device (available in QEMU 2.4.0 and higher).
+* [Scaleway] (`scaleway`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [VirtualBox] (`virtualbox`) - Use the VirtualBox guest property `/Ignition/Config` to provide the config to the virtual machine.
 * [VMware] (`vmware`) - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Vultr] (`vultr`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.

--- a/internal/providers/scaleway/scaleway.go
+++ b/internal/providers/scaleway/scaleway.go
@@ -1,0 +1,62 @@
+// Copyright 2024 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The Scaleway provider fetches a remote configuration from the Scaleway
+// user-data metadata service URL.
+// NOTE: For security reason, Scaleway requires to query user data with a source port below 1024.
+
+package scaleway
+
+import (
+	"math/rand"
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	userdataURL = url.URL{
+		Scheme: "http",
+		Host:   "169.254.42.42",
+		Path:   "user_data/cloud-init",
+	}
+)
+
+func init() {
+	platform.Register(platform.Provider{
+		Name:  "scaleway",
+		Fetch: fetchConfig,
+	})
+}
+
+func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	// For security reason, Scaleway requires to query user data with a source port below 1024.
+	port := func() int {
+		return rand.Intn(1022) + 1
+	}
+
+	data, err := f.FetchToBuffer(userdataURL, resource.FetchOptions{
+		LocalPort: port,
+	})
+	if err != nil && err != resource.ErrNotFound {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/packet"
 	_ "github.com/coreos/ignition/v2/internal/providers/powervs"
 	_ "github.com/coreos/ignition/v2/internal/providers/qemu"
+	_ "github.com/coreos/ignition/v2/internal/providers/scaleway"
 	_ "github.com/coreos/ignition/v2/internal/providers/virtualbox"
 	_ "github.com/coreos/ignition/v2/internal/providers/vmware"
 	_ "github.com/coreos/ignition/v2/internal/providers/vultr"


### PR DESCRIPTION
Hi,

In this PR we add the support for Scaleway cloud provider. Locally tested on Flatcar + Scaleway:
```
./ignition --platform scaleway --stage fetch --config-cache ./config.json
```

While it's a regular IMDS endpoint, it has a small difference with other providers:
```
$ curl http://169.254.42.42/user_data/cloud-init
# For security reason, you need to query user data with a source port below 1024. For instance, with curl, run as root: # curl http://169.254.42.42/user_data/... --local-port 1-1023
```

I decided to go with a new `FetchOption` called `LocalPort` and to override the default `DialContext`.

Related to: https://github.com/coreos/fedora-coreos-tracker/issues/866