### PR TITLE
butane: add overwrite support for trees

### DIFF
--- a/butane/base/v0_7/schema.go
+++ b/butane/base/v0_7/schema.go
@@ -249,12 +249,13 @@ type Timeouts struct {
 }
 
 type Tree struct {
-	Group    NodeGroup `yaml:"group"`
-	Local    string    `yaml:"local"`
-	Path     *string   `yaml:"path"`
-	User     NodeUser  `yaml:"user"`
-	FileMode *int      `yaml:"file_mode"`
-	DirMode  *int      `yaml:"dir_mode"`
+	Group     NodeGroup `yaml:"group"`
+	Local     string    `yaml:"local"`
+	Path      *string   `yaml:"path"`
+	User      NodeUser  `yaml:"user"`
+	FileMode  *int      `yaml:"file_mode"`
+	DirMode   *int      `yaml:"dir_mode"`
+	Overwrite *bool     `yaml:"overwrite"`
 }
 
 type Unit struct {

--- a/butane/base/v0_7/translate.go
+++ b/butane/base/v0_7/translate.go
@@ -118,7 +118,30 @@ func translateIgnition(from Ignition, options common.TranslateOptions) (to types
 	translate.MergeP(tr, tm, &r, "proxy", &from.Proxy, &to.Proxy)
 	translate.MergeP(tr, tm, &r, "security", &from.Security, &to.Security)
 	translate.MergeP(tr, tm, &r, "timeouts", &from.Timeouts, &to.Timeouts)
+
+	c := path.New("yaml", "ignition", "config")
+	for i, res := range from.Config.Merge {
+		if res.Local != nil {
+			validateLocalIgnitionConfig(c.Append("merge", i, "local"), *res.Local, options, &r)
+		}
+	}
+	if from.Config.Replace.Local != nil {
+		validateLocalIgnitionConfig(c.Append("replace", "local"), *from.Config.Replace.Local, options, &r)
+	}
 	return
+}
+
+func validateLocalIgnitionConfig(c path.ContextPath, local string, options common.TranslateOptions, r *report.Report) {
+	contents, err := baseutil.ReadLocalFile(local, options.FilesDir)
+	if err != nil {
+		r.AddOnError(c, err)
+		return
+	}
+	rp, err := ValidateIgnitionConfig(c, contents)
+	r.Merge(rp)
+	if err != nil {
+		r.AddOnError(c, err)
+	}
 }
 
 func translateFile(from File, options common.TranslateOptions) (to types.File, tm translate.TranslationSet, r report.Report) {
@@ -147,15 +170,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		if err != nil {
 			r.AddOnError(c, err)
 			return
-		}
-		// Validating the contents of the local file from here since there is no way to
-		// get both the filename and filedirectory in the Validate context
-		if strings.HasPrefix(c.String(), "$.ignition.config") {
-			rp, err := ValidateIgnitionConfig(c, contents)
-			r.Merge(rp)
-			if err != nil {
-				return
-			}
 		}
 
 		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)

--- a/butane/base/v0_7/translate.go
+++ b/butane/base/v0_7/translate.go
@@ -355,6 +355,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 			group:            tree.Group,
 			fileMode:         tree.FileMode,
 			dirMode:          tree.DirMode,
+			overwrite:        tree.Overwrite,
 		})
 	}
 	return ts, r
@@ -364,10 +365,11 @@ type treeWalkOptions struct {
 	srcBaseDir  string
 	destBaseDir string
 	common.TranslateOptions
-	user     NodeUser
-	group    NodeGroup
-	fileMode *int
-	dirMode  *int
+	user      NodeUser
+	group     NodeGroup
+	fileMode  *int
+	dirMode   *int
+	overwrite *bool
 }
 
 func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, options treeWalkOptions) {
@@ -406,6 +408,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 					Mode: mode,
 				},
 			})
+			dir.Overwrite = options.overwrite
 			ts.AddFromCommonSource(yamlPath, path.New("json", "storage", "directories", i), dir)
 			if i == 0 {
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "directories"))
@@ -425,6 +428,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				i, file = t.AddFile(types.File{
 					Node: createNode(destPath, options.user, options.group),
 				})
+				file.Overwrite = options.overwrite
 				ts.AddFromCommonSource(yamlPath, path.New("json", "storage", "files", i), file)
 				if i == 0 {
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "files"))
@@ -473,6 +477,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				i, link = t.AddLink(types.Link{
 					Node: createNode(destPath, options.user, options.group),
 				})
+				link.Overwrite = options.overwrite
 				ts.AddFromCommonSource(yamlPath, path.New("json", "storage", "links", i), link)
 				if i == 0 {
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "links"))

--- a/butane/base/v0_8_exp/schema.go
+++ b/butane/base/v0_8_exp/schema.go
@@ -250,12 +250,13 @@ type Timeouts struct {
 }
 
 type Tree struct {
-	Group    NodeGroup `yaml:"group"`
-	Local    string    `yaml:"local"`
-	Path     *string   `yaml:"path"`
-	User     NodeUser  `yaml:"user"`
-	FileMode *int      `yaml:"file_mode"`
-	DirMode  *int      `yaml:"dir_mode"`
+	Group     NodeGroup `yaml:"group"`
+	Local     string    `yaml:"local"`
+	Path      *string   `yaml:"path"`
+	User      NodeUser  `yaml:"user"`
+	FileMode  *int      `yaml:"file_mode"`
+	DirMode   *int      `yaml:"dir_mode"`
+	Overwrite *bool     `yaml:"overwrite"`
 }
 
 type Unit struct {

--- a/butane/base/v0_8_exp/translate.go
+++ b/butane/base/v0_8_exp/translate.go
@@ -525,6 +525,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 			group:            tree.Group,
 			fileMode:         tree.FileMode,
 			dirMode:          tree.DirMode,
+			overwrite:        tree.Overwrite,
 		})
 	}
 	return ts, r
@@ -534,10 +535,11 @@ type treeWalkOptions struct {
 	srcBaseDir  string
 	destBaseDir string
 	common.TranslateOptions
-	user     NodeUser
-	group    NodeGroup
-	fileMode *int
-	dirMode  *int
+	user      NodeUser
+	group     NodeGroup
+	fileMode  *int
+	dirMode   *int
+	overwrite *bool
 }
 
 func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report.Report, t *nodeTracker, options treeWalkOptions) {
@@ -576,6 +578,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 					Mode: mode,
 				},
 			})
+			dir.Overwrite = options.overwrite
 			ts.AddFromCommonSource(yamlPath, path.New("json", "storage", "directories", i), dir)
 			if i == 0 {
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "directories"))
@@ -595,6 +598,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				i, file = t.AddFile(types.File{
 					Node: createNode(destPath, options.user, options.group),
 				})
+				file.Overwrite = options.overwrite
 				ts.AddFromCommonSource(yamlPath, path.New("json", "storage", "files", i), file)
 				if i == 0 {
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "files"))
@@ -643,6 +647,7 @@ func walkTree(yamlPath path.ContextPath, ts *translate.TranslationSet, r *report
 				i, link = t.AddLink(types.Link{
 					Node: createNode(destPath, options.user, options.group),
 				})
+				link.Overwrite = options.overwrite
 				ts.AddFromCommonSource(yamlPath, path.New("json", "storage", "links", i), link)
 				if i == 0 {
 					ts.AddTranslation(yamlPath, path.New("json", "storage", "links"))

--- a/butane/base/v0_8_exp/translate.go
+++ b/butane/base/v0_8_exp/translate.go
@@ -122,7 +122,30 @@ func translateIgnition(from Ignition, options common.TranslateOptions) (to types
 	translate.MergeP(tr, tm, &r, "proxy", &from.Proxy, &to.Proxy)
 	translate.MergeP(tr, tm, &r, "security", &from.Security, &to.Security)
 	translate.MergeP(tr, tm, &r, "timeouts", &from.Timeouts, &to.Timeouts)
+
+	c := path.New("yaml", "ignition", "config")
+	for i, res := range from.Config.Merge {
+		if res.Local != nil {
+			validateLocalIgnitionConfig(c.Append("merge", i, "local"), *res.Local, options, &r)
+		}
+	}
+	if from.Config.Replace.Local != nil {
+		validateLocalIgnitionConfig(c.Append("replace", "local"), *from.Config.Replace.Local, options, &r)
+	}
 	return
+}
+
+func validateLocalIgnitionConfig(c path.ContextPath, local string, options common.TranslateOptions, r *report.Report) {
+	contents, err := baseutil.ReadLocalFile(local, options.FilesDir)
+	if err != nil {
+		r.AddOnError(c, err)
+		return
+	}
+	rp, err := ValidateIgnitionConfig(c, contents)
+	r.Merge(rp)
+	if err != nil {
+		r.AddOnError(c, err)
+	}
 }
 
 func translateFile(from File, options common.TranslateOptions) (to types.File, tm translate.TranslationSet, r report.Report) {
@@ -151,15 +174,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		if err != nil {
 			r.AddOnError(c, err)
 			return
-		}
-		// Validating the contents of the local file from here since there is no way to
-		// get both the filename and filedirectory in the Validate context
-		if strings.HasPrefix(c.String(), "$.ignition.config") {
-			rp, err := ValidateIgnitionConfig(c, contents)
-			r.Merge(rp)
-			if err != nil {
-				return
-			}
 		}
 
 		src, compression, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)

--- a/butane/base/v0_8_exp/translate_test.go
+++ b/butane/base/v0_8_exp/translate_test.go
@@ -1925,6 +1925,55 @@ func TestTranslateResourceLocalIgnitionValidation(t *testing.T) {
 	assert.Contains(t, r.String(), "invalid config version", "error should describe the invalid ignition config")
 }
 
+// TestTranslateTreeOverwrite ensures that setting overwrite on a tree flows down
+// to the files, directories, and links generated from it. See coreos/ignition#2257.
+func TestTranslateTreeOverwrite(t *testing.T) {
+	filesDir := t.TempDir()
+	treeDir := filepath.Join(filesDir, "tree")
+	if err := os.MkdirAll(filepath.Join(treeDir, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(treeDir, "file"), []byte("contents"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(treeDir, "exec"), []byte("contents"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("file", filepath.Join(treeDir, "subdir", "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	config := Config{
+		Storage: Storage{
+			Trees: []Tree{
+				{
+					Local:     "tree",
+					Overwrite: util.BoolToPtr(true),
+					DirMode:   util.IntToPtr(0755),
+				},
+			},
+		},
+	}
+
+	actual, _, r := config.ToIgn3_7Unvalidated(common.TranslateOptions{
+		FilesDir: filesDir,
+	})
+	assert.Equal(t, report.Report{}, r, "unexpected report errors")
+
+	for _, f := range actual.Storage.Files {
+		assert.Equal(t, util.BoolToPtr(true), f.Overwrite, "file %s should be marked overwrite", f.Path)
+	}
+	for _, d := range actual.Storage.Directories {
+		assert.Equal(t, util.BoolToPtr(true), d.Overwrite, "directory %s should be marked overwrite", d.Path)
+	}
+	for _, l := range actual.Storage.Links {
+		assert.Equal(t, util.BoolToPtr(true), l.Overwrite, "link %s should be marked overwrite", l.Path)
+	}
+	assert.NotEmpty(t, actual.Storage.Files, "expected generated files")
+	assert.NotEmpty(t, actual.Storage.Directories, "expected generated directories")
+	assert.NotEmpty(t, actual.Storage.Links, "expected generated links")
+}
+
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
 // It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {

--- a/butane/base/v0_8_exp/translate_test.go
+++ b/butane/base/v0_8_exp/translate_test.go
@@ -1892,6 +1892,39 @@ func TestTranslateTree(t *testing.T) {
 	}
 }
 
+// TestTranslateResourceLocalIgnitionValidation ensures that local files used as
+// ignition configs (via ignition.config.merge/replace) are validated as Ignition
+// configs. Previously the validation branch was guarded by
+// strings.HasPrefix(c.String(), "$.ignition.config") where c was a synthetic
+// path.New("yaml", "local") whose String() is "$.local", so the guard was always
+// false and validation never ran. See coreos/ignition#2280.
+func TestTranslateResourceLocalIgnitionValidation(t *testing.T) {
+	filesDir := t.TempDir()
+	invalidConfig := `{ "this is not": "a valid ignition config" }`
+	if err := os.WriteFile(filepath.Join(filesDir, "bad-config"), []byte(invalidConfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := Config{
+		Ignition: Ignition{
+			Config: IgnitionConfig{
+				Merge: []Resource{
+					{
+						Local: util.StrToPtr("bad-config"),
+					},
+				},
+			},
+		},
+	}
+
+	_, _, r := config.ToIgn3_7Unvalidated(common.TranslateOptions{
+		FilesDir: filesDir,
+	})
+
+	assert.NotEqual(t, report.Report{}, r, "local ignition config should be validated and produce an error")
+	assert.Contains(t, r.String(), "invalid config version", "error should describe the invalid ignition config")
+}
+
 // TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
 // It ensures that the version is set as well.
 func TestTranslateIgnition(t *testing.T) {

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,10 @@ nav_order: 9
 - `build_blackbox_tests` builds a blackbox-specific `ignition` binary with `make`
 - CI and GitHub Actions updated to build via `make ignition` and `make ignition-validate`
 
+### Features
+
+- butane: add `overwrite` support for trees, threading the flag through to every generated file, directory, and link ([#2284](https://github.com/coreos/ignition/pull/2284))
+
 ### Bug fixes
 
 


### PR DESCRIPTION
## Issue
Fixes #2257 (continuation of coreos/butane#712)

Trees are Butane-only sugar that expand into files, directories, and links.
This adds an optional `overwrite` field to the tree resource so the flag flows
down to every generated entry, matching the existing `overwrite` support on
files, directories, and links.

## Implementation
- Added `Overwrite *bool` to the `Tree` schema in both `butane/base/v0_7` and
  `butane/base/v0_8_exp`.
- Threaded the value through `treeWalkOptions` in `translateTree` and applied it
  to the generated `types.Directory`, `types.File`, and `types.Link` nodes (the
  `Overwrite` field lives on the shared `Node` struct in the v3_6/v3_7_experimental
  config types).
- Added `TestTranslateTreeOverwrite` which builds a tree with `overwrite: true`
  (containing a file, an executable, a subdirectory, and a symlink) and asserts
  every generated file, directory, and link carries `overwrite: true`.

## Verification
- `go test ./butane/...` passes with no regressions.
- The new test fails before the change (entries have `overwrite: nil`) and
  passes after.

/cc @prestist