### PR TITLE
docs: update documentation for Butane merge

### DIFF
--- a/.github/ISSUE_TEMPLATE/butane-bug.md
+++ b/.github/ISSUE_TEMPLATE/butane-bug.md
@@ -1,0 +1,31 @@
+---
+name: "Butane: Bug report"
+about: Report an issue with the Butane config transpiler
+labels: kind/bug, area/butane
+---
+
+# Bug #
+
+## Operating System Version ##
+
+## Butane Version ##
+
+## Config ##
+
+Please provide a minimal Butane config that reproduces the issue.
+
+```yaml
+variant: fcos
+version: 1.6.0
+```
+
+## Expected Behavior ##
+
+## Actual Behavior ##
+
+## Reproduction Steps ##
+
+  1. ...
+  2. ...
+
+## Other Information ##

--- a/.github/ISSUE_TEMPLATE/butane-feature.md
+++ b/.github/ISSUE_TEMPLATE/butane-feature.md
@@ -1,0 +1,20 @@
+---
+name: "Butane: Feature request"
+about: Suggest an enhancement to the Butane config transpiler
+labels: kind/feature, area/butane
+---
+
+# Feature Request #
+
+## Desired Feature ##
+
+## Example Config ##
+
+If applicable, provide an example of what the Butane config would look like.
+
+```yaml
+variant: fcos
+version: 1.6.0
+```
+
+## Other Information ##

--- a/.github/ISSUE_TEMPLATE/ignition-bug.md
+++ b/.github/ISSUE_TEMPLATE/ignition-bug.md
@@ -1,6 +1,7 @@
 ---
-name: Bug report
-about: Report an issue with Ignition
+name: "Ignition: Bug report"
+about: Report an issue with Ignition provisioning
+labels: kind/bug, area/ignition
 ---
 
 # Bug #

--- a/.github/ISSUE_TEMPLATE/ignition-feature.md
+++ b/.github/ISSUE_TEMPLATE/ignition-feature.md
@@ -1,6 +1,7 @@
 ---
-name: Feature request
-about: Suggest an enhancement to Ignition
+name: "Ignition: Feature request"
+about: Suggest an enhancement to Ignition provisioning
+labels: kind/feature, area/ignition
 ---
 
 # Feature Request #

--- a/.github/ISSUE_TEMPLATE/stabilize-checklist.md
+++ b/.github/ISSUE_TEMPLATE/stabilize-checklist.md
@@ -76,7 +76,7 @@ If there are any external kola tests that are not part of the Ignition repo (e.g
 - [ ] Bump ignition-config-rs in coreos-installer to support the new spec in `iso customize` and `pxe customize`. Update release notes.
   - [ ] Put out a new coreos-installer release.
 - [ ] Add a new downgrade translation to [ign-converter](https://github.com/coreos/ign-converter/).
-- [ ] [Stabilize Butane specs](https://coreos.github.io/butane/development/#bumping-spec-versions).
+- [ ] [Stabilize Butane specs](../../butane/docs/development.md#bumping-spec-versions).
   - [ ] Put out a new release.
 - [ ] Drop `-experimental` from configs in [FCOS docs](https://github.com/coreos/fedora-coreos-docs/) and remove colocated experimental-config warnings
 - [ ] Revendor Ignition and Butane into coreos-assembler and update `mantle/platform/conf/conf.go` and `conf_test.go`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ First-boot provisioning utility for immutable Linux (Fedora CoreOS, RHEL CoreOS,
 - **Module**: `github.com/coreos/ignition/v2`
 - **Dependencies**: Vendored (`vendor/`). After `go.mod` changes run `make vendor`.
 - **Testing**: Go `testing` + `testify` assertions
-- **Binaries**: `ignition` (provisioning engine), `ignition-validate` (config validator)
+- **Binaries**: `ignition` (provisioning engine), `ignition-validate` (config validator), `butane` (config transpiler)
 
 ## Architecture
 
@@ -19,6 +19,12 @@ config/                  # Frontend: stable library API (used by external progra
     schema/              # JSON schema → run ./generate after changes
     types/               # Go types (schema.go is generated)
     translate/           # Version translation
+butane/                  # Butane config transpiler (merged from coreos/butane)
+  config/                # Butane config variants (fcos, flatcar, openshift, r4e, fiot)
+  base/                  # Distro-agnostic base components
+  internal/              # CLI entry point and version
+  docs/                  # Butane documentation (specs, getting started, development)
+  translate/             # Butane-to-Ignition translation
 internal/                # Backend: system configuration engine
   exec/stages/           # Execution stages (fetch-offline, fetch, disks, mount, files, umount)
   providers/             # 30+ cloud/platform providers (aws, azure, gcp, ...)
@@ -32,12 +38,15 @@ dracut/                  # Dracut module for initramfs integration
 
 ## Build Commands
 
-- `./build` - Build binaries to `bin/<arch>/`
+- `./build ignition` - Build ignition binary to `bin/`
+- `./build ignition-validate` - Build ignition-validate binary to `bin/`
+- `./build butane` - Build butane binary to `bin/`
 - `./test` - Run all checks (license, gofmt, govet, unit tests, doc validation)
 - `./generate` - Regenerate schema types and docs after JSON schema changes
 - `./build_blackbox_tests` - Compile integration tests
 - `make vendor` - Vendor dependencies (`go mod vendor && go mod tidy`)
-- `make install` - Install binaries, dracut modules, systemd units
+- `make install` - Install ignition and ignition-validate binaries, dracut modules, systemd units
+- `make install-butane` - Install butane binary
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ By contributing to this project you agree to the Developer Certificate of Origin
 
 - Fork the repository on GitHub
 - Read the [README](README.md) and [development guide][dev-guide] for build and test instructions
+- This repository also contains the [Butane config transpiler](butane/docs/) in the `butane/` directory. See the [Butane development docs](butane/docs/development.md) for Butane-specific development information.
 - Play with the project, submit bugs, submit patches!
 
 ## Contribution Flow

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Ignition is a utility created to manipulate disks during the initramfs. This includes partitioning disks, formatting partitions, writing files (regular files, systemd units, etc.), and configuring users. On first boot, Ignition reads its configuration from a source of truth (remote URL, network metadata service, hypervisor bridge, etc.) and applies the configuration.
 
+Ignition accepts both [Ignition JSON configs](docs/specs.md) and [Butane YAML configs](butane/docs/specs.md). When a Butane YAML config is provided, Ignition automatically transpiles it at boot.
+
+## Butane
+
+This repository also contains [Butane](butane/docs/), a config transpiler that translates human-readable Butane YAML configs into Ignition JSON configs. The `butane` CLI can be used for local config validation and features like `--files-dir` that require client-side processing. See the [Butane getting started guide](butane/docs/getting-started.md) for details.
+
 ## Usage
 
 Odds are good that you don't want to invoke Ignition directly. In fact, it isn't even present in the root filesystem. Take a look at the [Getting Started Guide][getting started] for details on providing Ignition with a runtime configuration.

--- a/butane/docs/_config.yml
+++ b/butane/docs/_config.yml
@@ -23,7 +23,7 @@ color_scheme: coreos
 # Aux links for the upper right navigation
 aux_links:
   "Butane on GitHub":
-    - "https://github.com/coreos/butane"
+    - "https://github.com/coreos/ignition/tree/main/butane"
 
 footer_content: "Copyright &copy; <a href=\"https://www.redhat.com\">Red Hat, Inc.</a> and <a href=\"https://github.com/coreos\">others</a>."
 
@@ -34,9 +34,9 @@ last_edit_time_format: "%b %e %Y at %I:%M %p"
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true
 gh_edit_link_text: "Edit this page on GitHub"
-gh_edit_repository: "https://github.com/coreos/butane"
+gh_edit_repository: "https://github.com/coreos/ignition"
 gh_edit_branch: "main"
-gh_edit_source: docs
+gh_edit_source: butane/docs
 gh_edit_view_mode: "tree"
 
 compress_html:

--- a/butane/docs/development.md
+++ b/butane/docs/development.md
@@ -65,12 +65,12 @@ This approach may not always be suitable, since Ignition's config merging isn't 
 
 ## Creating a release
 
-Create a [release checklist](https://github.com/coreos/butane/issues/new?template=release-checklist.md) and follow those steps.
+Create a [release checklist](https://github.com/coreos/ignition/issues/new?template=release-checklist.md) and follow those steps.
 
 ## The build process
 
 Note that the binaries released in this repository are not built using the `build` script from this repository
-but using a `butane.spec` maintained in [Fedora rpms/butane](https://src.fedoraproject.org/rpms/butane).
+but using the `ignition.spec` maintained in [Fedora rpms/ignition](https://src.fedoraproject.org/rpms/ignition), where butane is built as a subpackage.
 This build process uses the [go-rpm-macros](https://pagure.io/go-rpm-macros) to set up the Go build environment and is
 subject to the [Golang Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Golang/).
 
@@ -82,4 +82,4 @@ In case you have trouble with the aforementioned standard Pull Request Guide, co
 
 ## Bumping spec versions
 
-Create a new [stabilization checklist](https://github.com/coreos/butane/issues/new?template=stabilize-checklist.md) and follow the steps there.
+Create a new [stabilization checklist](https://github.com/coreos/ignition/issues/new?template=stabilize-checklist.md) and follow the steps there.

--- a/butane/docs/getting-started.md
+++ b/butane/docs/getting-started.md
@@ -64,7 +64,7 @@ $ sudo dnf install -y butane
 
 #### Standalone binary
 
-Download the latest version of `butane` and the detached signature from the [releases page](https://github.com/coreos/butane/releases). Verify it with gpg:
+Download the latest version of `butane` and the detached signature from the [releases page](https://github.com/coreos/ignition/releases). Verify it with gpg:
 
 ```
 gpg --verify <detached sig> <butane binary>

--- a/butane/docs/index.md
+++ b/butane/docs/index.md
@@ -5,6 +5,6 @@ nav_order: 1
 # Butane
 
 Butane (formerly the Fedora CoreOS Config Transpiler, FCCT) translates human readable Butane Configs
-into machine readable [Ignition](https://coreos.github.io/ignition/) Configs. See the [getting
+into machine-readable [Ignition](../../docs/) Configs. Butane is part of the [Ignition](https://github.com/coreos/ignition) repository, and Ignition natively accepts Butane YAML configs at boot. See the [getting
 started](getting-started.md) guide for how to use Butane and the [configuration specifications](specs.md)
 for everything Butane configs support.

--- a/butane/docs/release-notes.md
+++ b/butane/docs/release-notes.md
@@ -4,7 +4,7 @@ nav_order: 9
 
 # Release notes
 
-Butane 0.29.0 is the last release from this standalone repository. Butane has been merged into the [Ignition](https://github.com/coreos/ignition) repository, where all future releases will be made.
+Butane 0.29.0 is the last release from this standalone repository. Butane has been merged into the [Ignition](https://github.com/coreos/ignition) repository. For changes after 0.29.0, see the [Ignition release notes](../../docs/release-notes.md).
 
 ## Butane 0.29.0 (2026-06-30)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,7 @@ The [frontend](https://github.com/coreos/ignition/tree/main/config) handles conf
 
 ### Adding functionality
 
-New config directives should only be added if the desired behavior cannot reasonably be achieved with existing directives.  User-friendly wrappers for existing syntax ("sugar") should be handled by [Butane](https://github.com/coreos/butane).
+New config directives should only be added if the desired behavior cannot reasonably be achieved with existing directives.  User-friendly wrappers for existing syntax ("sugar") should be handled by [Butane](https://coreos.github.io/butane/).
 
 New behavior should only be added in the current experimental spec.  If new functionality is backported to older specs, and a config using an older spec comes to depend on that functionality, then it won't be obvious that the config will not work on all Ignition versions supporting that spec.  It's not always possible to follow this restriction, since the backend doesn't know what config version the user specified.  Where possible, use config validation to prevent the backend from seeing config directives that a spec version doesn't support (for example, values of the filesystem `format` field).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ nav_order: 3
 
 Ignition is a low-level system configuration utility. The Ignition executable is part of the temporary initial root filesystem, the *initramfs*. When Ignition runs [on the first boot][firstboot], it finds configuration data in a named location for a given environment, such as a file or URL, and applies it to the machine before `switch_root` is called to pivot to the machine's root filesystem.
 
-Ignition uses a JSON configuration file to represent the set of changes to be made. The format of this config is detailed [in the specification][configspec] and the [MIME type][mime] is registered with IANA. One of the most important parts of this config is the version number. This **must** match the version number accepted by Ignition. If the config version isn't accepted by Ignition, Ignition will fail to run and the machine will not boot. This can be seen by inspecting the console output of the failed machine. For more information, check out the [troubleshooting section][troubleshooting].
+Ignition uses a JSON configuration file to represent the set of changes to be made. The format of this config is detailed [in the specification][configspec] and the [MIME type][mime] is registered with IANA. Ignition also natively accepts [Butane YAML configs][butanespecs], transpiling them automatically at boot. One of the most important parts of this config is the version number. This **must** match the version number accepted by Ignition. If the config version isn't accepted by Ignition, Ignition will fail to run and the machine will not boot. This can be seen by inspecting the console output of the failed machine. For more information, check out the [troubleshooting section][troubleshooting].
 
 ## Providing a Config
 
@@ -24,7 +24,7 @@ The Linux distro may provide a base config which specifies default configuration
 
 ## Config Validation
 
-To validate a config for Ignition there are binaries for a cli tool called `ignition-validate` available [on the releases page][releases]. There is also an ignition-validate container: `quay.io/coreos/ignition-validate`.
+To validate a config for Ignition there are binaries for a cli tool called `ignition-validate` available [on the releases page][releases]. `ignition-validate` accepts both Ignition JSON and Butane YAML configs. There is also an ignition-validate container: `quay.io/coreos/ignition-validate`.
 
 Example:
 ```
@@ -63,6 +63,7 @@ When Ignition enables systemd services, it doesn't directly create the symlinks 
 Ignition is not typically run more than once during a machine's lifetime in a given role, so this situation requiring manual systemd intervention does not commonly arise.
 
 [conditions]: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionFirstBoot=
+[butanespecs]: https://coreos.github.io/butane/specs/
 [configspec]: specs.md
 [examples]: examples.md
 [firstboot]: rationale.md#ignition-runs-only-on-the-first-boot

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ nav_order: 1
 
 # Ignition
 
-Ignition is a utility created to manipulate disks during the initramfs. This includes partitioning disks, formatting partitions, writing files (regular files, systemd units, etc.), and configuring users. On first boot, Ignition reads its configuration from a source of truth (remote URL, network metadata service, hypervisor bridge, etc.) and applies the configuration.
+Ignition is a utility created to manipulate disks during the initramfs. This includes partitioning disks, formatting partitions, writing files (regular files, systemd units, etc.), and configuring users. On first boot, Ignition reads its configuration from a source of truth (remote URL, network metadata service, hypervisor bridge, etc.) and applies the configuration. Ignition accepts both [Ignition JSON configs](specs.md) and [Butane YAML configs](https://coreos.github.io/butane/specs/), transpiling Butane configs automatically at boot.
 
 ## Usage
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -34,7 +34,7 @@ Ignition does not guess how the system should be configured.  For example, it do
 
 Ignition configs were designed to be human readable, but difficult to write, to discourage users from attempting to write configs by hand.  Ignition configs support basic primitives such as files, directories, filesystems, and partitions, but do not provide higher-level functionality for configuring specific system services.
 
-Use [Butane](https://coreos.github.io/butane/), or a similar tool, to generate Ignition configs. Butane reads [Butane configs](https://coreos.github.io/butane/specs/), which are YAML files containing distribution-independent Ignition directives and optional distribution-specific directives that provide an easier way to perform certain configuration tasks. Butane validates a Butane config for common errors and produces an Ignition config ready to be passed to a machine.
+Use [Butane](https://coreos.github.io/butane/), or a similar tool, to generate Ignition configs. Butane reads [Butane configs](https://coreos.github.io/butane/specs/), which are YAML files containing distribution-independent Ignition directives and optional distribution-specific directives that provide an easier way to perform certain configuration tasks. Butane validates a Butane config for common errors and produces an Ignition config ready to be passed to a machine. Ignition also natively accepts Butane YAML configs at boot, transpiling them automatically.
 
 ## Ignition is distro-independent
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -36,6 +36,12 @@ Ignition:
 
 - [v3.7.0-experimental](configuration-v3_7_experimental.md)
 
+## Butane configuration specifications
+
+Ignition also natively accepts Butane YAML configs, transpiling them
+automatically at boot. For Butane config specifications, see the
+[Butane specs](https://coreos.github.io/butane/specs/) page.
+
 ## Legacy spec 2.x configuration specifications
 
 Documentation for the spec 1 and 2.x configuration specifications is available


### PR DESCRIPTION
Fix broken links to the archived `coreos/butane` repo and `coreos.github.io/butane/` docs site
Document that Ignition natively accepts Butane YAML configs at boot
Add butane to architecture diagrams, build commands, and release/stabilization checklists
Update Butane docs Jekyll config, release links, and development docs to point to `coreos/ignition`


1. `AGENTS.md` -- add butane binary, directory tree, build commands
2. `README.md` -- add Butane integration section
3. `docs/development.md` -- fix Butane link to in-repo docs
4. `docs/rationale.md` -- fix Butane links to in-repo docs
5. `.github/ISSUE_TEMPLATE/stabilize-checklist.md` -- fix Butane link
6. `.github/ISSUE_TEMPLATE/release-checklist.md` -- add butane release steps
7. `butane/docs/_config.yml` -- update Jekyll GitHub links to coreos/ignition
8. `butane/docs/getting-started.md` -- fix releases link to ignition repo
9. `butane/docs/development.md` -- update issue template and packaging links
10. `docs/getting-started.md` -- document Butane YAML config support
11. `docs/index.md` -- mention Butane YAML config support
12. `docs/specs.md` -- add cross-reference to Butane specs
13. `CONTRIBUTING.md` -- mention butane/ directory
14. `butane/docs/index.md` -- update Ignition link and note repo merge

Related: https://github.com/coreos/fedora-coreos-tracker/issues/2006