### PR TITLE
Dockerfile.validate: update to Fedora 39

### DIFF
--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:38 AS builder
+FROM registry.fedoraproject.org/fedora:39 AS builder
 RUN dnf install -y golang git-core
 RUN mkdir /ignition-validate
 COPY . /ignition-validate


### PR DESCRIPTION
Updating Dockerfile due to F39 relase

See: https://github.com/coreos/fedora-coreos-tracker/issues/1490