### PR TITLE
internal/providers: Only load kernel modules when actually necessary

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,7 @@ nav_order: 9
 ### Bug fixes
 
 - Fix invalid random source in FIPS 140-only mode in FIPS mode ([#2159](https://github.com/coreos/ignition/pull/2159))
+- Only load kernel modules when actually necessary so that they can be built-in ([#2164](https://github.com/coreos/ignition/pull/2164))
 
 
 ## Ignition 2.24.0 (2024-10-14)

--- a/internal/providers/hyperv/kvp.go
+++ b/internal/providers/hyperv/kvp.go
@@ -16,6 +16,7 @@ package hyperv
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -47,9 +48,10 @@ func fetchConfig(f *resource.Fetcher) ([]types.File, types.Config, report.Report
 
 	// To read key-value pairs from the Windows host, the hv_util kernel
 	// module must be loaded to create the kernel device
-	_, err := f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "hv_utils"), "loading hv_utils kernel module")
-	if err != nil {
-		return nil, types.Config{}, report.Report{}, fmt.Errorf("loading hv_utils kernel module: %w", err)
+	if _, statErr := os.Stat("/sys/bus/vmbus/drivers/hv_utils"); statErr != nil {
+		if _, err := f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "hv_utils"), "loading hv_utils kernel module"); err != nil {
+			return nil, types.Config{}, report.Report{}, fmt.Errorf("loading hv_utils kernel module: %w", err)
+		}
 	}
 
 	keyValuePairs, err := kvp.GetKeyValuePairs()

--- a/internal/providers/qemu/qemu_blockdev.go
+++ b/internal/providers/qemu/qemu_blockdev.go
@@ -52,9 +52,10 @@ func init() {
 func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
 	f.Logger.Warning("Fetching the Ignition config via the Virtio block driver is currently experimental and subject to change.")
 
-	_, err := f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "virtio_blk"), "loading Virtio block driver module")
-	if err != nil {
-		return types.Config{}, report.Report{}, err
+	if _, statErr := os.Stat("/sys/bus/virtio/drivers/virtio_blk"); statErr != nil {
+		if _, err := f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "virtio_blk"), "loading Virtio block driver module"); err != nil {
+			return types.Config{}, report.Report{}, err
+		}
 	}
 
 	data, err := fetchConfigFromBlockDevice(f.Logger)

--- a/internal/providers/qemu/qemu_fwcfg.go
+++ b/internal/providers/qemu/qemu_fwcfg.go
@@ -51,8 +51,10 @@ func init() {
 
 func fetchConfig(f *resource.Fetcher) (cfg types.Config, rpt report.Report, err error) {
 	// load qemu_fw_cfg module
-	if _, err = f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "qemu_fw_cfg"), "loading QEMU firmware config module"); err != nil {
-		return
+	if _, statErr := os.Stat("/sys/firmware/qemu_fw_cfg"); statErr != nil {
+		if _, err = f.Logger.LogCmd(exec.Command(distro.ModprobeCmd(), "qemu_fw_cfg"), "loading QEMU firmware config module"); err != nil {
+			return
+		}
 	}
 
 	// get size of firmware blob, if it exists


### PR DESCRIPTION
If the modules are built-in, attempting to load them with modprobe will cause a fatal error. Having them built-in makes kernel debugging easier.

I didn't touch the vmur (zvm) module as I'm not familiar with that.