### PR TITLE
dracut: Ignore module when building kdump initrd

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -3,6 +3,11 @@
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
 check() {
+    # Ignore when building kdump initrd
+    if [[ $hostonly_mode == "strict" ]]; then 
+        return 1
+    fi
+
     # Only include this if another module requests it.
     # In our case it'll be the distro provided module with integration and customizations
     # (coreos-ignition/ignition-microos/...).


### PR DESCRIPTION
Related to: coreos/fedora-coreos-tracker#1832