### PR TITLE
Makefile: Bring in same build step as in the rpm spec file

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -13,8 +13,9 @@ buildPod {
     withEnv(["XDG_CACHE_HOME=${env.WORKSPACE}/cache"]) {
         // XXX: convert all this to coreos-ci-lib sugar
         stage("Build") {
-            shwrap("make")
-            shwrap("make install DESTDIR=install")
+            shwrap("make ignition BIN_PATH=bin/amd64")
+            shwrap("make ignition-validate BIN_PATH=bin/amd64")
+            shwrap("make install BIN_PATH=bin/amd64 DESTDIR=install")
             stash name: 'build', includes: 'install/**'
         }
         // first, run gofmt/govet/unit tests

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Check out PR branch
       uses: actions/checkout@v6
     - name: Build PR binary
-      run: ./build
+      run: make ignition BIN_PATH=bin/amd64
     - name: Measure PR binary size
       id: pr
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,8 +36,10 @@ jobs:
         sudo apt-get install libblkid-dev
     - name: Check modules
       run: go mod verify
-    - name: Build
-      run: ./build
+    - name: Build Ignition
+      run: make ignition
+    - name: Build Ignition Validate
+      run: make ignition-validate
     - name: Test
       run: ./test
     - name: Check Go formatting (gofmt)

--- a/Makefile
+++ b/Makefile
@@ -13,26 +13,57 @@ else ifeq ($(patsubst armv%,arm,$(GOARCH)),arm)
 else ifeq ($(patsubst i%86,386,$(GOARCH)),386)
 	GOARCH=386
 endif
+export GOARCH
+
+BIN_PATH ?= bin
+export BIN_PATH
 
 .PHONY: all
-all:
-	./build
+all: ignition ignition-validate ignition-validate-cross
+
+.PHONY: ignition
+ignition:
+	./build ignition
+
+.PHONY: ignition-validate
+ignition-validate:
+	./build ignition-validate
+
+.PHONY: ignition-validate-cross
+ignition-validate-cross:
+	./build ignition-validate-cross
 
 .PHONY: install
-install: all
+install:
 	for x in dracut/*; do \
 	  bn=$$(basename $$x); \
 	  install -m 0644 -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
 	done
+
 	chmod a+x $(DESTDIR)/usr/lib/dracut/modules.d/*/*.sh $(DESTDIR)/usr/lib/dracut/modules.d/*/*-generator
 	install -m 0644 -D -t $(DESTDIR)/usr/lib/systemd/system systemd/ignition-delete-config.service
-	install -m 0755 -D -t $(DESTDIR)/usr/lib/dracut/modules.d/30ignition bin/$(GOARCH)/ignition
-	install -m 0755 -D -t $(DESTDIR)/usr/bin bin/$(GOARCH)/ignition-validate
+	install -m 0755 -D -t $(DESTDIR)/usr/lib/dracut/modules.d/30ignition $(BIN_PATH)/ignition
+	install -m 0755 -D -t $(DESTDIR)/usr/bin $(BIN_PATH)/ignition-validate
 	install -m 0755 -d $(DESTDIR)/usr/libexec
 	ln -sf ../lib/dracut/modules.d/30ignition/ignition $(DESTDIR)/usr/libexec/ignition-apply
 	ln -sf ../lib/dracut/modules.d/30ignition/ignition $(DESTDIR)/usr/libexec/ignition-rmcfg
 
+# For distros that need to build cross platform ignition-validate binaries
+# Used in fedora for now. See ignition rpm spec for details.
+.PHONY: install-ignition-validate-cross
+install-ignition-validate-cross:
+	install -d -p $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-aarch64-apple-darwin $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-aarch64-unknown-linux-gnu-static $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-ppc64le-unknown-linux-gnu-static $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-s390x-unknown-linux-gnu-static $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-x86_64-apple-darwin $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-x86_64-pc-windows-gnu.exe $(DESTDIR)/usr/share/ignition
+	install -p -m 0644 $(BIN_PATH)/ignition-validate-x86_64-unknown-linux-gnu-static $(DESTDIR)/usr/share/ignition
+
+.PHONY: install-grub-for-bootupd
 install-grub-for-bootupd:
+	install -d -p $(DESTDIR)/usr/lib/bootupd/grub2-static/configs.d
 	install -m 0644 -D -t $(DESTDIR)/usr/lib/bootupd/grub2-static/configs.d grub2/05_ignition.cfg
 
 .PHONY: vendor

--- a/build
+++ b/build
@@ -2,36 +2,82 @@
 
 set -eu
 
+print_usage() {
+	echo "Usage: $0 [ignition|ignition-validate|ignition-validate-cross]" >&2
+}
+
+if [ $# -eq 0 ]; then
+	print_usage
+	exit 1
+fi
+
 export GO111MODULE=on
 
 NAME="ignition"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}/v2"
-GLDFLAGS=${GLDFLAGS:-}
 export GOFLAGS=-mod=vendor
+GLDFLAGS=${GLDFLAGS:-}
 
-if [ -z ${VERSION+a} ]; then
+if [ -z "${VERSION:-}" ]; then
 	VERSION=$(git describe --dirty --always)
-	echo "Using version from git: $VERSION"
+	echo "Using version from git: ${VERSION}"
 fi
 
-GLDFLAGS+="-X github.com/coreos/ignition/v2/internal/version.Raw=${VERSION}"
+GLDFLAGS+=" -X github.com/coreos/ignition/v2/internal/version.Raw=${VERSION}"
 
 eval $(go env)
 
 if [ -z ${BIN_PATH+a} ]; then
-	export BIN_PATH=${PWD}/bin/${GOARCH}
+	export BIN_PATH=${PWD}/bin/
 fi
 
 export CGO_ENABLED=1
 
-echo "Building ${NAME}..."
-# clean the cache since cgo isn't correctly handled by gocache. Test to see if this version
-# of go supports caching before trying to clear the cache
-go clean -help 2>&1 | grep -F '[-cache]' >/dev/null && go clean -cache -testcache
-go build -buildmode=pie -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${NAME} ${REPO_PATH}/internal
+ignition() {
+	local name="ignition"
+	echo "Building ${name} ${GOEXPERIMENT:+with GOEXPERIMENT=${GOEXPERIMENT}}..."
+	# clean the cache since cgo isn't correctly handled by gocache.
+	go clean -cache -testcache
+	go build -buildmode=pie -ldflags "${GLDFLAGS}" -o "${BIN_PATH}/${name}" ${REPO_PATH}/internal
+}
 
-NAME="ignition-validate"
+ignition_validate() {
+	local name="ignition-validate"
 
-echo "Building ${NAME}..."
-go build -ldflags "${GLDFLAGS}" -o ${BIN_PATH}/${NAME} ${REPO_PATH}/validate
+	echo "Building ${name}..."
+	go build -ldflags "${GLDFLAGS}" -o "${BIN_PATH}/${name}" ${REPO_PATH}/validate
+}
+
+build_cross_validate() {
+	local goos=$1 goarch=$2 output=$3
+	echo "Building ${output}..."
+	CGO_ENABLED=0 GOARCH=${goarch} GOOS=${goos} go build -ldflags "${GLDFLAGS}" -a -v -x -o "${BIN_PATH}/${output}" ${REPO_PATH}/validate
+}
+
+ignition_validate_cross() {
+	build_cross_validate linux arm64 ignition-validate-aarch64-unknown-linux-gnu-static
+	build_cross_validate darwin arm64 ignition-validate-aarch64-apple-darwin
+	build_cross_validate linux ppc64le ignition-validate-ppc64le-unknown-linux-gnu-static
+	build_cross_validate linux s390x ignition-validate-s390x-unknown-linux-gnu-static
+	build_cross_validate linux amd64 ignition-validate-x86_64-unknown-linux-gnu-static
+	build_cross_validate darwin amd64 ignition-validate-x86_64-apple-darwin
+	build_cross_validate windows amd64 ignition-validate-x86_64-pc-windows-gnu.exe
+}
+
+case "$1" in
+ignition)
+	ignition
+	;;
+ignition-validate)
+	ignition_validate
+	;;
+ignition-validate-cross)
+	ignition_validate_cross
+	;;
+*)
+	echo "Unknown command: $1" >&2
+	print_usage
+	exit 1
+	;;
+esac

--- a/build_blackbox_tests
+++ b/build_blackbox_tests
@@ -14,7 +14,17 @@ GLDFLAGS+="-X github.com/coreos/ignition/v2/internal/distro.groupmodCmd=groupmod
 GLDFLAGS+="-X github.com/coreos/ignition/v2/internal/distro.groupdelCmd=groupdel-stub "
 GLDFLAGS+="-X github.com/coreos/ignition/v2/internal/distro.blackboxTesting=true "
 
-. ./build
+REPO_PATH="github.com/coreos/ignition/v2"
+
+eval $(go env)
+if [ -z ${BIN_PATH+a} ]; then
+	export BIN_PATH=${PWD}/bin/${GOARCH}
+fi
+
+export GLDFLAGS
+
+echo "Building ignition for blackbox tests..."
+make ignition BIN_PATH=${BIN_PATH}
 
 PKG=$(go list ./tests/)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,22 @@ nav_order: 9
 
 # Release Notes
 
+## Upcoming Ignition 2.28.0 (unreleased)
+
+### Breaking changes
+
+- The `build` script now requires a subcommand (`ignition`, `ignition-validate`, or `ignition-validate-cross`). Sourcing the build script is no longer supported.
+- Build and install are separate steps with explicit targets (`ignition`, `ignition-validate`, `ignition-validate-cross`, `install`, `install-ignition-validate-cross`, `install-grub-for-bootupd`).
+
+### Changes
+
+- Refactored the Makefile and build script to match the Fedora RPM spec: separate build targets per binary, with `VERSION` and linker flags passed in at build time
+- `build_blackbox_tests` builds a blackbox-specific `ignition` binary with `make`
+- CI and GitHub Actions updated to build via `make ignition` and `make ignition-validate`
+
+### Bug fixes
+
+
 ## Upcoming Ignition 2.27.0 (unreleased)
 
 Starting with this release, ignition-validate binaries are signed with the

--- a/test
+++ b/test
@@ -2,6 +2,8 @@
 
 set -eu
 
+eval $(go env)
+
 echo "Checking for license headers..."
 EXPECTED_HEADER='//
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,8 +32,6 @@ done
 if [ "${HEADER_CHECK_FAILED}" -ne 0 ]; then
     exit 1
 fi
-
-source ./build
 
 SRC=$(find . -name '*.go' -not -path "./vendor/*")
 


### PR DESCRIPTION
Makefile and the build script are not being used by the rpmspec now. We need to update the steps in these files to match the spec and change the rpmspec to use Makefile.

Added new make targets:
 - ignition: build ignition binary
 - ignition-validate: build ignition validate binary
 - ignition-validate-cross: crossbuild ignition validate binary
 - install-ignition-validate-cross: install cross built validate binary

Build script updated to support these changes.

---

Goes with https://src.fedoraproject.org/rpms/ignition/pull-request/147 for Fedora