### PR TITLE
kubevirt: Support nocloud user-data

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,8 @@ nav_order: 9
 
 ### Features
 
+- Add support for nocloud config fetching in kubevirt
+
 ### Changes
 
 ### Bug fixes

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -20,7 +20,7 @@ Ignition is currently supported for the following platforms:
 * [Hetzner Cloud] (`hetzner`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Microsoft Hyper-V] (`hyperv`) - Ignition will read its configuration from the `ignition.config` key in pool 0 of the Hyper-V Data Exchange Service (KVP). Values are limited to approximately 1 KiB of text, so Ignition can also read and concatenate multiple keys named `ignition.config.0`, `ignition.config.1`, and so on.
 * [IBM Cloud] (`ibmcloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
-* [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
+* [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via `cloudInitConfigDrive` or `cloudInitNoCloud`. Cloud SSH keys are handled separately.
 * Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, `arn:`, or `gs://` schemes to specify a remote config.
 * [Nutanix] (`nutanix`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.


### PR DESCRIPTION
At kubevirt one can configure the cloud init as config drive or nocloud, with config drive is the current approch, this change add the nocloud that spect a device mount with "cidata" label and tue user data file at /user-data there, also the main different if that on those cases the network data follows the netplan v1 or v2 that's is better format than the openstack meta data network service one.