### PR TITLE
refactor(log): ingore error log when journal is disable

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -35,6 +35,7 @@ nav_order: 9
 - Fix network race when phoning home on Equinix Metal
 - Fix Akamai Ignition base64 decoding on padded payloads
 - Fix Makefile GOARCH for loongarch64 ([#1942](https://github.com/coreos/ignition/pull/1942))
+- Don't log to journal if not available
 
 
 ## Ignition 2.19.0 (2024-06-05)

--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -179,7 +179,7 @@ func (e *Engine) acquireConfig(stageName string) (cfg types.Config, err error) {
 		cfg, err = e.acquireProviderConfig()
 
 		// if we've successfully fetched and cached the configs, log about them
-		if err == nil {
+		if err == nil && journal.Enabled() {
 			for _, cfgInfo := range e.State.FetchedConfigs {
 				if logerr := logStructuredJournalEntry(cfgInfo); logerr != nil {
 					e.Logger.Info("failed to log systemd journal entry: %v", logerr)


### PR DESCRIPTION
There is no systemd and journal in our distribution, and when using ignition, many warning logs are printed. The changes in this PR will check if there is a journal in the current distribution, and if not, it will not pass the logs to the journal.

![img_v3_02fl_4ae5cd52-92cc-4c5a-a110-a6d3e432c6dg](https://github.com/user-attachments/assets/489f540d-7715-43c8-9b41-a626f69d7f1b)

Notes: The distro Alpine has no journal. Add conditional to avoid failure due to logging method not being available.