### PR TITLE
test: add -go flag to go tool fix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.22.x, 1.23.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/test
+++ b/test
@@ -46,6 +46,7 @@ PKG_VET=$(go list ./... | \
 echo "Checking gofix..."
 # https://github.com/coreos/ignition/issues/1950
 go_version=$(go version | awk '{print $3}')
+echo $go_version
 go tool fix -go="$go_version" -diff $SRC
 
 echo "Checking gofmt..."

--- a/test
+++ b/test
@@ -44,7 +44,9 @@ PKG_VET=$(go list ./... | \
 	grep --invert-match internal/log)
 
 echo "Checking gofix..."
-go tool fix -diff $SRC
+# https://github.com/coreos/ignition/issues/1950
+go_version=$(go version | awk '{print $3}')
+go tool fix -go="$go_version" -diff $SRC
 
 echo "Checking gofmt..."
 res=$(gofmt -d -e -s $SRC)


### PR DESCRIPTION
Add -go flag to go tool fix to correctly set the go version. A change external to the codebase is causing the default go version to not populate.

fixes: #1950