### PR TITLE
templates/release-checklist: drop rhaos packaging; add c10s

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -65,19 +65,8 @@ Quay release:
  - [ ] Visit the [Quay tags page](https://quay.io/repository/coreos/ignition-validate?tab=tags) and wait for a versioned tag to appear
  - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
 
-RHCOS packaging for the current RHCOS development release:
- - [ ] Update the [spec file](https://gitlab.com/redhat/rhel/rpms/ignition)
-   - Bump the `Version`
-   - Switch the `Release` back to `1%{?dist}`
-   - Remove any patches obsoleted by the new release
-   - Run `go-mods-to-bundled-provides.py | sort` while inside of the `ignition` directory you ran `./tag_release` from & copy output into spec file in `# Main package provides` section
-   - Update changelog
- - [ ] Run `spectool -g -S ignition.spec`
- - [ ] Run `kinit your_account@IPA.REDHAT.COM`
- - [ ] Run `rhpkg new-sources $(spectool -S ignition.spec | sed 's:.*/::')`
- - [ ] PR the changes
- - [ ] Get the PR reviewed and merge it
- - [ ] Update your local repo and run `rhpkg build`
-
 CentOS Stream 9 packaging:
   - [ ] Create a `rebase-c9s-ignition` issue in the internal team-operations repo and follow the steps there
+
+CentOS Stream 10 packaging:
+  - [ ] Create a `rebase-c10s-ignition` issue in the internal team-operations repo and follow the steps there


### PR DESCRIPTION
We don't need to build rhaos packages any longer as we pull them from RHEL. Let's drop it here and also add c10s steps.