### PR TITLE
luks: fix occasional cex.key file removal

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,7 +15,7 @@ nav_order: 9
 ### Changes
 
 ### Bug fixes
-
+- Fix occasional cex.key file removal
 
 ## Ignition 2.23.0 (2025-09-10)
 

--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -132,11 +132,13 @@ func (s *stage) createLuks(config types.Config) error {
 			if err := keyFile.Close(); err != nil {
 				s.Warning("could not close file %s: %v", keyFilePath, err)
 			}
-			defer func() {
-				if err = os.Remove(keyFilePath); err != nil {
-					s.Warning("could not remove file %s: %v", keyFilePath, err)
+			// We must pass 'keyFilePath' as a parameter here, since it may change below (cex).
+			// Otherwise, the deferred function will see the modified value instead of the original one.
+			defer func(name string) {
+				if removeErr := os.Remove(name); removeErr != nil {
+					s.Warning("could not remove file %s: %v", name, removeErr)
 				}
-			}()
+			}(keyFilePath)
 
 			if luks.Cex.IsPresent() {
 				// each LUKS device has associated keyfiles


### PR DESCRIPTION
https://github.com/coreos/ignition/commit/1df22385190ad55fbde8160998f8323a50d34a08 broke CEX:
```
[   30.496802] ignition-ostree-growfs[1118]: + cryptsetup resize root --key-file /etc/luks/cex.key
[   30.501834] ignition-ostree-growfs[1257]: Failed to open key file.
```

Issue: https://github.com/coreos/rhel-coreos-config/issues/76