### PR TITLE
providers/outscale: add Outscale support

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,10 @@ nav_order: 9
 - The `build` script now requires a subcommand (`ignition`, `ignition-validate`, or `ignition-validate-cross`). Sourcing the build script is no longer supported.
 - Build and install are separate steps with explicit targets (`ignition`, `ignition-validate`, `ignition-validate-cross`, `install`, `install-ignition-validate-cross`, `install-grub-for-bootupd`).
 
+### Features
+
+- Support Outscale
+
 ### Changes
 
 - Refactored the Makefile and build script to match the Fedora RPM spec: separate build targets per binary, with `VERSION` and linker flags passed in at build time

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -26,6 +26,7 @@ Ignition is currently supported for the following platforms:
 * [NVIDIA BlueField] (`nvidiabluefield`) - Ignition will read its configuration from the bootfifo sysfs interface from the mlxbf_bootctl platform driver.
 * [OpenStack] (`openstack`) - Ignition will read its configuration from the instance userdata via either metadata service or config drive. Cloud SSH keys are handled separately.
 * [Oracle Cloud Infrastucture] (`oraclecloud`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
+* [Outscale] (`outscale`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [Proxmox VE] (`proxmoxve`) - Ignition will read its configuration from the instance userdata via config drive. If there isn't any valid Ignition configuration in userdata it will check the vendordata next. Cloud SSH keys are handled separately.
 * [Equinix Metal] (`packet`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
 * [IBM Power Systems Virtual Server] (`powervs`) - Ignition will read its configuration from the instance userdata. Cloud SSH keys are handled separately.
@@ -59,6 +60,7 @@ For most cloud providers, cloud SSH keys and custom network configuration are ha
 [Nutanix]: https://www.nutanix.com/products/ahv
 [OpenStack]: https://www.openstack.org/
 [Oracle Cloud Infrastucture]: https://www.oracle.com/cloud
+[Outscale]: https://docs.outscale.com
 [Proxmox VE]: https://www.proxmox.com/en/proxmox-virtual-environment/overview
 [Equinix Metal]: https://metal.equinix.com/product/
 [IBM Power Systems Virtual Server]: https://www.ibm.com/products/power-virtual-server

--- a/internal/providers/outscale/outscale.go
+++ b/internal/providers/outscale/outscale.go
@@ -1,0 +1,59 @@
+// Copyright 2026 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The outscale provider fetches a remote configuration from the Outscale
+// user-data metadata service URL.
+
+package outscale
+
+import (
+	"net/url"
+
+	"github.com/coreos/ignition/v2/config/v3_7_experimental/types"
+	"github.com/coreos/ignition/v2/internal/platform"
+	"github.com/coreos/ignition/v2/internal/providers/util"
+	"github.com/coreos/ignition/v2/internal/resource"
+
+	"github.com/coreos/vcontext/report"
+)
+
+// userdataURL is the Outscale metadata service endpoint for user-data.
+var (
+	userdataURL = url.URL{
+		Scheme: "http",
+		Host:   "169.254.169.254",
+		Path:   "/latest/user-data",
+	}
+)
+
+// init registers the Outscale provider with the platform registry.
+func init() {
+	platform.Register(platform.Provider{
+		Name:  "outscale",
+		Fetch: fetchConfig,
+	})
+}
+
+// fetchConfig fetches the Ignition config from the Outscale metadata service.
+func fetchConfig(f *resource.Fetcher) (types.Config, report.Report, error) {
+	data, err := f.FetchToBuffer(userdataURL, resource.FetchOptions{})
+	if err != nil {
+		if err == resource.ErrNotFound {
+			return types.Config{}, report.Report{}, nil
+		}
+		return types.Config{}, report.Report{}, err
+	}
+
+	return util.ParseConfig(f.Logger, data)
+}

--- a/internal/register/providers.go
+++ b/internal/register/providers.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package register imports all platform providers so their init functions
+// register themselves with the platform registry.
 package register
 
 import (
@@ -35,6 +37,7 @@ import (
 	_ "github.com/coreos/ignition/v2/internal/providers/nvidiabluefield"
 	_ "github.com/coreos/ignition/v2/internal/providers/openstack"
 	_ "github.com/coreos/ignition/v2/internal/providers/oraclecloud"
+	_ "github.com/coreos/ignition/v2/internal/providers/outscale"
 	_ "github.com/coreos/ignition/v2/internal/providers/packet"
 	_ "github.com/coreos/ignition/v2/internal/providers/powervs"
 	_ "github.com/coreos/ignition/v2/internal/providers/proxmoxve"


### PR DESCRIPTION
### Add support for the Outscale cloud platform.

Outscale provides an AWS-compatible metadata service at
http://169.254.169.254/latest/ with no IMDSv2 requirement.
The provider fetches the Ignition config from the instance
user-data endpoint.

The provider follows the same pattern as other simple
providers (Hetzner, Vultr, Exoscale).

Tested on an Outscale VM — the metadata service responds
correctly to both /latest/meta-data/ and /latest/user-data
endpoints.

Docs: https://docs.outscale.com/en/userguide/Accessing-the-Metadata-and-User-Data-of-a-VM.html