### PR TITLE
akamai: fix base64 decoding

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Fix Akamai Ignition base64 decoding on padded payloads
 
 ## Ignition 2.19.0 (2024-06-05)
 

--- a/internal/providers/akamai/akamai.go
+++ b/internal/providers/akamai/akamai.go
@@ -86,11 +86,12 @@ func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	// The Linode Metadata Service requires userdata to be base64-encoded
 	// when it is uploaded, so we will have to decode the response.
 	data := make([]byte, base64.StdEncoding.DecodedLen(len(encoded)))
-	if _, err := base64.StdEncoding.Decode(data, encoded); err != nil {
+	n, err := base64.StdEncoding.Decode(data, encoded)
+	if err != nil {
 		return types.Config{}, report.Report{}, fmt.Errorf("decode base64: %w", err)
 	}
 
-	return util.ParseConfig(f.Logger, data)
+	return util.ParseConfig(f.Logger, data[:n])
 }
 
 // defaultTokenTTL is the time-to-live (TTL; in seconds) for an authorization


### PR DESCRIPTION
trailing \x00 character was making Ignition to fail parsing the config. It is not always the case, that is why we did not catch it earlier: when there is no padding in the base64 payload, everything was working.

https://pkg.go.dev/encoding/base64#Encoding.Decode

---
cc @nesv 

![image](https://github.com/coreos/ignition/assets/28657343/f40a1467-d185-44e4-b198-bde7863b8e20)


(sorry for the screenshot but it's not easy to copy-paste logs from emergency shell) 

EDIT: Successfully tested on Flatcar test build with previously failing configuration.