### PR TITLE
ci: add override-size-check label to skip binary size enforcement

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -2,6 +2,7 @@ name: Binary Size
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 permissions:
   contents: read
 
@@ -100,6 +101,11 @@ jobs:
         path: /tmp/binary-size/result.txt
     - name: Fail on excessive growth
       run: |
+        override="${{ contains(github.event.pull_request.labels.*.name, 'override-size-check') }}"
+        if [ "$override" = "true" ]; then
+          echo "Label 'override-size-check' is present — skipping size threshold enforcement."
+          exit 0
+        fi
         pct_raw=${{ steps.compare.outputs.pct_raw }}
         threshold=${{ env.SIZE_THRESHOLD_PCT }}
         exceeds=$(awk "BEGIN {print ($pct_raw > $threshold) ? 1 : 0}")


### PR DESCRIPTION
There might be some edge cases where we want an override. lets add a lable for it like "skip-notes"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Binary size validation now responds to pull request label changes.
  - Authorized maintainers can apply the `override-size-check` label to bypass the binary size threshold when appropriate.
  - Removing the label re-enables normal binary size validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->