### PR TITLE
build: drop package name when used with 'go clean' argument(s)

### DIFF
--- a/build
+++ b/build
@@ -28,7 +28,7 @@ export CGO_ENABLED=1
 echo "Building ${NAME}..."
 # clean the cache since cgo isn't correctly handled by gocache. Test to see if this version
 # of go supports caching before trying to clear the cache
-go clean -help 2>&1 | grep -F '[-cache]' >/dev/null && go clean -cache -testcache internal
+go clean -help 2>&1 | grep -F '[-cache]' >/dev/null && go clean -cache -testcache
 go build -buildmode=pie -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${NAME} ${REPO_PATH}/internal
 
 NAME="ignition-validate"


### PR DESCRIPTION
I dont see mention of this change in the 1.23 changelog, however it is mentioned in the commit https://github.com/golang/go/commit/c22865fcfa1ec434e5655c652c6376fa2d0eb821

fixes: #1931