### PR TITLE
Backport of arbitrary custom clevis pin in ignition spec 3.5

### DIFF
--- a/config/v3_5/types/clevis.go
+++ b/config/v3_5/types/clevis.go
@@ -33,13 +33,7 @@ func (cu ClevisCustom) Validate(c path.ContextPath) (r report.Report) {
 	if util.NilOrEmpty(cu.Pin) && util.NilOrEmpty(cu.Config) && !util.IsTrue(cu.NeedsNetwork) {
 		return
 	}
-	if util.NotEmpty(cu.Pin) {
-		switch *cu.Pin {
-		case "tpm2", "tang", "sss":
-		default:
-			r.AddOnError(c.Append("pin"), errors.ErrUnknownClevisPin)
-		}
-	} else {
+	if util.NilOrEmpty(cu.Pin) {
 		r.AddOnError(c.Append("pin"), errors.ErrClevisPinRequired)
 	}
 	if util.NilOrEmpty(cu.Config) {

--- a/config/v3_5/types/clevis_test.go
+++ b/config/v3_5/types/clevis_test.go
@@ -56,7 +56,7 @@ func TestClevisCustomValidate(t *testing.T) {
 				Pin:    util.StrToPtr("z"),
 			},
 			at:  path.New("", "pin"),
-			out: errors.ErrUnknownClevisPin,
+			out: nil,
 		},
 		{
 			in: ClevisCustom{

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,7 +22,7 @@ Starting with this release, ignition-validate binaries are signed with the
 
 ### Features
 
-- The name for custom clevis pins is not validated by Ignition anymore, enabling the use of arbitrary custom pins _(3.6.0-exp)_
+- The name for custom clevis pins is not validated by Ignition anymore, enabling the use of arbitrary custom pins _(3.5)_
 - Add NVIDIA BlueField provider
 
 ### Bug fixes


### PR DESCRIPTION
The original PR is https://github.com/coreos/ignition/pull/2145.

In order to support new clevis pin, either they need to be added each time in the hardcoded list of pins or ignition can allow any name for the pin. This is required in order to enable the clevis trustee pin used for confidential clusters.

The backport to 3.5 is necessary because the rust crate for ignition only support up to 3.5 config version and cannot be used with 3.6-experimental.
