### PR TITLE
Update logging calls for upcoming Go 1.24

### DIFF
--- a/internal/exec/engine.go
+++ b/internal/exec/engine.go
@@ -121,7 +121,7 @@ func (e Engine) Run(stageName string) error {
 		return err
 	}
 
-	e.Logger.PushPrefix(stageName) //nolint:govet
+	e.Logger.PushPrefix("%s", stageName)
 	defer e.Logger.PopPrefix()
 
 	fullConfig := latest.Merge(baseConfig, latest.Merge(systemBaseConfig, cfg))

--- a/internal/main.go
+++ b/internal/main.go
@@ -89,7 +89,7 @@ func ignitionMain() {
 	logger := log.New(flags.logToStdout)
 	defer logger.Close()
 
-	logger.Info(version.String) //nolint:govet
+	logger.Info("%s", version.String)
 	logger.Info("Stage: %v", flags.stage)
 
 	platformConfig := platform.MustGet(flags.platform.String())
@@ -157,7 +157,7 @@ func ignitionApplyMain() {
 	logger := log.New(true)
 	defer logger.Close()
 
-	logger.Info(version.String) //nolint:govet
+	logger.Info("%s", version.String)
 
 	var blob []byte
 	var err error
@@ -219,7 +219,7 @@ func ignitionRmCfgMain() {
 	logger := log.New(flags.logToStdout)
 	defer logger.Close()
 
-	logger.Info(version.String) //nolint:govet
+	logger.Info("%s", version.String)
 
 	platformConfig := platform.MustGet(flags.platform)
 	fetcher, err := platformConfig.NewFetcher(&logger)


### PR DESCRIPTION
Some calls to `Logger.PushPrefix` and `Logger.Info` were being passed a single, variable argument, rather than a format string as its first argument (as printf-style functions expect).

The Vet in Go's upcoming 1.24 release [has a new check that will flag these calls](https://tip.golang.org/doc/go1.24#vet) (which were already annotated with `// nolint:govet` comments). Rather than disabling linting, add a format-string first argument to make the calls kosher.