### PR TITLE
#2128 - Fix device mapper partitioning

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,7 @@ nav_order: 9
 ### Bug fixes
 
 - Fix fetch-offline for Oracle Cloud Infrastructure
+- Fix multipath partitioning: ignore DM holders when no partitions are mounted;continue to refuse if the disk or any partition is active. ([#2128](https://github.com/coreos/ignition/issues/2128))
 
 ## Ignition 2.22.0 (2025-07-08)
 Starting with this release, ignition-validate binaries are signed with the


### PR DESCRIPTION
When run ignition on a device mapper, ie, multipath, it fails because the function blockDevHeld returns true as the block device contains holders. A block device with holders do not necessary means the block device is in use (like mounted).
The function blockDevInUse should look for mounted devices only.

fixes #2128 