### PR TITLE
raid: add assemble option

### DIFF
--- a/config/doc/ignition.yaml
+++ b/config/doc/ignition.yaml
@@ -168,6 +168,8 @@ root:
               desc: the number of spares (if applicable) in the array.
             - name: options
               desc: any additional options to be passed to mdadm.
+            - name: assemble
+              desc: try to assemble raid array from the list of devices before creating it. Defaults to false.
         - name: filesystems
           desc: the list of filesystems to be configured. `device` and `format` need to be specified. Every filesystem must have a unique `device`.
           children:

--- a/config/v3_5_experimental/schema/ignition.json
+++ b/config/v3_5_experimental/schema/ignition.json
@@ -236,6 +236,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "assemble": {
+              "type": ["boolean", "null"]
             }
           },
           "required": [

--- a/config/v3_5_experimental/types/schema.go
+++ b/config/v3_5_experimental/types/schema.go
@@ -195,11 +195,12 @@ type Proxy struct {
 }
 
 type Raid struct {
-	Devices []Device     `json:"devices,omitempty"`
-	Level   *string      `json:"level,omitempty"`
-	Name    string       `json:"name"`
-	Options []RaidOption `json:"options,omitempty"`
-	Spares  *int         `json:"spares,omitempty"`
+	Assemble *bool        `json:"assemble,omitempty"`
+	Devices  []Device     `json:"devices,omitempty"`
+	Level    *string      `json:"level,omitempty"`
+	Name     string       `json:"name"`
+	Options  []RaidOption `json:"options,omitempty"`
+	Spares   *int         `json:"spares,omitempty"`
 }
 
 type RaidOption string

--- a/docs/configuration-v3_5_experimental.md
+++ b/docs/configuration-v3_5_experimental.md
@@ -70,6 +70,7 @@ The Ignition configuration is a JSON document conforming to the following specif
     * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
     * **_spares_** (integer): the number of spares (if applicable) in the array.
     * **_options_** (list of strings): any additional options to be passed to mdadm.
+    * **_assemble_** (boolean): try to assemble raid array from the list of devices before creating it. Defaults to false.
   * **_filesystems_** (list of objects): the list of filesystems to be configured. `device` and `format` need to be specified. Every filesystem must have a unique `device`.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
     * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, swap, or none).

--- a/internal/exec/stages/disks/raid.go
+++ b/internal/exec/stages/disks/raid.go
@@ -74,6 +74,9 @@ func (s stage) createRaids(config types.Config) error {
 				if err := s.waitOnDevices([]string{devName}, "raids"); err != nil {
 					s.Logger.Info("mdadm assemble failed: %v", err)
 				} else {
+					if err := s.waitOnDevices([]string{devName}, "raids"); err != nil {
+						return err
+					}
 					return nil
 				}
 			}


### PR DESCRIPTION
Adds option to assemble raid devices before creating new ones. Allows for persistent raid configurations without wiping existing data.

Haven't tested this yet, but my main goal is to provide an option to reassemble existing raids when reprovisioning. Looking forward to feedback.