### PR TITLE
internal/exec/stages/files: fix wrong map key in unit preset duplicate check

### DIFF
--- a/internal/exec/stages/files/units.go
+++ b/internal/exec/stages/files/units.go
@@ -79,7 +79,7 @@ func (s *stage) createUnits(config types.Config) error {
 				}
 			} else {
 				key := fmt.Sprintf("%s-%s", unit.Name, identifier)
-				if _, ok := presets[unit.Name]; !ok {
+				if _, ok := presets[key]; !ok {
 					presets[key] = &Preset{unit.Name, *unit.Enabled, false, []string{}}
 				} else {
 					return fmt.Errorf("%q key is already present in the presets map", key)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the duplicate detection logic for systemd unit presets within the `files` stage. 

Previously, when checking if a unit was already present in the `presets` map (to prevent conflicting enabled/disabled states for the same unit), the code incorrectly checked `presets[unit.Name]` instead of the dynamically constructed `key` (which is formatted as `unitName-enabled` or `unitName-disabled`). Because the bare unit name never exists as a key in the map, the duplicate check always evaluated to false. This effectively disabled the conflict detection entirely and made the error return path dead code. 

This PR corrects the map lookup to use the proper `key`, restoring the intended protection against duplicate/conflicting unit declarations.

**Fixes**:
*(Add the related issue number here if you opened an issue for this, e.g., `Fixes #XYZ`)*

**Special notes for your reviewer**:
* Verified that `presets[key]` is properly scoped and correctly identifies duplicate entries matching the `fmt.Sprintf("%s-%s", unit.Name, identifier)` pattern.