### PR TITLE
oraclecloud: do not wrap errors from FetchToBuffer

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Fix fetch-offline for Oracle Cloud Infrastructure
 
 ## Ignition 2.22.0 (2025-07-08)
 Starting with this release, ignition-validate binaries are signed with the

--- a/internal/providers/oraclecloud/oraclecloud.go
+++ b/internal/providers/oraclecloud/oraclecloud.go
@@ -53,7 +53,8 @@ func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 		RetryCodes: []int{http.StatusTooManyRequests},
 	})
 	if err != nil && err != resource.ErrNotFound {
-		return types.Config{}, report.Report{}, fmt.Errorf("fetching to buffer: %w", err)
+		// Do not wrap these errors, ignition uses direct comparsion to distinguish them.
+		return types.Config{}, report.Report{}, err
 	}
 
 	userdata := make([]byte, base64.StdEncoding.DecodedLen(len(data)))


### PR DESCRIPTION
Ignition internal machinery relies on being able to match against an error directly, in this case, `ErrNeedNet`. By wrapping errors from `FetchToBuffer`, ignition would not be able to detect the lack of networking during `fetch-offline` phase and fail to run.