### PR TITLE
Reverting tpm2_getcap change

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -57,8 +57,7 @@ install() {
         clevis-luks-unlock \
         pwmake \
         tpm2_create \
-        tpm2_createpolicy \
-        tpm2_getcap
+        tpm2_createpolicy
 
     # Required by s390x's z/VM installation.
     # Supporting https://github.com/coreos/ignition/pull/865


### PR DESCRIPTION
We are reverting the addition of `tpm2_cap` binary that was done as part of the kola test failure `ext.config.var-mount.luks` caused by clevis pkg upgrade from `clevis-21-6.fc42 -> 21-7.fc42`, as the issue is now fixed in with clevis pkg update `clevis-21-8.fc42.x86_64`

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1836#issuecomment-2513303989