### PR TITLE
Sync repo templates ⚙

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -30,13 +30,13 @@ Fedora packaging:
  - [ ] Run `kinit your_fas_account@FEDORAPROJECT.ORG`
  - [ ] Run `fedpkg new-sources $(spectool -S ignition.spec | sed 's:.*/::')`
  - [ ] PR the changes in [Fedora](https://src.fedoraproject.org/rpms/ignition)
- - [ ] Once the PR merges to rawhide, merge rawhide into the other relevant branches (e.g. f43) then push those, for example:
+ - [ ] Once the PR merges to rawhide, merge rawhide into the other relevant branches (e.g. f44) then push those, for example:
    ```bash
    git checkout rawhide
    git pull --ff-only
-   git checkout f43
+   git checkout f44
    git merge --ff-only rawhide
-   git push origin f43
+   git push origin f44
    ```
  - [ ] On each of those branches run `fedpkg build` including rawhide.
  - [ ] Once the builds have finished, submit them to [bodhi](https://bodhi.fedoraproject.org/updates/new), filling in:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,9 @@ nav_order: 9
 
 ## Upcoming Ignition 2.27.0 (unreleased)
 
+Starting with this release, ignition-validate binaries are signed with the
+[Fedora 44 key](https://getfedora.org/security/).
+
 ### Breaking changes
 
 ### Features

--- a/signing-ticket.sh
+++ b/signing-ticket.sh
@@ -15,11 +15,11 @@ make_script() {
 #!/bin/bash
 set -eux -o pipefail
 
-# Use the Fedora 43 key for the detached signatures
-KEYTOSIGNWITH='fedora-43'
+# Use the Fedora 44 key for the detached signatures
+KEYTOSIGNWITH='fedora-44'
 
-VR='@@VERSION@@-@@RELEASE@@.fc43'
-RPMKEY='31645531' # Fedora 43 key
+VR='@@VERSION@@-@@RELEASE@@.fc44'
+RPMKEY='6d9f90a6' # Fedora 44 key
 
 do_sign() {
     # Sign with sigul unless FAKESIGN=1


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/repo-templates/actions/workflows/sync.yml) ([source](https://github.com/coreos/repo-templates/blob/main/.github/workflows/sync.yml)).

Sync with coreos/repo-templates@39d8ae6c600c856672a5386c1da8ad6969477156.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Fedora release checklist example to reflect the latest branch merge and push steps.
  * Clarified release notes to state that `ignition-validate` binaries are now signed with the Fedora 44 key.
* **Chores**
  * Brought signing-related templates and examples in line with Fedora 44.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->