### PR TITLE
Add clevis pin for Trustee

### DIFF
--- a/config/v3_3/types/clevis.go
+++ b/config/v3_3/types/clevis.go
@@ -35,7 +35,7 @@ func (cu ClevisCustom) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if util.NotEmpty(cu.Pin) {
 		switch *cu.Pin {
-		case "tpm2", "tang", "sss":
+		case "tpm2", "tang", "sss", "trustee":
 		default:
 			r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
 		}

--- a/config/v3_3/types/clevis_test.go
+++ b/config/v3_3/types/clevis_test.go
@@ -65,6 +65,14 @@ func TestClevisCustomValidate(t *testing.T) {
 			at:  path.New("", "config"),
 			out: errors.ErrClevisConfigRequired,
 		},
+		{
+			in: ClevisCustom{
+				Config:       util.StrToPtr("z"),
+				NeedsNetwork: util.BoolToPtr(true),
+				Pin:          util.StrToPtr("trustee"),
+			},
+			out: nil,
+		},
 	}
 
 	for i, test := range tests {

--- a/config/v3_4/types/clevis.go
+++ b/config/v3_4/types/clevis.go
@@ -35,7 +35,7 @@ func (cu ClevisCustom) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if util.NotEmpty(cu.Pin) {
 		switch *cu.Pin {
-		case "tpm2", "tang", "sss":
+		case "tpm2", "tang", "sss", "trustee":
 		default:
 			r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
 		}

--- a/config/v3_4/types/clevis_test.go
+++ b/config/v3_4/types/clevis_test.go
@@ -65,6 +65,14 @@ func TestClevisCustomValidate(t *testing.T) {
 			at:  path.New("", "config"),
 			out: errors.ErrClevisConfigRequired,
 		},
+		{
+			in: ClevisCustom{
+				Config:       util.StrToPtr("z"),
+				NeedsNetwork: util.BoolToPtr(true),
+				Pin:          util.StrToPtr("trustee"),
+			},
+			out: nil,
+		},
 	}
 
 	for i, test := range tests {

--- a/config/v3_5/types/clevis.go
+++ b/config/v3_5/types/clevis.go
@@ -35,7 +35,7 @@ func (cu ClevisCustom) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if util.NotEmpty(cu.Pin) {
 		switch *cu.Pin {
-		case "tpm2", "tang", "sss":
+		case "tpm2", "tang", "sss", "trustee":
 		default:
 			r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
 		}

--- a/config/v3_5/types/clevis_test.go
+++ b/config/v3_5/types/clevis_test.go
@@ -65,6 +65,14 @@ func TestClevisCustomValidate(t *testing.T) {
 			at:  path.New("", "config"),
 			out: errors.ErrClevisConfigRequired,
 		},
+		{
+			in: ClevisCustom{
+				Config:       util.StrToPtr("z"),
+				NeedsNetwork: util.BoolToPtr(true),
+				Pin:          util.StrToPtr("trustee"),
+			},
+			out: nil,
+		},
 	}
 
 	for i, test := range tests {

--- a/config/v3_6_experimental/types/clevis.go
+++ b/config/v3_6_experimental/types/clevis.go
@@ -35,7 +35,7 @@ func (cu ClevisCustom) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if util.NotEmpty(cu.Pin) {
 		switch *cu.Pin {
-		case "tpm2", "tang", "sss":
+		case "tpm2", "tang", "sss", "trustee":
 		default:
 			r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
 		}

--- a/config/v3_6_experimental/types/clevis_test.go
+++ b/config/v3_6_experimental/types/clevis_test.go
@@ -65,6 +65,14 @@ func TestClevisCustomValidate(t *testing.T) {
 			at:  path.New("", "config"),
 			out: errors.ErrClevisConfigRequired,
 		},
+		{
+			in: ClevisCustom{
+				Config:       util.StrToPtr("z"),
+				NeedsNetwork: util.BoolToPtr(true),
+				Pin:          util.StrToPtr("trustee"),
+			},
+			out: nil,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Add trustee as supported clevis pin.

Trustee is an attestation server which release a secret upon a successful attestation. The secret will be used by clevis to encrypt/decrypt the disk.