### PR TITLE
config/types: allow deleting partitions by label

### DIFF
--- a/config/v3_6/types/partition.go
+++ b/config/v3_6/types/partition.go
@@ -46,7 +46,7 @@ func (p Partition) Key() string {
 
 func (p Partition) Validate(c path.ContextPath) (r report.Report) {
 	if util.IsFalse(p.ShouldExist) &&
-		(util.NotEmpty(p.TypeGUID) || util.NotEmpty(p.GUID) || p.StartMiB != nil || p.SizeMiB != nil) {
+		(p.Label != nil || util.NotEmpty(p.TypeGUID) || util.NotEmpty(p.GUID) || p.StartMiB != nil || p.SizeMiB != nil) {
 		r.AddOnError(c, errors.ErrShouldNotExistWithOthers)
 	}
 	if p.Number == 0 && p.Label == nil {

--- a/config/v3_6/types/partition.go
+++ b/config/v3_6/types/partition.go
@@ -46,7 +46,7 @@ func (p Partition) Key() string {
 
 func (p Partition) Validate(c path.ContextPath) (r report.Report) {
 	if util.IsFalse(p.ShouldExist) &&
-		(p.Label != nil || util.NotEmpty(p.TypeGUID) || util.NotEmpty(p.GUID) || p.StartMiB != nil || p.SizeMiB != nil) {
+		(util.NotEmpty(p.TypeGUID) || util.NotEmpty(p.GUID) || p.StartMiB != nil || p.SizeMiB != nil) {
 		r.AddOnError(c, errors.ErrShouldNotExistWithOthers)
 	}
 	if p.Number == 0 && p.Label == nil {

--- a/config/v3_7_experimental/types/partition.go
+++ b/config/v3_7_experimental/types/partition.go
@@ -46,7 +46,7 @@ func (p Partition) Key() string {
 
 func (p Partition) Validate(c path.ContextPath) (r report.Report) {
 	if util.IsFalse(p.ShouldExist) &&
-		(p.Label != nil || util.NotEmpty(p.TypeGUID) || util.NotEmpty(p.GUID) || p.StartMiB != nil || p.SizeMiB != nil) {
+		(util.NotEmpty(p.TypeGUID) || util.NotEmpty(p.GUID) || p.StartMiB != nil || p.SizeMiB != nil) {
 		r.AddOnError(c, errors.ErrShouldNotExistWithOthers)
 	}
 	if p.Number == 0 && p.Label == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a validation bug that prevented users from deleting a disk partition by referencing its label. 

In Ignition, partitions can be addressed either by their `Number` or by their `Label`. When a user wants to delete a specific partition, they set `shouldExist: false` and identify the partition. However, the validation logic incorrectly included the `Label` field in the "forbidden-fields" list when `shouldExist` is false. This made it impossible to delete a partition by label, as the validator would incorrectly reject the configuration with `ErrShouldNotExistWithOthers`.

This PR removes `Label` from that specific validation check across both `v3_6` and `v3_7_experimental` config schemas, acknowledging that the label serves as an identifier rather than a conflicting property.

**Fixes**:
*(Add the related issue number here if you opened an issue for this, e.g., `Fixes #XYZ`)*

**Special notes for your reviewer**:
* Verified that `ShouldExist: false` now properly validates when a `Label` is provided.
* Ensured that `ErrShouldNotExistWithOthers` still correctly fires if `TypeGUID`, `GUID`, `StartMiB`, or `SizeMiB` are specified alongside `ShouldExist: false`.