### PR TITLE
dracut: Correctly add pkey_cca kernel mod for cex card

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,7 @@ Starting with this release, ignition-validate binaries are signed with the
 
 ### Bug fixes
 
+- Add `pkey_cca` kernel module to detect CEX domain for LUKS encryption
 
 ## Ignition 2.20.0 (2024-10-22)
 

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -121,6 +121,7 @@ installkernel() {
      # required for cex card early initialization
      if [[ ${DRACUT_ARCH:-$(uname -m)} == s390x ]]; then
         instmods -c zcrypt_cex4
+        instmods -c pkey_cca
      fi
 }
 


### PR DESCRIPTION
While doing  testing hardware disk encryption using cex on `4.19 rhel 9.6 `failed to detect cex domain for luks encryption. 

```
[   23.293503] ignition[970]: Ignition failed: failed to create luks: generating secure key: generating secure key: exit status 1: Cmd: "zkey" "generate" "--name" "ignition-luks-root" "--key-type" "CCA-AESCIPHER" "--xts" "--description" "Secure Key for root Volume" "--apqns" "00.0047" Stdout: "" Stderr: "zkey: No APQN is available that can generate a secure key of type CCA-AESCIPHER\n"
[   23.294715] systemd[1]: ignition-disks.service: Main process exited, code=exited, status=1/FAILURE
[FAILED] Failed to start Ignition (disks).
[   23.295000] systemd[1]: Failed to start Ignition (disks).
```

when run the command in verbose mode folllowing logs found.
```
description "secure key" --apqns 00.0047 -voot --key-type CCA-AESCIPHER --xts --des 
zkey version 2.33.1-2.el9
Copyright IBM Corp. 2017, 2020
cription "secure key" --apqns 00.0047 -Voot --key-type CCA-AESCIPHER --xts --desc
zkey: Keystore in directory '/etc/zkey/repository' opened successfully
zkey: Device '/dev/pkey' has been opened successfully
zkey: File names for key 'ignition-luks-root': '/etc/zkey/repository/ignition-luks-root.skey' and '/etc/zkey/repository/ignition-luks-root.info'
zkey: Cross checking APQNs with mkvp 0000000000000000, min-level 6, and min-fw-version 0.0 (api: 0): 00.0047
zkey: Specified: 00.0047
zkey: mkvp for 00.0047: AES NEW: empty 0x0000000000000000
zkey: mkvp for 00.0047: AES CUR: valid 0xa40c15477abf80a7
zkey: mkvp for 00.0047: AES OLD: valid 0x71ecf46a35bd8924
zkey: mkvp for 00.0047: APKA NEW: empty 0x0000000000000000
zkey: mkvp for 00.0047: APKA CUR: valid 0x71772e2bf9e44214
zkey: mkvp for 00.0047: APKA OLD: valid 0x71772e2bf9e44214
zkey: mkvp for 00.0047: ASYM NEW: empty 0x00000000000000000000000000000000
zkey: mkvp for 00.0047: ASYM CUR: valid 0x12879b31fc17593939f460eaccd49ff4
zkey: mkvp for 00.0047: ASYM OLD: valid 0x12879b31fc17593939f460eaccd49ff4
zkey: Generate secure key by random
zkey: Build a list of APQNs for key type 2
zkey: ioctl PKEY_APQNS4KT rc: No such device
zkey: No APQN is available that can generate a secure key of type CCA-AESCIPHER
zkey: Failed to generate key 'ignition-luks-root': No such device
```

IBM suggested that there is split for `pkey` module in kernel version `5.14.0-556`  `pkey` to `pkey/pkey_cca/pkey_ep11/pkey_pckmo ` 

pkey.ko is now a base module  and "handler" modules pkey_cca.ko, pkey_ep11.ko.
You would need the pkey_cca.ko also in your initrd. 

I've tested this in zVM, zKVM  logs have attached for reference.
[PKEY_CEX_DASD_Test.log](https://github.com/user-attachments/files/18671176/PKEY_CEX_DASD_Test.log)
[PKEY_CEX_FCP_Test.log](https://github.com/user-attachments/files/18671177/PKEY_CEX_FCP_Test.log)
[PKEY_CEX_KVM_Test.log](https://github.com/user-attachments/files/18671178/PKEY_CEX_KVM_Test.log)
