### PR TITLE
internal/exec/stages/disks: guard against nil tang Thumbprint deref

### DIFF
--- a/internal/exec/stages/disks/luks.go
+++ b/internal/exec/stages/disks/luks.go
@@ -329,9 +329,13 @@ func (s *stage) createLuks(config types.Config) error {
 								return fmt.Errorf("unmarshalling advertisement: %v", err)
 							}
 						}
+						thumbprint := ""
+						if tang.Thumbprint != nil {
+							thumbprint = *tang.Thumbprint
+						}
 						c.Pins.Tang = append(c.Pins.Tang, Tang{
 							URL:           tang.URL,
-							Thumbprint:    *tang.Thumbprint,
+							Thumbprint:    thumbprint,
 							Advertisement: adv,
 						})
 					}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a runtime panic caused by an unchecked nil pointer dereference on `tang.Thumbprint` when processing LUKS clevis configurations. 

While the config validator enforces that `Thumbprint` must be present (`ErrTangThumbprintRequired`), this validation only runs for user-specified configs. Programmatically generated configs, configs merged dynamically, or system base configs can bypass this strict validation. If `Thumbprint` evaluates to `nil`, it previously caused a hard panic. This PR introduces a safe check, defaulting to an empty string to allow execution to proceed gracefully or fail appropriately downstream without crashing the provisioner.

**Fixes**:
*(Add the related issue number here if you opened an issue for this, e.g., `Fixes #XYZ`)*

**Special notes for your reviewer**:
* Verified that when `tang.Thumbprint` is `nil`, the value safely defaults to an empty string and the clevis configuration successfully marshals to JSON instead of triggering a panic.