### PR TITLE
Nvidia Bluefield ignition provider

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,7 @@ nav_order: 9
 ### Features
 
 - The name for custom clevis pins is not validated by Ignition anymore, enabling the use of arbitrary custom pins _(3.6.0-exp)_
+- Add NVIDIA BlueField provider
 
 ### Changes
 

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -23,6 +23,7 @@ Ignition is currently supported for the following platforms:
 * [KubeVirt] (`kubevirt`) - Ignition will read its configuration from the instance userdata via `cloudInitConfigDrive` or `cloudInitNoCloud`. Cloud SSH keys are handled separately.
 * Bare Metal (`metal`) - Use the `ignition.config.url` kernel parameter to provide a URL to the configuration. The URL can use the `http://`, `https://`, `tftp://`, `s3://`, `arn:`, or `gs://` schemes to specify a remote config.
 * [Nutanix] (`nutanix`) - Ignition will read its configuration from the instance userdata via config drive. Cloud SSH keys are handled separately.
+* [NVIDIA BlueField] (`nvidiabluefield`) - Ignition will read its configuration from the bootfifo sysfs interface from the mlxbf_bootctl platform driver.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.
 * [Oracle Cloud Infrastucture] (`oraclecloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Proxmox VE] (`proxmoxve`) - Ignition will read its configuration from the instance userdata via config drive. If there isn't any valid Ignition configuration in userdata it will check the vendordata next. Cloud SSH keys are handled separately.

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -123,5 +123,10 @@ installkernel() {
         instmods -c zcrypt_cex4
         instmods -c pkey_cca
      fi
+
+     # required by nvidiabluefield platform to read ignition file through bootfifo sysfs interface
+     if [[ ${DRACUT_ARCH:-$(uname -m)} == aarch64 ]]; then
+        instmods -c mlxbf_bootctl
+     fi
 }
 

--- a/internal/providers/nvidiabluefield/nvidiabluefield.go
+++ b/internal/providers/nvidiabluefield/nvidiabluefield.go
@@ -1,0 +1,75 @@
+// Copyright 2025 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The NVIDIA BlueField [1] provider fetches configurations from the bootfifo interface.
+// [1] https://www.nvidia.com/en-eu/networking/products/data-processing-unit
+
+package nvidiabluefield
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/coreos/ignition/v2/config/v3_6_experimental/types"
+	"github.com/coreos/ignition/v2/internal/distro"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+// bootfifo paths are exposed in sysfs by the mlxbf_bootctl platform driver.
+// https://github.com/torvalds/linux/blob/2fbe820/drivers/platform/mellanox/mlxbf-bootctl.c#L954
+var bootfifoPaths = []string{
+	"/sys/bus/platform/devices/MLNXBF04:00/bootfifo",
+}
+
+func init() {
+	platform.Register(platform.Provider{
+		Name:  "nvidiabluefield",
+		Fetch: fetchConfig,
+	})
+}
+
+func fetchConfig(f *resource.Fetcher) (cfg types.Config, rpt report.Report, err error) {
+	// load mlxbf_bootctl module
+	if _, err = f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "mlxbf_bootctl"), "loading mlxbf-booctl kernel module"); err != nil {
+		return
+	}
+
+	for _, bootfifoPath := range bootfifoPaths {
+		f.Logger.Debug("Attempting to read bootfifo at %s", bootfifoPath)
+		raw, err := os.ReadFile(bootfifoPath)
+
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			f.Logger.Err("Could not read bootfifo at %s: %v", bootfifoPath, err)
+			continue
+		}
+
+		if len(raw) == 0 {
+			f.Logger.Info("%s is empty", bootfifoPath)
+			continue
+		}
+
+		data := bytes.Trim(raw, "\x00")
+		return util.ParseConfig(f.Logger, data)
+	}
+
+	f.Logger.Info("No config found in any of the NVIDIA BlueField bootfifo interfaces")
+	return types.Config{}, report.Report{}, err
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/kubevirt"
 	_ "github.com/coreos/ignition/v2/internal/providers/metal"
 	_ "github.com/coreos/ignition/v2/internal/providers/nutanix"
+	_ "github.com/coreos/ignition/v2/internal/providers/nvidiabluefield"
 	_ "github.com/coreos/ignition/v2/internal/providers/openstack"
 	_ "github.com/coreos/ignition/v2/internal/providers/oraclecloud"
 	_ "github.com/coreos/ignition/v2/internal/providers/packet"


### PR DESCRIPTION
`nvidiabluefield` is an ignition provider for Nvidia BlueField DPUs.

It uses the `bootfifo` device provided by the `mlxbf-bootctl` kernel module to pull the ignition.

Previous discussion is at issue #2148 
