### PR TITLE
issue_template/stablize-checklist: add yaml matter header

### DIFF
--- a/.github/ISSUE_TEMPLATE/stabilize-checklist.md
+++ b/.github/ISSUE_TEMPLATE/stabilize-checklist.md
@@ -1,3 +1,10 @@
+---
+name: Stabilization checklist
+about: Stabilization checklist template
+title: New stabilization for ignition
+labels: jira
+---
+
 # Marking an experimental spec as stable
 
 When an experimental version of the Ignition config spec (e.g.: `3.1.0-experimental`) is to be declared stable (e.g. `3.1.0`), there are a handful of changes that must be made to the code base. These changes should have the following effects:


### PR DESCRIPTION
With the latest github changes, issue templates are now required to have a yaml matter header to function.