### PR TITLE
docs: link source field to AWS S3 access operator notes

### DIFF
--- a/config/doc/ignition.yaml
+++ b/config/doc/ignition.yaml
@@ -1,7 +1,7 @@
 resource:
   children:
     - name: source
-      desc: "the URL of the %TYPE%. Supported schemes are `http`, `https`, `tftp`, `s3`, `arn`, `gs`, and [`data`](https://tools.ietf.org/html/rfc2397). When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified."
+      desc: "the URL of the %TYPE%. Supported schemes are `http`, `https`, `tftp`, `s3`, `arn`, `gs`, and [`data`](https://tools.ietf.org/html/rfc2397). When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. For `s3` and `arn` sources, see [Ignition's documentation on AWS S3 access](https://coreos.github.io/ignition/operator-notes/#aws-s3-access) for the supported URL formats and how credentials are resolved at runtime."
       # source is typically required by validation, but some inclusion sites
       # will override this
       required: true


### PR DESCRIPTION
## Issue

coreos/butane#662 — the `source` field docs list `s3`/`arn` as supported schemes but are silent on how S3 credentials are resolved at runtime.

## Approach

As agreed with @pabo99 / @prestist in the issue thread, the fix belongs upstream in Ignition's `config/doc/ignition.yaml` (Butane's spec docs are generated from this file, and the butane and ignition repos are now merged). The `source` field description now links to Ignition's AWS S3 access operator notes, which document the supported `s3://`/`arn:...` URL formats and credential resolution.

This follows the existing pattern used by other fields that link to `operator-notes/#...` (e.g. the filesystem wipe descriptions).

## Verification

- `config/doc/ignition.yaml` and `butane/internal/doc/butane.yaml` parse as valid YAML.
- The openshift variant's `source` transform (a full-replacement regex ending at "haven't been modified.") is unaffected — it still replaces the whole description with "Only the `data` scheme is supported." for openshift, which remains correct.

Fixes coreos/butane#662