### PR TITLE
OpenStack single-stack IPv6 support 

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,7 @@ Starting with this release, ignition-validate binaries are signed with the
 - Support partitioning disk with mounted partitions
 - Support Proxmox VE
 - Support gzipped Akamai user_data
+- Support IPv6 for single-stack OpenStack
 
 ### Changes
 


### PR DESCRIPTION
In https://github.com/coreos/ignition/issues/1897 issue, we are requested to create support for IPv6 so Ignition can fetch the metadata in single-stack environments. 

To achieve this, we added a new URL with the IPv6 endpoint. We also created logic to first attempt the IPv4 endpoint so If this fails, it will try the IPv6 one. If both endpoints fail, it will return the appropriate error.