### PR TITLE
Add tpm2_getcap to the initrd for Clevis TPM2 functionality

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -57,7 +57,8 @@ install() {
         clevis-luks-unlock \
         pwmake \
         tpm2_create \
-        tpm2_createpolicy
+        tpm2_createpolicy \
+        tpm2_getcap
 
     # Required by s390x's z/VM installation.
     # Supporting https://github.com/coreos/ignition/pull/865


### PR DESCRIPTION
The tpm2_getcap is required for Clevis TPM2 operations but was missing from the initrd.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1836