### PR TITLE
azure: retry HTTP requests on codes 404, 410, and 429

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,6 +23,7 @@ nav_order: 9
 ### Bug fixes
 
 - Fix failure when config only disables units already disabled
+- Retry HTTP requests on Azure on status codes 404, 410, and 429
 
 
 ## Ignition 2.17.0 (2023-11-20)

--- a/internal/resource/url.go
+++ b/internal/resource/url.go
@@ -131,6 +131,10 @@ type FetchOptions struct {
 	// LocalPort is a function returning a local port used to establish the TCP connection.
 	// Most of the time, letting the Kernel choose a random port is enough.
 	LocalPort func() int
+
+	// List of HTTP codes to retry that usually would be considered as complete.
+	// Status codes >= 500 are always retried.
+	RetryCodes []int
 }
 
 // FetchToBuffer will fetch the given url into a temporary file, and then read


### PR DESCRIPTION
For some reason, the Azure IMDS server expects clients to retry their HTTP requests even on codes that usually would be considered final. The documented one is 410[[1]], but let's just match the set from cloud-init, which also includes 404 and 429[[2]].

Closes: #1806

[1]: https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#errors-and-debugging
[2]: https://github.com/canonical/cloud-init/commit/c1a2047cf291