### PR TITLE
OCPBUGS-65684: Fix invalid random source in FIPS 140-only mode in FIPS mode

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ nav_order: 9
 
 ### Bug fixes
 
+- Fix invalid random source in FIPS 140-only mode in FIPS mode ([#2159](https://github.com/coreos/ignition/pull/2159))
 
 ## Ignition 2.24.0 (2024-10-14)
 


### PR DESCRIPTION
When igntion is compiled with GOEXPERIMENT=strictfipsruntime and running in a computer with FIPS enabled, the random source is invalid.

Instead of use a custom random on TLS config, we must do not set a random source at all as it will use crypto/rand.Reader by default