### PR TITLE
butane: validate local files used as ignition configs

### DIFF
--- a/butane/base/v0_7/translate.go
+++ b/butane/base/v0_7/translate.go
@@ -118,7 +118,30 @@ func translateIgnition(from Ignition, options common.TranslateOptions) (to types
 	translate.MergeP(tr, tm, &r, "proxy", &from.Proxy, &to.Proxy)
 	translate.MergeP(tr, tm, &r, "security", &from.Security, &to.Security)
 	translate.MergeP(tr, tm, &r, "timeouts", &from.Timeouts, &to.Timeouts)
+
+	c := path.New("yaml", "ignition", "config")
+	for i, res := range from.Config.Merge {
+		if res.Local != nil {
+			validateLocalIgnitionConfig(c.Append("merge", i, "local"), *res.Local, options, &r)
+		}
+	}
+	if from.Config.Replace.Local != nil {
+		validateLocalIgnitionConfig(c.Append("replace", "local"), *from.Config.Replace.Local, options, &r)
+	}
 	return
+}
+
+func validateLocalIgnitionConfig(c path.ContextPath, local string, options common.TranslateOptions, r *report.Report) {
+	contents, err := baseutil.ReadLocalFile(local, options.FilesDir)
+	if err != nil {
+		r.AddOnError(c, err)
+		return
+	}
+	rp, err := ValidateIgnitionConfig(c, contents)
+	r.Merge(rp)
+	if err != nil {
+		r.AddOnError(c, err)
+	}
 }
 
 func translateFile(from File, options common.TranslateOptions) (to types.File, tm translate.TranslationSet, r report.Report) {
@@ -147,15 +170,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		if err != nil {
 			r.AddOnError(c, err)
 			return
-		}
-		// Validating the contents of the local file from here since there is no way to
-		// get both the filename and filedirectory in the Validate context
-		if strings.HasPrefix(c.String(), "$.ignition.config") {
-			rp, err := ValidateIgnitionConfig(c, contents)
-			r.Merge(rp)
-			if err != nil {
-				return
-			}
 		}
 
 		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)

--- a/butane/base/v0_8_exp/translate.go
+++ b/butane/base/v0_8_exp/translate.go
@@ -122,7 +122,30 @@ func translateIgnition(from Ignition, options common.TranslateOptions) (to types
 	translate.MergeP(tr, tm, &r, "proxy", &from.Proxy, &to.Proxy)
 	translate.MergeP(tr, tm, &r, "security", &from.Security, &to.Security)
 	translate.MergeP(tr, tm, &r, "timeouts", &from.Timeouts, &to.Timeouts)
+
+	c := path.New("yaml", "ignition", "config")
+	for i, res := range from.Config.Merge {
+		if res.Local != nil {
+			validateLocalIgnitionConfig(c.Append("merge", i, "local"), *res.Local, options, &r)
+		}
+	}
+	if from.Config.Replace.Local != nil {
+		validateLocalIgnitionConfig(c.Append("replace", "local"), *from.Config.Replace.Local, options, &r)
+	}
 	return
+}
+
+func validateLocalIgnitionConfig(c path.ContextPath, local string, options common.TranslateOptions, r *report.Report) {
+	contents, err := baseutil.ReadLocalFile(local, options.FilesDir)
+	if err != nil {
+		r.AddOnError(c, err)
+		return
+	}
+	rp, err := ValidateIgnitionConfig(c, contents)
+	r.Merge(rp)
+	if err != nil {
+		r.AddOnError(c, err)
+	}
 }
 
 func translateFile(from File, options common.TranslateOptions) (to types.File, tm translate.TranslationSet, r report.Report) {
@@ -151,15 +174,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		if err != nil {
 			r.AddOnError(c, err)
 			return
-		}
-		// Validating the contents of the local file from here since there is no way to
-		// get both the filename and filedirectory in the Validate context
-		if strings.HasPrefix(c.String(), "$.ignition.config") {
-			rp, err := ValidateIgnitionConfig(c, contents)
-			r.Merge(rp)
-			if err != nil {
-				return
-			}
 		}
 
 		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)

--- a/butane/base/v0_8_exp/translate_test.go
+++ b/butane/base/v0_8_exp/translate_test.go
@@ -1892,6 +1892,39 @@ func TestTranslateTree(t *testing.T) {
 	}
 }
 
+// TestTranslateResourceLocalIgnitionValidation ensures that local files used as
+// ignition configs (via ignition.config.merge/replace) are validated as Ignition
+// configs. Previously the validation branch was guarded by
+// strings.HasPrefix(c.String(), "$.ignition.config") where c was a synthetic
+// path.New("yaml", "local") whose String() is "$.local", so the guard was always
+// false and validation never ran. See coreos/ignition#2280.
+func TestTranslateResourceLocalIgnitionValidation(t *testing.T) {
+	filesDir := t.TempDir()
+	invalidConfig := `{ "this is not": "a valid ignition config" }`
+	if err := os.WriteFile(filepath.Join(filesDir, "bad-config"), []byte(invalidConfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := Config{
+		Ignition: Ignition{
+			Config: IgnitionConfig{
+				Merge: []Resource{
+					{
+						Local: util.StrToPtr("bad-config"),
+					},
+				},
+			},
+		},
+	}
+
+	_, _, r := config.ToIgn3_7Unvalidated(common.TranslateOptions{
+		FilesDir: filesDir,
+	})
+
+	assert.NotEqual(t, report.Report{}, r, "local ignition config should be validated and produce an error")
+	assert.Contains(t, r.String(), "invalid config version", "error should describe the invalid ignition config")
+}
+
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
 // It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,8 @@ nav_order: 9
 
 ### Bug fixes
 
+- butane: validate local files referenced via `ignition.config.merge` or `ignition.config.replace` as Ignition configs, instead of silently embedding invalid ones ([#2283](https://github.com/coreos/ignition/pull/2283))
+
 
 ## Upcoming Ignition 2.27.0 (unreleased)
 


### PR DESCRIPTION
## Issue
Fixes #2280

Local files referenced via `ignition.config.merge` or `ignition.config.replace` were never validated as Ignition configs. Invalid local ignition configs were silently embedded into the output without any error.

## Root cause
`translateResource` built a synthetic path `path.New("yaml", "local")` whose `String()` is `$.local`, then guarded the validation with `strings.HasPrefix(c.String(), "$.ignition.config")`. That condition is always false, so the `ValidateIgnitionConfig` call was dead code and never executed.

## Fix
Move the validation into `translateIgnition`, where the real context path is available. The merge list and the replace resource are validated there when their source is a local file. This keeps validation scoped to `ignition.config` resources only, so file `append`/`contents` local files are unaffected.

The change is applied to both `butane/base/v0_7` and `butane/base/v0_8_exp` (the issue lists both).

## Test
Added `TestTranslateResourceLocalIgnitionValidation` in `butane/base/v0_8_exp/translate_test.go`, which references a local file containing an invalid ignition config via `ignition.config.merge` and asserts that translation now reports a validation error. Before the fix the test fails (no error is reported); after the fix it passes.

Full `./butane/...` test suite passes with no regressions.

/cc @prestist