### PR TITLE
Worktree fix luks soft reboot

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,8 @@ nav_order: 9
 
 ### Bug fixes
 
+- Add `x-initrd.attach` to crypttab entries on ostree systems to fix soft-reboot with LUKS ([#2219](https://github.com/coreos/ignition/pull/2219))
+
 
 ## Ignition 2.26.0 (2026-02-17)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,6 +27,7 @@ Starting with this release, ignition-validate binaries are signed with the
 
 - Fix giving disk partition number 0 to get the next available slot. This caused the disks stage to fail since version 2.20.0. ([#2234](https://github.com/coreos/ignition/pull/2234))
 - Fix disk partitioning race condition where the kernel is already aware of the changes before running `partx`, causing a fatal error. ([#2234](https://github.com/coreos/ignition/pull/2234))
+- Add `x-initrd.attach` to crypttab entries to fix soft-reboot with LUKS ([#2219](https://github.com/coreos/ignition/pull/2219))
 
 
 ## Ignition 2.26.0 (2026-02-17)

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -33,6 +33,37 @@ import (
 	"github.com/vincent-petithory/dataurl"
 )
 
+// isOstreeSystem checks if the system is running ostree by checking for
+// the presence of /run/ostree-booted. This marker file is created by
+// ostree during boot. Also supports OSTREE_BOOTED=1 environment variable
+// for testing.
+func isOstreeSystem(ostreeBootedPath string) bool {
+	if os.Getenv("OSTREE_BOOTED") == "1" {
+		return true
+	}
+	_, err := os.Stat(ostreeBootedPath)
+	return err == nil
+}
+
+// buildCrypttabOptions constructs the options suffix for a crypttab entry.
+// It adds _netdev if network is needed and x-initrd.attach on ostree systems.
+// The x-initrd.attach option prevents systemd-cryptsetup-generator from adding
+// Conflicts=umount.target, which is necessary for soft-reboot to work correctly
+// on ostree systems where /sysroot is not the kernel root mount.
+func buildCrypttabOptions(hasNetworkDev, isOstree bool) string {
+	var options []string
+	if hasNetworkDev {
+		options = append(options, "_netdev")
+	}
+	if isOstree {
+		options = append(options, "x-initrd.attach")
+	}
+	if len(options) == 0 {
+		return ""
+	}
+	return "," + strings.Join(options, ",")
+}
+
 // createCrypttabEntries creates entries inside of /etc/crypttab for LUKS volumes,
 // as well as copying keyfiles to the sysroot.
 func (s *stage) createCrypttabEntries(config types.Config) error {
@@ -55,6 +86,11 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 			Mode: cutil.IntToPtr(0600),
 		},
 	}
+
+	// Detect if we're on an ostree system
+	// Check the host's /run directory, not the target sysroot
+	isOstree := isOstreeSystem("/run/ostree-booted")
+
 	extrafiles := []filesystemEntry{}
 	for _, luks := range config.Storage.Luks {
 		out, err := exec.Command(distro.CryptsetupCmd(), "luksUUID", util.DeviceAlias(*luks.Device)).CombinedOutput()
@@ -62,10 +98,7 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 			return fmt.Errorf("gathering luks uuid: %s: %v", out, err)
 		}
 		uuid := strings.TrimSpace(string(out))
-		netdev := ""
-		if len(luks.Clevis.Tang) > 0 || cutil.NotEmpty(luks.Clevis.Custom.Pin) && cutil.IsTrue(luks.Clevis.Custom.NeedsNetwork) {
-			netdev = ",_netdev"
-		}
+		hasNetworkDev := len(luks.Clevis.Tang) > 0 || cutil.NotEmpty(luks.Clevis.Custom.Pin) && cutil.IsTrue(luks.Clevis.Custom.NeedsNetwork)
 		keyfile := "none"
 		if !luks.Clevis.IsPresent() {
 			keyfile = filepath.Join(distro.LuksRealRootKeyFilePath(), luks.Name)
@@ -91,7 +124,8 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 				},
 			})
 		}
-		uri := dataurl.EncodeBytes([]byte(fmt.Sprintf("%s UUID=%s %s luks%s\n", luks.Name, uuid, keyfile, netdev)))
+		options := buildCrypttabOptions(hasNetworkDev, isOstree)
+		uri := dataurl.EncodeBytes([]byte(fmt.Sprintf("%s UUID=%s %s luks%s\n", luks.Name, uuid, keyfile, options)))
 		crypttab.Append = append(crypttab.Append, types.Resource{
 			Source: &uri,
 		})

--- a/internal/exec/stages/files/filesystemEntries.go
+++ b/internal/exec/stages/files/filesystemEntries.go
@@ -33,6 +33,19 @@ import (
 	"github.com/vincent-petithory/dataurl"
 )
 
+// buildCrypttabOptions constructs the options suffix for a crypttab entry.
+// It always adds x-initrd.attach and adds _netdev if network is needed.
+// The x-initrd.attach option prevents systemd-cryptsetup-generator from
+// adding Conflicts=umount.target, which is necessary for soft-reboot to
+// work correctly with LUKS.
+func buildCrypttabOptions(hasNetworkDev bool) string {
+	options := "x-initrd.attach"
+	if hasNetworkDev {
+		options = "_netdev," + options
+	}
+	return "," + options
+}
+
 // createCrypttabEntries creates entries inside of /etc/crypttab for LUKS volumes,
 // as well as copying keyfiles to the sysroot.
 func (s *stage) createCrypttabEntries(config types.Config) error {
@@ -62,10 +75,7 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 			return fmt.Errorf("gathering luks uuid: %s: %v", out, err)
 		}
 		uuid := strings.TrimSpace(string(out))
-		netdev := ""
-		if len(luks.Clevis.Tang) > 0 || cutil.NotEmpty(luks.Clevis.Custom.Pin) && cutil.IsTrue(luks.Clevis.Custom.NeedsNetwork) {
-			netdev = ",_netdev"
-		}
+		hasNetworkDev := len(luks.Clevis.Tang) > 0 || cutil.NotEmpty(luks.Clevis.Custom.Pin) && cutil.IsTrue(luks.Clevis.Custom.NeedsNetwork)
 		keyfile := "none"
 		if !luks.Clevis.IsPresent() {
 			keyfile = filepath.Join(distro.LuksRealRootKeyFilePath(), luks.Name)
@@ -91,7 +101,8 @@ func (s *stage) createCrypttabEntries(config types.Config) error {
 				},
 			})
 		}
-		uri := dataurl.EncodeBytes([]byte(fmt.Sprintf("%s UUID=%s %s luks%s\n", luks.Name, uuid, keyfile, netdev)))
+		options := buildCrypttabOptions(hasNetworkDev)
+		uri := dataurl.EncodeBytes([]byte(fmt.Sprintf("%s UUID=%s %s luks%s\n", luks.Name, uuid, keyfile, options)))
 		crypttab.Append = append(crypttab.Append, types.Resource{
 			Source: &uri,
 		})

--- a/internal/exec/stages/files/filesystemEntries_test.go
+++ b/internal/exec/stages/files/filesystemEntries_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestIsOstreeSystem tests the ostree system detection function
+func TestIsOstreeSystem(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupFunc   func(string) error
+		expected    bool
+		description string
+	}{
+		{
+			name: "ostree system",
+			setupFunc: func(tmpDir string) error {
+				ostreeMarker := filepath.Join(tmpDir, "run", "ostree-booted")
+				if err := os.MkdirAll(filepath.Dir(ostreeMarker), 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(ostreeMarker, []byte(""), 0644)
+			},
+			expected:    true,
+			description: "Should detect ostree system when /run/ostree-booted exists",
+		},
+		{
+			name: "non-ostree system",
+			setupFunc: func(tmpDir string) error {
+				// Just create the run directory without the ostree-booted file
+				return os.MkdirAll(filepath.Join(tmpDir, "run"), 0755)
+			},
+			expected:    false,
+			description: "Should not detect ostree when /run/ostree-booted is missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "ignition-test-")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			defer func() {
+				if err := os.RemoveAll(tmpDir); err != nil {
+					t.Logf("failed to remove temp dir: %v", err)
+				}
+			}()
+
+			if err := tt.setupFunc(tmpDir); err != nil {
+				t.Fatalf("setup failed: %v", err)
+			}
+
+			result := isOstreeSystem(filepath.Join(tmpDir, "run", "ostree-booted"))
+			if result != tt.expected {
+				t.Errorf("%s: got %v, want %v", tt.description, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestCrypttabOptionsGeneration tests that the crypttab options are generated correctly
+func TestCrypttabOptionsGeneration(t *testing.T) {
+	tests := []struct {
+		name           string
+		hasNetworkDev  bool
+		isOstree       bool
+		expectedResult string
+		expectedFormat string
+		description    string
+	}{
+		{
+			name:           "regular system without network",
+			hasNetworkDev:  false,
+			isOstree:       false,
+			expectedResult: "",
+			expectedFormat: "testdev UUID=test-uuid /path/to/keyfile luks\n",
+			description:    "Should have no options on non-ostree without network",
+		},
+		{
+			name:           "regular system with network",
+			hasNetworkDev:  true,
+			isOstree:       false,
+			expectedResult: ",_netdev",
+			expectedFormat: "testdev UUID=test-uuid /path/to/keyfile luks,_netdev\n",
+			description:    "Should have _netdev on non-ostree with network",
+		},
+		{
+			name:           "ostree system without network",
+			hasNetworkDev:  false,
+			isOstree:       true,
+			expectedResult: ",x-initrd.attach",
+			expectedFormat: "testdev UUID=test-uuid /path/to/keyfile luks,x-initrd.attach\n",
+			description:    "Should have x-initrd.attach on ostree without network",
+		},
+		{
+			name:           "ostree system with network",
+			hasNetworkDev:  true,
+			isOstree:       true,
+			expectedResult: ",_netdev,x-initrd.attach",
+			expectedFormat: "testdev UUID=test-uuid /path/to/keyfile luks,_netdev,x-initrd.attach\n",
+			description:    "Should have both _netdev and x-initrd.attach on ostree with network",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := buildCrypttabOptions(tt.hasNetworkDev, tt.isOstree)
+
+			// Check the options string is exactly what we expect
+			if options != tt.expectedResult {
+				t.Errorf("%s:\n  got options:  %q\n  want options: %q", tt.description, options, tt.expectedResult)
+			}
+
+			// Build the full crypttab line for format verification
+			crypttabLine := "testdev UUID=test-uuid /path/to/keyfile luks" + options + "\n"
+			if crypttabLine != tt.expectedFormat {
+				t.Errorf("%s:\n  got line:  %q\n  want line: %q", tt.description, crypttabLine, tt.expectedFormat)
+			}
+		})
+	}
+}
+
+// TestCrypttabOptionsWithClevis tests crypttab options when using Clevis
+func TestCrypttabOptionsWithClevis(t *testing.T) {
+	tests := []struct {
+		name            string
+		hasNetworkDev   bool
+		isOstree        bool
+		expectedKeyfile string
+		expectedOptions string
+		expectedLine    string
+		description     string
+	}{
+		{
+			name:            "clevis on regular system",
+			hasNetworkDev:   true,
+			isOstree:        false,
+			expectedKeyfile: "none",
+			expectedOptions: ",_netdev",
+			expectedLine:    "testdev UUID=test-uuid none luks,_netdev\n",
+			description:     "Clevis should use 'none' as keyfile on non-ostree",
+		},
+		{
+			name:            "clevis on ostree system",
+			hasNetworkDev:   true,
+			isOstree:        true,
+			expectedKeyfile: "none",
+			expectedOptions: ",_netdev,x-initrd.attach",
+			expectedLine:    "testdev UUID=test-uuid none luks,_netdev,x-initrd.attach\n",
+			description:     "Clevis should use 'none' as keyfile and have x-initrd.attach on ostree",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := buildCrypttabOptions(tt.hasNetworkDev, tt.isOstree)
+
+			// Check the options are correct
+			if options != tt.expectedOptions {
+				t.Errorf("%s:\n  got options:  %q\n  want options: %q", tt.description, options, tt.expectedOptions)
+			}
+
+			// Verify full crypttab entry format
+			crypttabLine := "testdev UUID=test-uuid " + tt.expectedKeyfile + " luks" + options + "\n"
+			if crypttabLine != tt.expectedLine {
+				t.Errorf("%s:\n  got line:  %q\n  want line: %q", tt.description, crypttabLine, tt.expectedLine)
+			}
+		})
+	}
+}

--- a/internal/exec/stages/files/filesystemEntries_test.go
+++ b/internal/exec/stages/files/filesystemEntries_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"testing"
+)
+
+func TestBuildCrypttabOptions(t *testing.T) {
+	tests := []struct {
+		name           string
+		hasNetworkDev  bool
+		expectedResult string
+		expectedFormat string
+	}{
+		{
+			name:           "without network",
+			hasNetworkDev:  false,
+			expectedResult: ",x-initrd.attach",
+			expectedFormat: "testdev UUID=test-uuid /path/to/keyfile luks,x-initrd.attach\n",
+		},
+		{
+			name:           "with network",
+			hasNetworkDev:  true,
+			expectedResult: ",_netdev,x-initrd.attach",
+			expectedFormat: "testdev UUID=test-uuid /path/to/keyfile luks,_netdev,x-initrd.attach\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := buildCrypttabOptions(tt.hasNetworkDev)
+
+			if options != tt.expectedResult {
+				t.Errorf("got options %q, want %q", options, tt.expectedResult)
+			}
+
+			crypttabLine := "testdev UUID=test-uuid /path/to/keyfile luks" + options + "\n"
+			if crypttabLine != tt.expectedFormat {
+				t.Errorf("got line %q, want %q", crypttabLine, tt.expectedFormat)
+			}
+		})
+	}
+}
+
+func TestBuildCrypttabOptionsWithClevis(t *testing.T) {
+	tests := []struct {
+		name            string
+		hasNetworkDev   bool
+		expectedOptions string
+		expectedLine    string
+	}{
+		{
+			name:            "clevis without network",
+			hasNetworkDev:   false,
+			expectedOptions: ",x-initrd.attach",
+			expectedLine:    "testdev UUID=test-uuid none luks,x-initrd.attach\n",
+		},
+		{
+			name:            "clevis with network",
+			hasNetworkDev:   true,
+			expectedOptions: ",_netdev,x-initrd.attach",
+			expectedLine:    "testdev UUID=test-uuid none luks,_netdev,x-initrd.attach\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := buildCrypttabOptions(tt.hasNetworkDev)
+
+			if options != tt.expectedOptions {
+				t.Errorf("got options %q, want %q", options, tt.expectedOptions)
+			}
+
+			crypttabLine := "testdev UUID=test-uuid none luks" + options + "\n"
+			if crypttabLine != tt.expectedLine {
+				t.Errorf("got line %q, want %q", crypttabLine, tt.expectedLine)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add x-initrd.attach option unconditionally to all LUKS crypttab entries.
This prevents systemd-cryptsetup-generator from adding
Conflicts=umount.target, which is necessary for soft-reboot to work
correctly with LUKS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LUKS soft-reboot reliability by adding the required initramfs attachment option to crypttab entries.
  - Correctly handles encrypted devices that depend on network availability during startup.

- **Tests**
  - Added coverage for crypttab entries with and without network-dependent Clevis configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->