### PR TITLE
butane: update Dockerfile and build script for ignition repo

### DIFF
--- a/butane/Dockerfile
+++ b/butane/Dockerfile
@@ -1,10 +1,10 @@
 FROM quay.io/fedora/fedora:44 AS builder
 RUN dnf install -y golang git-core
-RUN mkdir /butane
-COPY . /butane
-WORKDIR /butane
-RUN ./build_for_container
+RUN mkdir /ignition
+COPY . /ignition
+WORKDIR /ignition
+RUN ./butane/build_for_container
 
 FROM quay.io/fedora/fedora-minimal:44
-COPY --from=builder /butane/bin/container/butane /usr/local/bin/butane
+COPY --from=builder /ignition/bin/container/butane /usr/local/bin/butane
 ENTRYPOINT ["/usr/local/bin/butane"]

--- a/butane/build_for_container
+++ b/butane/build_for_container
@@ -6,7 +6,7 @@ export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 export CGO_ENABLED=0
 version=$(git describe --dirty --always)
-LDFLAGS="-w -X github.com/coreos/butane/internal/version.Raw=$version"
+LDFLAGS="-w -X github.com/coreos/ignition/v2/butane/internal/version.Raw=$version"
 
 eval $(go env)
 if [ -z ${BIN_PATH+a} ]; then
@@ -14,4 +14,4 @@ if [ -z ${BIN_PATH+a} ]; then
 fi
 
 export GOOS=linux
-go build -o ${BIN_PATH}/butane -ldflags "$LDFLAGS" internal/main.go
+go build -o ${BIN_PATH}/butane -ldflags "$LDFLAGS" github.com/coreos/ignition/v2/butane/internal


### PR DESCRIPTION
## Summary

Update `butane/Dockerfile` and `butane/build_for_container` to work correctly from within the ignition repo after the Butane merge (#2235).

## Changes

- **`butane/Dockerfile`** -- Update Docker context from `/butane` to `/ignition` (repo root), run `./butane/build_for_container` instead of `./build_for_container`
- **`butane/build_for_container`** -- Update import path from `github.com/coreos/butane` to `github.com/coreos/ignition/v2/butane`, use module path instead of `internal/main.go`

The CI workflow to build and push this container will come from [coreos/repo-templates#371](https://github.com/coreos/repo-templates/pull/371).

## Tracking

- Related: https://github.com/coreos/fedora-coreos-tracker/issues/2006