### PR TITLE
dracut: add dependency network to ignition-mount.service

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Fix network race when phoning home on Equinix Metal
 - Fix Akamai Ignition base64 decoding on padded payloads
 
 ## Ignition 2.19.0 (2024-06-05)

--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -13,7 +13,13 @@ After=ignition-disks.service
 Before=ignition-files.service
 
 # Make sure ExecStop= runs before we switch root
+# and that we order ourselves after network such that
+# if networking is brought up it will still be available
+# for our ExecStop= command. On some providers like Equinix
+# Metal (Packet) there is a network callback sent out
+# for each Ignition stage (including umount).
 Before=initrd-switch-root.target
+After=network.target
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
On some providers (like Equinix Metal), there is a network dependency for the umount stage, network must be still around when ExecStop is executed.

Thanks @dustymabe for the suggestion on the fix. :muscle: 

---

Tested on Flatcar CI with Equinix Metal tests:
* working: http://bincache.flatcar-linux.net/testing/9999.0.1+tormath1-ignition/amd64/equinix_metal/_kola_temp/equinixmetal-2024-09-12-1117-222/kubeadm.v1.28.7.calico.base/5c53442c-d350-41dd-9fe3-eeaf1c726cd4/console.txt
```
[   17.117250] ignition[1066]: INFO     : Stage: umount
[   17.134237] ignition[1066]: INFO     : no configs at "/usr/lib/ignition/base.d"
[   17.144233] ignition[1066]: INFO     : no config dir at "/usr/lib/ignition/base.platform.d/packet"
[   17.155231] ignition[1066]: INFO     : umount: umount passed
[   17.163285] ignition[1066]: INFO     : POST message to Packet Timeline
[   17.172314] ignition[1066]: INFO     : GET https://metadata.packet.net/metadata: attempt #1
[   17.182386] systemd[1]: Stopping ignition-mount.service - Ignition (mount)...
[   17.192471] systemd[1]: remount-sysroot.service - Remount Root File System was skipped because of an unmet condition check (ConditionPathIsReadWrite=!/sysroot).
[   17.209370] systemd[1]: systemd-udev-trigger.service: Deactivated successfully.
[   17.219369] systemd[1]: Stopped systemd-udev-trigger.service - Coldplug All udev Devices.
[   17.229791] systemd[1]: dracut-pre-trigger.service: Deactivated successfully.
[   17.239272] systemd[1]: Stopped dracut-pre-trigger.service - dracut pre-trigger hook.
[   17.249398] systemd[1]: initrd-cleanup.service: Deactivated successfully.
[   17.258429] systemd[1]: Finished initrd-cleanup.service - Cleaning Up and Shutting Down Daemons.
[   17.525189] ignition[1066]: INFO     : GET result: OK
[   17.790691] ignition[1066]: INFO     : Ignition finished successfully
...
[   17.943385] systemd[1]: Stopped target network.target - Network.
[[0;32m  OK  [0m] Stopped target [0;1;39msockets.target[0m - Socket Units.
```

* not working: http://bincache.flatcar-linux.net/testing/4088.0.0+nightly-20240909-2100/amd64/equinix_metal/_kola_temp/equinixmetal-2024-09-10-2311-53/kubeadm.v1.28.7.calico.base/5ad7f3ac-e442-498d-a033-447c14c186f9/console.txt
```
[   21.915639] systemd[1]: Stopped target network.target - Network.
...
[   22.590416] ignition[1212]: INFO     : Ignition 2.19.0
[   22.605169] ignition[1212]: INFO     : Stage: umount
         Stopping [0;1;39msystemd-networkd.service[0m - Network Configuration...

[   22.605284] ignition[1212]: INFO     : no configs at "/usr/lib/ignition/base.d"
[   22.629140] ignition[1212]: INFO     : no config dir at "/usr/lib/ignition/base.platform.d/packet"
         Stopping [0;1;39msystemd-resolved.service[0m - Network Name Resolution...

[   22.629185] ignition[1212]: INFO     : umount: umount passed
[[0;32m  OK  [0m] Stopped [0;1;39msystemd-udev-trigger.service[0m - Coldplug All udev Devices.

[   32.565905] ignition[1212]: INFO     : GET error: Get "https://metadata.packet.net/metadata": net/http: timeout awaiting response headers
[   32.766388] ignition[1212]: INFO     : GET https://metadata.packet.net/metadata: attempt #2
[K[  [0;31m*[0;1;31m*[0m[0;31m* [0m] Job ignition-mount.service/stop running (11s / 1min 30s)

M
[K[ [0;31m*[0;1;31m*[0m[0;31m*  [0m] Job ignition-mount.service/stop running (11s / 1min 30s)
```