### PR TITLE
providers: add UpCloud provider

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,8 @@ nav_order: 9
 
 ### Features
 
+- Support UpCloud
+
 ### Changes
 
 ### Bug fixes

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -30,6 +30,7 @@ Ignition is currently supported for the following platforms:
 * [IBM Power Systems Virtual Server] (`powervs`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [QEMU] (`qemu`) - Ignition will read its configuration from the 'opt/com.coreos/config' key on the QEMU Firmware Configuration Device (available in QEMU 2.4.0 and higher).
 * [Scaleway] (`scaleway`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
+* [UpCloud] (`upcloud`) - Ignition will read its configuration from the instance userdata fetched from the metadata service (which is NOT enabled by default, make sure you enable it if you use custom images). Cloud SSH keys are handled separately.
 * [VirtualBox] (`virtualbox`) - Use the VirtualBox guest property `/Ignition/Config` to provide the config to the virtual machine.
 * [VMware] (`vmware`) - Use the VMware Guestinfo variables `ignition.config.data` and `ignition.config.data.encoding` to provide the config and its encoding to the virtual machine. Valid encodings are "", "base64", and "gzip+base64". Guestinfo variables can be provided directly or via an OVF environment, with priority given to variables specified directly.
 * [Vultr] (`vultr`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
@@ -62,6 +63,7 @@ For most cloud providers, cloud SSH keys and custom network configuration are ha
 [IBM Power Systems Virtual Server]: https://www.ibm.com/products/power-virtual-server
 [QEMU]: https://www.qemu.org/
 [Scaleway]: https://www.scaleway.com
+[UpCloud]: https://www.upcloud.com
 [VirtualBox]: https://www.virtualbox.org/
 [VMware]: https://www.vmware.com/
 [Vultr]: https://www.vultr.com/products/cloud-compute/

--- a/internal/providers/upcloud/upcloud.go
+++ b/internal/providers/upcloud/upcloud.go
@@ -1,0 +1,54 @@
+// Copyright 2025 UpCloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The UpCloud provider fetches a remote configuration from the UpCloud
+// user_data metadata service URL.
+// https://developers.upcloud.com/1.3/8-servers/#metadata-service
+
+package upcloud
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/v3_6_experimental/types"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	userdataURL = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "metadata/v1/user_data",
+	}
+)
+
+func init() {
+	platform.Register(platform.Provider{
+		Name:  "upcloud",
+		Fetch: fetchConfig,
+	})
+}
+
+func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataURL, resource.FetchOptions{})
+	if err != nil && err != resource.ErrNotFound {
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/proxmoxve"
 	_ "github.com/coreos/ignition/v2/internal/providers/qemu"
 	_ "github.com/coreos/ignition/v2/internal/providers/scaleway"
+	_ "github.com/coreos/ignition/v2/internal/providers/upcloud"
 	_ "github.com/coreos/ignition/v2/internal/providers/virtualbox"
 	_ "github.com/coreos/ignition/v2/internal/providers/vmware"
 	_ "github.com/coreos/ignition/v2/internal/providers/vultr"


### PR DESCRIPTION
This PR adds support for fetching the ignition config from UpCloud metadata service.

Successfully tested with a custom-built flatcar image.