### PR TITLE
Fix "go tool fix" test script

### DIFF
--- a/test
+++ b/test
@@ -44,7 +44,7 @@ PKG_VET=$(go list ./... | \
 	grep --invert-match internal/log)
 
 echo "Checking gofix..."
-go tool fix -diff $SRC
+go tool fix -go=go1.20 -diff $SRC
 
 echo "Checking gofmt..."
 res=$(gofmt -d -e -s $SRC)


### PR DESCRIPTION
This pull request includes a minor change to the `test` file. The change specifies the Go version to be used by the `go tool fix` command.

* [`test`](diffhunk://#diff-9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08L47-R47): Updated the `go tool fix` command to use Go version 1.20.

fix #1950 