### PR TITLE
internal/exec/stages/disks: fix file descriptor leak in blockDevMounted

### DIFF
--- a/internal/exec/stages/disks/partitions.go
+++ b/internal/exec/stages/disks/partitions.go
@@ -364,6 +364,7 @@ func blockDevMounted(blockDevResolved string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to open /proc/mounts: %v", err)
 	}
+	defer mounts.Close()
 	scanner := bufio.NewScanner(mounts)
 	for scanner.Scan() {
 		mountSource := strings.Split(scanner.Text(), " ")[0]


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a file descriptor leak in the `blockDevMounted` function within the disk stages. 

Previously, `os.Open("/proc/mounts")` was called without a corresponding `Close()`. Since `blockDevMounted` is executed (via `blockDevInUse`) for every partition and every block device during the storage initialization stage, this leak could quickly exhaust the process's open file descriptor limit during early-boot provisioning on systems with many partitions or devices.

This PR adds the missing `defer mounts.Close()` immediately after the file is successfully opened to ensure the file descriptor is released safely on all exit paths.

**Fixes**:
*(Add the related issue number here if you opened an issue for this, e.g., `Fixes #XYZ`)*

**Special notes for your reviewer**:
* Verified that `mounts.Close()` executes correctly regardless of whether the `bufio.Scanner` completes entirely or returns early when a matching block device is found.