### PR TITLE
providers: support for vendor-data in proxmoxve

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ Starting with this release, ignition-validate binaries are signed with the
 ### Features
 
 - Add Azure blob support for fetching ignition configs
+- Add a check for ignition config in vendor-data (proxmoxve)
 
 ### Changes
 

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -24,7 +24,7 @@ Ignition is currently supported for the following platforms:
 * Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, `arn:`, or `gs://` schemes to specify a remote config.
 * [Nutanix] (`nutanix`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.
-* [Proxmox VE] (`proxmoxve`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
+* [Proxmox VE] (`proxmoxve`) - Ignition will read its configuration from the instance userdata via config drive. If there isn't any valid Ignition configuration in userdata it will check the vendordata next. Cloud SSH keys are handled separately.
 * [Equinix Metal] (`packet`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [IBM Power Systems Virtual Server] (`powervs`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [QEMU] (`qemu`) - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device (available in QEMU 2.4.0 and higher).


### PR DESCRIPTION
This PR adds support for reading Ignition data out of the vendor-data file so we can leave the cloud-config in the user-data file. It will always use the user-data file if it has an ignition config over using the vendor-data file.

This works as expected:

```bash
# /home/jdoss/ignition --platform proxmoxve --stage fetch -log-to-stdout
INFO     : Ignition v2.10.1-1315-gaf19b7d7-dirty
INFO     : Stage: fetch
INFO     : no config dir at "/usr/lib/ignition/base.d"
INFO     : no config dir at "/usr/lib/ignition/base.platform.d/proxmoxve"
DEBUG    : parsed url from cmdline: ""
INFO     : no config URL provided
INFO     : reading system config file "/usr/lib/ignition/user.ign"
INFO     : no config at "/usr/lib/ignition/user.ign"
DEBUG    : creating temporary mount point
INFO     : op(1): [started]  mounting config drive
DEBUG    : op(1): executing: "mount" "-o" "ro" "-t" "auto" "/dev/disk/by-label/cidata" "/tmp/ignition-configdrive2469853404"
INFO     : op(1): [finished] mounting config drive
DEBUG    : config drive ("/tmp/ignition-configdrive2469853404/user-data") contains a cloud-config configuration, ignoring
DEBUG    : config drive ("/tmp/ignition-configdrive2469853404/vendor-data") contains a ignition configuration
INFO     : op(2): [started]  unmounting "/dev/disk/by-label/cidata" at "/tmp/ignition-configdrive2469853404"
INFO     : op(2): [finished] unmounting "/dev/disk/by-label/cidata" at "/tmp/ignition-configdrive2469853404"
DEBUG    : parsing config with SHA512: d45cc6bd9291debbfbd47365a802208a027b77407d39caf42f873ffd9183cc20dbc01803da2c17cfba09e1c753bff9168a5865bff30f9428088ae7f7b87d7ae0
INFO     : fetch: fetch complete
INFO     : fetch: fetch passed
INFO     : Ignition finished successfully
```