### PR TITLE
Fix disk partitioning race condition and using partition number 0

### DIFF
--- a/config/shared/errors/errors.go
+++ b/config/shared/errors/errors.go
@@ -85,7 +85,6 @@ var (
 	ErrUnrecognizedRaidLevel            = errors.New("unrecognized raid level")
 	ErrRaidDevicesRequired              = errors.New("raid devices required")
 	ErrShouldNotExistWithOthers         = errors.New("shouldExist specified false with other options also specified")
-	ErrZeroesWithShouldNotExist         = errors.New("shouldExist is false for a partition and other partition(s) has start or size 0")
 	ErrNeedLabelOrNumber                = errors.New("a partition number >= 1 or a label must be specified")
 	ErrDuplicateLabels                  = errors.New("cannot use the same partition label twice")
 	ErrInvalidProxy                     = errors.New("proxies must be http(s)")

--- a/config/v3_0/types/disk.go
+++ b/config/v3_0/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_1/types/disk.go
+++ b/config/v3_1/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_2/types/disk.go
+++ b/config/v3_2/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_3/types/disk.go
+++ b/config/v3_3/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_4/types/disk.go
+++ b/config/v3_4/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_5/types/disk.go
+++ b/config/v3_5/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_6/types/disk.go
+++ b/config/v3_6/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/config/v3_7_experimental/types/disk.go
+++ b/config/v3_7_experimental/types/disk.go
@@ -16,7 +16,6 @@ package types
 
 import (
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
 
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
@@ -38,9 +37,6 @@ func (n Disk) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if overlaps, p := n.partitionsOverlap(); overlaps {
 		r.AddOnError(c.Append("partitions", p), errors.ErrPartitionsOverlap)
-	}
-	if n.partitionsMixZeroesAndNonexistence() {
-		r.AddOnError(c.Append("partitions"), errors.ErrZeroesWithShouldNotExist)
 	}
 	if collides, p := n.partitionLabelsCollide(); collides {
 		r.AddOnError(c.Append("partitions", p), errors.ErrDuplicateLabels)
@@ -122,14 +118,4 @@ func (n Disk) partitionsOverlap() (bool, int) {
 		}
 	}
 	return false, 0
-}
-
-func (n Disk) partitionsMixZeroesAndNonexistence() bool {
-	hasZero := false
-	hasShouldNotExist := false
-	for _, p := range n.Partitions {
-		hasShouldNotExist = hasShouldNotExist || util.IsFalse(p.ShouldExist)
-		hasZero = hasZero || (p.Number == 0)
-	}
-	return hasZero && hasShouldNotExist
 }

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,8 @@ nav_order: 9
 
 ### Bug fixes
 
+- Fix giving disk partition number 0 to get the next available slot. This caused the disks stage to fail since version 2.20.0. ([#2234](https://github.com/coreos/ignition/pull/2234))
+
 
 ## Ignition 2.26.0 (2026-02-17)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,7 @@ nav_order: 9
 ### Bug fixes
 
 - Fix giving disk partition number 0 to get the next available slot. This caused the disks stage to fail since version 2.20.0. ([#2234](https://github.com/coreos/ignition/pull/2234))
+- Fix disk partitioning race condition where the kernel is already aware of the changes before running `partx`, causing a fatal error. ([#2234](https://github.com/coreos/ignition/pull/2234))
 
 
 ## Ignition 2.26.0 (2026-02-17)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,7 @@ nav_order: 9
 
 - Support reading configs from `/run/ignition` and `/etc/ignition/` in addition to `/usr/lib/ignition/`, searched in descending priority order ([#2221](https://github.com/coreos/ignition/pull/2221))
 - Add support for `virtiofs`
+- Allow deleting a disk partition while creating another partition with number 0. ([#2234](https://github.com/coreos/ignition/pull/2234))
 
 ### Changes
 

--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -38,6 +38,7 @@ var (
 	groupaddCmd  = "groupadd"
 	groupmodCmd  = "groupmod"
 	groupdelCmd  = "groupdel"
+	dmsetupCmd   = "dmsetup"
 	mdadmCmd     = "mdadm"
 	mountCmd     = "mount"
 	partxCmd     = "partx"
@@ -109,6 +110,7 @@ func SystemConfigDirs() []string {
 func GroupaddCmd() string  { return groupaddCmd }
 func GroupmodCmd() string  { return groupmodCmd }
 func GroupdelCmd() string  { return groupdelCmd }
+func DmsetupCmd() string   { return dmsetupCmd }
 func MdadmCmd() string     { return mdadmCmd }
 func MountCmd() string     { return mountCmd }
 func PartxCmd() string     { return partxCmd }

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -323,11 +323,15 @@ func (p PartitionList) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
 
-func isBlockDevMapper(blockDevResolved string) bool {
+// blockDevDMName returns the device mapper name for the given block device,
+// or an empty string if it is not a device mapper device.
+func blockDevDMName(blockDevResolved string) string {
 	blockDevNode := filepath.Base(blockDevResolved)
-	dmName := fmt.Sprintf("/sys/class/block/%s/dm/name", blockDevNode)
-	_, err := os.Stat(dmName)
-	return err == nil
+	dmNameBytes, err := os.ReadFile(fmt.Sprintf("/sys/class/block/%s/dm/name", blockDevNode))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(dmNameBytes))
 }
 
 // Expects a /dev/xyz path
@@ -368,8 +372,23 @@ func blockDevMounted(blockDevResolved string) (bool, error) {
 }
 
 // Expects a /dev/xyz path
-func blockDevPartitions(blockDevResolved string) ([]string, error) {
-	_, blockDevNode := filepath.Split(blockDevResolved)
+func blockDevPartitions(blockDevResolved string, dmName string) ([]string, error) {
+	blockDevNode := filepath.Base(blockDevResolved)
+
+	if dmName != "" {
+		// For device mapper (e.g. multipath), partition devices are
+		// separate DM nodes. Find them via dm-name symlinks.
+		matches, _ := filepath.Glob(fmt.Sprintf("/dev/disk/by-id/dm-name-%sp[0-9]*", dmName))
+		var partitions []string
+		for _, m := range matches {
+			resolved, err := filepath.EvalSymlinks(m)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve %q: %v", m, err)
+			}
+			partitions = append(partitions, resolved)
+		}
+		return partitions, nil
+	}
 
 	// This also works for extended MBR partitions
 	sysDir := fmt.Sprintf("/sys/class/block/%s/", blockDevNode)
@@ -388,12 +407,11 @@ func blockDevPartitions(blockDevResolved string) ([]string, error) {
 }
 
 // Expects a /dev/xyz path
-func blockDevInUse(blockDevResolved string, skipPartitionCheck bool) (bool, []string, error) {
+func blockDevInUse(blockDevResolved string, dmName string, skipPartitionCheck bool) (bool, []string, error) {
 	// Note: This ignores swap and LVM usage
 	inUse := false
-	isDevMapper := isBlockDevMapper(blockDevResolved)
 	held := false
-	if !isDevMapper {
+	if dmName == "" {
 		var err error
 		held, err = blockDevHeld(blockDevResolved)
 		if err != nil {
@@ -408,13 +426,13 @@ func blockDevInUse(blockDevResolved string, skipPartitionCheck bool) (bool, []st
 	if skipPartitionCheck {
 		return inUse, nil, nil
 	}
-	partitions, err := blockDevPartitions(blockDevResolved)
+	partitions, err := blockDevPartitions(blockDevResolved, dmName)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to retrieve partitions of %q: %v", blockDevResolved, err)
 	}
 	var activePartitions []string
 	for _, partition := range partitions {
-		partInUse, _, err := blockDevInUse(partition, true)
+		partInUse, _, err := blockDevInUse(partition, dmName, true)
 		if err != nil {
 			return false, nil, fmt.Errorf("failed to check if partition %q is in use: %v", partition, err)
 		}
@@ -435,6 +453,18 @@ func partitionNumberPrefix(blockDevResolved string) string {
 	return ""
 }
 
+// partitionDevPath returns the expected device path for the given partition
+// number on the given disk. For device mapper devices (e.g. multipath), the
+// partition devices are separate DM nodes, so we locate them via
+// /dev/disk/by-id/dm-name-<name>p<N> symlinks. The returned path may or may
+// not exist on disk.
+func partitionDevPath(blockDevResolved string, dmName string, prefix string, partNum int) string {
+	if dmName == "" {
+		return fmt.Sprintf("%s%s%d", blockDevResolved, prefix, partNum)
+	}
+	return fmt.Sprintf("/dev/disk/by-id/dm-name-%sp%d", dmName, partNum)
+}
+
 // partitionDisk partitions devAlias according to the spec given by dev
 func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 	blockDevResolved, err := filepath.EvalSymlinks(devAlias)
@@ -442,7 +472,9 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 		return fmt.Errorf("failed to resolve %q: %v", devAlias, err)
 	}
 
-	inUse, activeParts, err := blockDevInUse(blockDevResolved, false)
+	dmName := blockDevDMName(blockDevResolved)
+
+	inUse, activeParts, err := blockDevInUse(blockDevResolved, dmName, false)
 	if err != nil {
 		return fmt.Errorf("failed usage check on %q: %v", devAlias, err)
 	}
@@ -499,7 +531,12 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 		}
 		matches := exists && matchErr == nil
 		wipeEntry := cutil.IsTrue(part.WipePartitionEntry)
-		partInUse := iutil.StrSliceContains(activeParts, fmt.Sprintf("%s%s%d", blockDevResolved, prefix, part.Number))
+
+		partDevForCheck := partitionDevPath(blockDevResolved, dmName, prefix, part.Number)
+		if resolved, err := filepath.EvalSymlinks(partDevForCheck); err == nil {
+			partDevForCheck = resolved
+		}
+		partInUse := iutil.StrSliceContains(activeParts, partDevForCheck)
 
 		var modification bool
 

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -22,10 +22,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"iter"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -475,6 +477,32 @@ func partitionDevPath(blockDevResolved string, dmName string, prefix string, par
 	return fmt.Sprintf("/dev/disk/by-id/dm-name-%sp%d", dmName, partNum)
 }
 
+// dmPartitionStartAndSize returns the start sector and size (in 512-byte
+// sectors) of a device mapper partition device by parsing `dmsetup table`.
+// The table for a linear DM partition looks like:
+//
+//	0 <size> linear <major:minor> <start>
+func dmPartitionStartAndSize(partDev string) (int64, int64, error) {
+	out, err := exec.Command(distro.DmsetupCmd(), "table", partDev).Output()
+	if err != nil {
+		return 0, 0, fmt.Errorf("dmsetup table failed for %q: %v", partDev, err)
+	}
+	// Parse: "0 <size> linear <dev> <start>"
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 5 || fields[2] != "linear" {
+		return 0, 0, fmt.Errorf("unexpected dmsetup table output for %q: %q", partDev, string(out))
+	}
+	size, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse size from dmsetup table for %q: %v", partDev, err)
+	}
+	start, err := strconv.ParseInt(fields[4], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse start from dmsetup table for %q: %v", partDev, err)
+	}
+	return start, size, nil
+}
+
 // partitionDisk partitions devAlias according to the spec given by dev
 func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 	blockDevResolved, err := filepath.EvalSymlinks(devAlias)
@@ -528,9 +556,9 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 		return err
 	}
 
-	var partxAdd []uint64
-	var partxDelete []uint64
-	var partxUpdate []uint64
+	var partxAdd []int
+	var partxDelete []int
+	var partxUpdate []int
 
 	for _, part := range resolvedPartitions {
 		shouldExist := partitionShouldExist(part)
@@ -557,13 +585,13 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 		case !exists && shouldExist:
 			op.CreatePartition(part)
 			modification = true
-			partxAdd = append(partxAdd, uint64(part.Number))
+			partxAdd = append(partxAdd, part.Number)
 		case exists && !shouldExist && !wipeEntry:
 			return fmt.Errorf("partition %d exists but is specified as nonexistant and wipePartitionEntry is false", part.Number)
 		case exists && !shouldExist && wipeEntry:
 			op.DeletePartition(part.Number)
 			modification = true
-			partxDelete = append(partxDelete, uint64(part.Number))
+			partxDelete = append(partxDelete, part.Number)
 		case exists && shouldExist && matches:
 			s.Info("partition %d found with correct specifications", part.Number)
 		case exists && shouldExist && !wipeEntry && !matches:
@@ -577,7 +605,7 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 				part.StartSector = &info.StartSector
 				op.CreatePartition(part)
 				modification = true
-				partxUpdate = append(partxUpdate, uint64(part.Number))
+				partxUpdate = append(partxUpdate, part.Number)
 			} else {
 				return fmt.Errorf("partition %d didn't match: %v", part.Number, matchErr)
 			}
@@ -586,7 +614,7 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 			op.DeletePartition(part.Number)
 			op.CreatePartition(part)
 			modification = true
-			partxUpdate = append(partxUpdate, uint64(part.Number))
+			partxUpdate = append(partxUpdate, part.Number)
 		default:
 			// unfortunatey, golang doesn't check that all cases are handled exhaustively
 			return fmt.Errorf("unreachable code reached when processing partition %d. golang--", part.Number)
@@ -604,26 +632,22 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 	// In contrast to similar tools, sgdisk does not trigger the update of the
 	// kernel partition table with BLKPG but only uses BLKRRPART which fails
 	// as soon as one partition of the disk is mounted
-	if len(activeParts) > 0 {
-		runPartxCommand := func(op string, partitions []uint64) error {
-			for _, partNr := range partitions {
-				cmd := exec.Command(distro.PartxCmd(), "--"+op, "--nr", strconv.FormatUint(partNr, 10), blockDevResolved)
-				if _, err := s.LogCmd(cmd, "triggering partition %d %s on %q", partNr, op, devAlias); err != nil {
-					return fmt.Errorf("partition %s failed: %v", op, err)
-				}
+	runPartxCommand := func(op string, partitions iter.Seq[int]) {
+		for partNr := range partitions {
+			// Don't use LogCmd here because we don't want to treat failure as
+			// critical and this command will never produce anything on Stdout.
+			cmd := exec.Command(distro.PartxCmd(), "--"+op, "--nr", fmt.Sprint(partNr), blockDevResolved)
+			s.Info("triggering partition %d %s on %q", partNr, op, devAlias)
+			s.Debug("executing: %q", cmd.Args)
+			_, err := cmd.Output()
+			if err, ok := err.(*exec.ExitError); ok {
+				s.Notice("%v: Cmd: %q Stderr: %q", err, cmd.Args, err.Stderr)
 			}
-			return nil
-		}
-		if err := runPartxCommand("delete", partxDelete); err != nil {
-			return err
-		}
-		if err := runPartxCommand("update", partxUpdate); err != nil {
-			return err
-		}
-		if err := runPartxCommand("add", partxAdd); err != nil {
-			return err
 		}
 	}
+	runPartxCommand("delete", slices.Values(partxDelete))
+	runPartxCommand("update", slices.Values(partxUpdate))
+	runPartxCommand("add", slices.Values(partxAdd))
 
 	// It's best to wait here for the /dev/ABC entries to be
 	// (re)created, not only for other parts of the initramfs but
@@ -631,6 +655,71 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 	// partition entry recreation.
 	if err := s.waitForUdev(devAlias); err != nil {
 		return fmt.Errorf("failed to wait for udev on %q after partitioning: %v", devAlias, err)
+	}
+
+	for _, part := range resolvedPartitions {
+		partDev := partitionDevPath(blockDevResolved, dmName, prefix, part.Number)
+
+		if slices.Contains(partxDelete, part.Number) {
+			_, err := os.Stat(partDev)
+			if err == nil {
+				return fmt.Errorf("%q unexpectedly exists after partitioning", partDev)
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to stat %q after partitioning: %v", partDev, err)
+			}
+		} else if slices.Contains(partxAdd, part.Number) || slices.Contains(partxUpdate, part.Number) {
+			var kernelStart, kernelSize int64
+
+			// sysfs always reports in 512-byte sectors; convert our expected
+			// values from logical sectors to 512-byte sectors for comparison
+			logicalTo512 := int64(diskInfo.LogicalSectorSize) / 512
+
+			if dmName != "" {
+				// DM partition devices don't have a "start" entry in
+				// sysfs. Use dmsetup table to get start and size.
+				kernelStart, kernelSize, err = dmPartitionStartAndSize(partDev)
+				if err != nil {
+					return fmt.Errorf("failed to get DM table for %q: %v", partDev, err)
+				}
+			} else {
+				partDevResolved, err := filepath.EvalSymlinks(partDev)
+				if err != nil {
+					return fmt.Errorf("failed to resolve %q: %v", partDev, err)
+				}
+				sysBlockDir := fmt.Sprintf("/sys/class/block/%s/", filepath.Base(partDevResolved))
+
+				startStr, err := os.ReadFile(sysBlockDir + "start")
+				if err != nil {
+					return fmt.Errorf("failed to read start of %q from sysfs: %v", partDev, err)
+				}
+				kernelStart, err = strconv.ParseInt(strings.TrimSpace(string(startStr)), 10, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse start of %q from sysfs: %v", partDev, err)
+				}
+
+				sizeStr, err := os.ReadFile(sysBlockDir + "size")
+				if err != nil {
+					return fmt.Errorf("failed to read size of %q from sysfs: %v", partDev, err)
+				}
+				kernelSize, err = strconv.ParseInt(strings.TrimSpace(string(sizeStr)), 10, 64)
+				if err != nil {
+					return fmt.Errorf("failed to parse size of %q from sysfs: %v", partDev, err)
+				}
+			}
+
+			if part.StartSector != nil {
+				expectedStart := *part.StartSector * logicalTo512
+				if kernelStart != expectedStart {
+					return fmt.Errorf("kernel partition start for %q does not match expected (%d != %d 512-byte sectors)", partDev, kernelStart, expectedStart)
+				}
+			}
+			if part.SizeInSectors != nil {
+				expectedSize := *part.SizeInSectors * logicalTo512
+				if kernelSize != expectedSize {
+					return fmt.Errorf("kernel partition size for %q does not match expected (%d != %d 512-byte sectors)", partDev, kernelSize, expectedSize)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -562,6 +562,11 @@ func (s stage) partitionDisk(dev types.Disk, devAlias string) error {
 
 	for _, part := range resolvedPartitions {
 		shouldExist := partitionShouldExist(part)
+		if !shouldExist && slices.ContainsFunc(resolvedPartitions, func(p sgdisk.Partition) bool {
+			return p.Number == part.Number && partitionShouldExist(p)
+		}) {
+			continue
+		}
 		info, exists := diskInfo.GetPartition(part.Number)
 		var matchErr error
 		if exists {

--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -112,15 +112,6 @@ func partitionMatchesCommon(existing util.PartitionInfo, spec sgdisk.Partition) 
 	return nil
 }
 
-// partitionShouldBeInspected returns if the partition has zeroes that need to be resolved to sectors.
-func partitionShouldBeInspected(part sgdisk.Partition) bool {
-	if part.Number == 0 {
-		return false
-	}
-	return (part.StartSector != nil && *part.StartSector == 0) ||
-		(part.SizeInSectors != nil && *part.SizeInSectors == 0)
-}
-
 func convertMiBToSectors(mib *int, sectorSize int) *int64 {
 	if mib != nil {
 		v := int64(*mib) * (1024 * 1024 / int64(sectorSize))
@@ -130,10 +121,17 @@ func convertMiBToSectors(mib *int, sectorSize int) *int64 {
 	}
 }
 
-// getRealStartAndSize returns a map of partition numbers to a struct that contains what their real start
-// and end sector should be. It runs sgdisk --pretend to determine what the partitions would look like if
-// everything specified were to be (re)created.
+// getRealStartAndSize returns a copy of the given partition configuration with the real partition
+// numbers, start sectors, and end sectors filled in. It runs sgdisk --pretend to determine what the
+// partitions would look like if everything specified were to be (re)created.
 func (s stage) getRealStartAndSize(dev types.Disk, devAlias string, diskInfo util.DiskInfo) ([]sgdisk.Partition, error) {
+	used := map[int]bool{}
+
+	// Determine which partition numbers are already used.
+	for _, part := range diskInfo.Partitions {
+		used[part.Number] = true
+	}
+
 	partitions := []sgdisk.Partition{}
 	for _, cpart := range dev.Partitions {
 		partitions = append(partitions, sgdisk.Partition{
@@ -156,6 +154,10 @@ func (s stage) getRealStartAndSize(dev types.Disk, devAlias string, diskInfo uti
 				part.SizeInSectors = &info.SizeInSectors
 			}
 		}
+		if part.Number > 0 {
+			// Mark the partition number as used or not.
+			used[part.Number] = partitionShouldExist(part)
+		}
 		if partitionShouldExist(part) {
 			// Clear the label. sgdisk doesn't escape control characters. This makes parsing easier
 			part.Label = nil
@@ -163,12 +165,25 @@ func (s stage) getRealStartAndSize(dev types.Disk, devAlias string, diskInfo uti
 		}
 	}
 
-	// We only care to examine partitions that have start or size 0.
+	free := 1
 	partitionsToInspect := []int{}
-	for _, part := range partitions {
-		if partitionShouldBeInspected(part) {
-			op.Info(part.Number)
-			partitionsToInspect = append(partitionsToInspect, part.Number)
+	for i := range partitions {
+		part := &partitions[i]
+		if partitionShouldExist(*part) {
+			// Find the next free partition number and use it.
+			if part.Number == 0 {
+				for used[free] {
+					free++
+				}
+				part.Number = free
+				free++
+			}
+			// We only care to examine partitions that have start or size 0.
+			if part.StartSector == nil || *part.StartSector == 0 ||
+				part.SizeInSectors == nil || *part.SizeInSectors == 0 {
+				op.Info(part.Number)
+				partitionsToInspect = append(partitionsToInspect, part.Number)
+			}
 		}
 	}
 
@@ -182,19 +197,14 @@ func (s stage) getRealStartAndSize(dev types.Disk, devAlias string, diskInfo uti
 		return nil, err
 	}
 
-	result := []sgdisk.Partition{}
-	for _, part := range partitions {
+	for i := range partitions {
+		part := &partitions[i]
 		if dims, ok := realDimensions[part.Number]; ok {
-			if part.StartSector != nil {
-				part.StartSector = &dims.start
-			}
-			if part.SizeInSectors != nil {
-				part.SizeInSectors = &dims.size
-			}
+			part.StartSector = &dims.start
+			part.SizeInSectors = &dims.size
 		}
-		result = append(result, part)
 	}
-	return result, nil
+	return partitions, nil
 }
 
 type sgdiskOutput struct {

--- a/internal/exec/stages/disks/partitions_test.go
+++ b/internal/exec/stages/disks/partitions_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disks
+
+import (
+	"testing"
+)
+
+func TestPartitionNumberPrefix(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{"/dev/sda", ""},
+		{"/dev/vda", ""},
+		{"/dev/nvme0n1", "p"},
+		{"/dev/mmcblk0", "p"},
+		{"/dev/loop0", "p"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := partitionNumberPrefix(tt.in)
+			if got != tt.out {
+				t.Errorf("partitionNumberPrefix(%q) = %q, want %q", tt.in, got, tt.out)
+			}
+		})
+	}
+}
+
+func TestPartitionDevPath(t *testing.T) {
+	tests := []struct {
+		blockDev string
+		dmName   string
+		prefix   string
+		partNum  int
+		out      string
+	}{
+		{"/dev/sda", "", "", 1, "/dev/sda1"},
+		{"/dev/sda", "", "", 12, "/dev/sda12"},
+		{"/dev/nvme0n1", "", "p", 1, "/dev/nvme0n1p1"},
+		{"/dev/nvme0n1", "", "p", 3, "/dev/nvme0n1p3"},
+		{"/dev/mmcblk0", "", "p", 2, "/dev/mmcblk0p2"},
+		{"/dev/dm-0", "mpath0", "p", 1, "/dev/disk/by-id/dm-name-mpath0p1"},
+		{"/dev/dm-0", "mpath0", "p", 5, "/dev/disk/by-id/dm-name-mpath0p5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.out, func(t *testing.T) {
+			got := partitionDevPath(tt.blockDev, tt.dmName, tt.prefix, tt.partNum)
+			if got != tt.out {
+				t.Errorf("partitionDevPath(%q, %q, %q, %d) = %q, want %q",
+					tt.blockDev, tt.dmName, tt.prefix, tt.partNum, got, tt.out)
+			}
+		})
+	}
+}

--- a/tests/positive/partitions/complex-mb.go
+++ b/tests/positive/partitions/complex-mb.go
@@ -85,6 +85,11 @@ func KitchenSinkMiB() types.Test {
 					"wipePartitionEntry": true
 				},
 				{
+					"number": 2,
+					"shouldExist": false,
+					"wipePartitionEntry": true
+				},
+				{
 					"label": "new-auto2",
 					"number": 0,
 					"sizeMiB": 64,
@@ -162,6 +167,13 @@ func KitchenSinkMiB() types.Test {
 				Length:   65536,
 				TypeGUID: "316f19f9-9e0f-431e-859e-ae6908dbe8ca",
 				GUID:     "3ED3993F-0016-422B-B134-09FCBA6F66EF",
+			},
+			{
+				Label:    "to-replace",
+				Number:   2,
+				Length:   163840,
+				TypeGUID: "c1ea8ad5-2663-44c8-859e-da7fa0c2c059",
+				GUID:     "bd5febf1-f8d3-4b55-9c16-678d4a98ea72",
 			},
 		},
 	})

--- a/tests/positive/partitions/complex-mb.go
+++ b/tests/positive/partitions/complex-mb.go
@@ -71,6 +71,36 @@ func KitchenSinkMiB() types.Test {
 					"shouldExist": false
 				}
 				]
+			}, {
+				"device": "$disk2",
+				"wipeTable": false,
+				"partitions": [
+				{
+					"label": "p1",
+					"number": 1,
+					"startMiB": 1,
+					"sizeMiB": 32,
+					"typeGuid": "3a5cddf2-5a21-4913-a94d-156344d0f11d",
+					"guid": "f7c8f4c2-f406-426d-8fa2-56f0f03f2062",
+					"wipePartitionEntry": true
+				},
+				{
+					"label": "new-auto2",
+					"number": 0,
+					"sizeMiB": 64,
+					"typeGuid": "f6b5fb7e-4856-4254-8754-971dda7f250b",
+					"guid": "9c235a9c-6d3c-42a3-adfb-b2188234c231",
+					"wipePartitionEntry": true
+				},
+				{
+					"label": "new-auto3",
+					"number": 0,
+					"sizeMiB": 96,
+					"typeGuid": "31ce4b8c-6107-4c81-83f0-527770ef7e1f",
+					"guid": "74e097ce-11c3-4f68-855c-4704f597f90d",
+					"wipePartitionEntry": true
+				}
+				]
 			}]
 		}
 	}`
@@ -123,6 +153,18 @@ func KitchenSinkMiB() types.Test {
 			},
 		},
 	})
+	in = append(in, types.Disk{
+		Alignment: types.IgnitionAlignment,
+		Partitions: types.Partitions{
+			{
+				Label:    "p1",
+				Number:   1,
+				Length:   65536,
+				TypeGUID: "316f19f9-9e0f-431e-859e-ae6908dbe8ca",
+				GUID:     "3ED3993F-0016-422B-B134-09FCBA6F66EF",
+			},
+		},
+	})
 	out = append(out, types.Disk{
 		Alignment: types.IgnitionAlignment,
 		Partitions: types.Partitions{
@@ -157,6 +199,32 @@ func KitchenSinkMiB() types.Test {
 			{
 				TypeCode: "blank",
 				Length:   131072,
+			},
+		},
+	})
+	out = append(out, types.Disk{
+		Alignment: types.IgnitionAlignment,
+		Partitions: types.Partitions{
+			{
+				Label:    "p1",
+				Number:   1,
+				Length:   65536,
+				TypeGUID: "3a5cddf2-5a21-4913-a94d-156344d0f11d",
+				GUID:     "f7c8f4c2-f406-426d-8fa2-56f0f03f2062",
+			},
+			{
+				Label:    "new-auto2",
+				Number:   2,
+				Length:   131072,
+				TypeGUID: "f6b5fb7e-4856-4254-8754-971dda7f250b",
+				GUID:     "9c235a9c-6d3c-42a3-adfb-b2188234c231",
+			},
+			{
+				Label:    "new-auto3",
+				Number:   3,
+				Length:   196608,
+				TypeGUID: "31ce4b8c-6107-4c81-83f0-527770ef7e1f",
+				GUID:     "74e097ce-11c3-4f68-855c-4704f597f90d",
 			},
 		},
 	})


### PR DESCRIPTION
I've admittedly lost the output of the race condition triggering, but this is what was going on underneath.

```
$ partx --add --nr 1 --verbose /dev/nvme0n1
partition: none, disk: /dev/nvme0n1, lower: 1, upper: 1
/dev/nvme0n1: partition table type 'gpt' detected
range recount: max partno=9, lower=1, upper=1
partx: /dev/nvme0n1: adding partition #1 failed: Device or resource busy
partx: /dev/nvme0n1: error adding partition 1
```

We started reliably seeing this in Flatcar after some batch updates. We don't know exactly which update triggered it, but it was probably systemd. While we could have looked into systemd's changes, I strongly felt that this code was always potentially racy. There was never anything stopping the kernel picking up the partition changes before partx had a chance to run.

This change therefore allows partx to fail and then checks that added/updated partitions have the right start sector and size and that deleted partitions are absent once udev has settled.

On first submitting this change, Gemini highlighted that I had broken the feature that allows you to specify partition number 0 to get the next available slot. On testing this, I found that this was already broken since c2cc56cd0208efe8929f59424c2c4b668617f62b. Passing 0 to partx causes it to try and add all the partitions, which will almost always fail because the kernel will usually already know about at least some of them.

If anything, my initial change had improved the situation by ignoring the partx failure, but I have now fixed the issue properly. This changes `getRealStartAndSize()` to also determine and return the resulting partition numbers so that subsequent operations use these instead of 0.

sgdisk does support `--new=0`, but it has no way to report which partition number it actually used.

Following that, I was able to drop the restriction that prevented users from deleting a partition while creating partition number 0. We previously disallowed this because we didn't resolve the partition numbers to their final values, making it impossible to determine whether they would actually exist in the end.

The error message that was shown mentioned partitions having a start or size of 0 rather than the number. It's not clear why this was.

New cases have been added to tests/positive/partitions/complex-mb.go to cover all this. The creation of the `new-auto3` partition triggers the race condition on Fedora 44. I don't know why just this one does, but at least that confirms the fix works.