### PR TITLE
docs/release-notes: add a note correcting the date for v2.24.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,9 @@ Starting with this release, ignition-validate binaries are signed with the
 
 ## Ignition 2.24.0 (2024-10-14)
 
+This version was actually released 2025-10-14, but changing the title now would
+invalidate links to this entry here in the release notes.
+
 ### Features
 
 - Add support for nocloud config fetching in kubevirt


### PR DESCRIPTION
As stated in the note, not changing the subheader for that release to not invalidate any links pointing to it - I think this is a good middle ground between correct and pragmatic.

Noticed while adding release note link here: https://github.com/flatcar/scripts/pull/3533