### PR TITLE
Dockerfile: use quay.io as source for Fedora base image

### DIFF
--- a/Dockerfile.validate
+++ b/Dockerfile.validate
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:42 AS builder
+FROM quay.io/fedora/fedora:42 AS builder
 RUN dnf install -y golang git-core
 RUN mkdir /ignition-validate
 COPY . /ignition-validate


### PR DESCRIPTION
Switch the builder stage from `registry.fedoraproject.org` to `quay.io/fedora/fedora:42` to align with common usage in container build workflows.

Ref : https://github.com/coreos/fedora-coreos-tracker/issues/1851