### PR TITLE
Proxmox VE provider

### DIFF
--- a/internal/providers/proxmoxve/proxmoxve.go
+++ b/internal/providers/proxmoxve/proxmoxve.go
@@ -1,0 +1,129 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxmoxve
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/ignition/v2/config/v3_5_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/log"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+	ut "github.com/coreos/ignition/v2/internal/util"
+
+	"github.com/coreos/vcontext/report"
+)
+
+const (
+	cidataPath  = "/user-data"
+	deviceLabel = "cidata"
+)
+
+func init() {
+	platform.Register(platform.Provider{
+		Name:  "proxmoxve",
+		Fetch: fetchConfig,
+	})
+}
+
+func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	var data []byte
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+	dispatch := func(name string, fn func() ([]byte, error)) {
+		raw, err := fn()
+		if err != nil {
+			switch err {
+			case context.Canceled:
+			case context.DeadlineExceeded:
+				f.Logger.Err("timed out while fetching config from %s", name)
+			default:
+				f.Logger.Err("failed to fetch config from %s: %v", name, err)
+			}
+			return
+		}
+
+		data = raw
+		cancel()
+	}
+
+	go dispatch("config drive (cidata)", func() ([]byte, error) {
+		return fetchConfigFromDevice(f.Logger, ctx, filepath.Join(distro.DiskByLabelDir(), deviceLabel))
+	})
+
+	<-ctx.Done()
+	if ctx.Err() == context.DeadlineExceeded {
+		f.Logger.Info("cidata drive was not available in time. Continuing without a config...")
+	}
+
+	config, report, err := util.ParseConfig(f.Logger, data)
+	if err != nil {
+		// Proxmox VE will populate user-data with a cloud-init YAML config by default.
+		// If such config is present, we should not return an error,
+		// and instead just ignore it and let Afterburn pick it up later.
+		return util.ParseConfig(f.Logger, []byte{})
+	}
+
+	return config, report, err
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return (err == nil)
+}
+
+func fetchConfigFromDevice(logger *log.Logger, ctx context.Context, path string) ([]byte, error) {
+	for !fileExists(path) {
+		logger.Debug("config drive (%q) not found. Waiting...", path)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	logger.Debug("creating temporary mount point")
+	mnt, err := os.MkdirTemp("", "ignition-configdrive")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	defer os.Remove(mnt)
+
+	cmd := exec.Command(distro.MountCmd(), "-o", "ro", "-t", "auto", path, mnt)
+	if _, err := logger.LogCmd(cmd, "mounting config drive"); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = logger.LogOp(
+			func() error {
+				return ut.UmountPath(mnt)
+			},
+			"unmounting %q at %q", path, mnt,
+		)
+	}()
+
+	if !fileExists(filepath.Join(mnt, cidataPath)) {
+		return nil, nil
+	}
+
+	return os.ReadFile(filepath.Join(mnt, cidataPath))
+}

--- a/internal/providers/proxmoxve/proxmoxve.go
+++ b/internal/providers/proxmoxve/proxmoxve.go
@@ -75,15 +75,7 @@ func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		f.Logger.Info("cidata drive was not available in time. Continuing without a config...")
 	}
 
-	config, report, err := util.ParseConfig(f.Logger, data)
-	if err != nil {
-		// Proxmox VE will populate user-data with a cloud-init YAML config by default.
-		// If such config is present, we should not return an error,
-		// and instead just ignore it and let Afterburn pick it up later.
-		return util.ParseConfig(f.Logger, []byte{})
-	}
-
-	return config, report, err
+	return util.ParseConfig(f.Logger, data)
 }
 
 func fileExists(path string) bool {

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/openstack"
 	_ "github.com/coreos/ignition/v2/internal/providers/packet"
 	_ "github.com/coreos/ignition/v2/internal/providers/powervs"
+	_ "github.com/coreos/ignition/v2/internal/providers/proxmoxve"
 	_ "github.com/coreos/ignition/v2/internal/providers/qemu"
 	_ "github.com/coreos/ignition/v2/internal/providers/scaleway"
 	_ "github.com/coreos/ignition/v2/internal/providers/virtualbox"


### PR DESCRIPTION
Hello,

This PR implements the `proxmoxve` provider.

The provider mounts the cloud-init drive and parses the user-data file assuming it is an ignition config.

If the file is not an ignition config, it will not fail. It will just ignore it and say that the config is empty.
That is because Proxmox VE will create a user-data by default containing some cloud-init config in YAML.
This config will be picked up by afterburn anyway, so we don't need ignition to crash for that.

This PR is the missing puzzle piece to provide Proxmox VE images for Flatcar (see flatcar/scripts#1783)

Whats missing for the PR to be ready :
- [ ] tests
- [ ] docs and changelog
- [ ] commit formatting

I will work on that soon.