### PR TITLE
.cci.jenkinsfile: switch to `cosa osbuild`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -69,9 +69,7 @@ cosaPod {
     }, testiso: {
         shwrap("""
             cd /srv/coreos
-            cosa buildextend-metal
-            cosa buildextend-metal4k
-            cosa buildextend-live --fast
+            cosa osbuild metal metal4k live
         """)
         kolaTestIso()
     }


### PR DESCRIPTION
These can now be built in a single invocation so let's do that.