### PR TITLE
butane/fcos: remove duplicate cex translation registration

### DIFF
--- a/butane/config/fcos/v1_6/translate.go
+++ b/butane/config/fcos/v1_6/translate.go
@@ -361,8 +361,7 @@ func translateBootDeviceLuksCex(from BootDeviceLuks, options common.TranslateOpt
 	tr := translate.NewTranslator("yaml", "json", options)
 	// Discard field is handled by the caller because it doesn't go
 	// into types.Cex
-	tm, r = translate.Prefixed(tr, "enabled", &from.Cex.Enabled, &to.Enabled)
-	translate.MergeP(tr, tm, &r, "enabled", &from.Cex.Enabled, &to.Enabled)
+	tm, r = translate.Prefixed(tr, "cex", &from.Cex, &to)
 	// we're being called manually, not via the translate package's
 	// custom translator mechanism, so we have to add the base
 	// translation ourselves

--- a/butane/config/fcos/v1_7/translate.go
+++ b/butane/config/fcos/v1_7/translate.go
@@ -361,8 +361,7 @@ func translateBootDeviceLuksCex(from BootDeviceLuks, options common.TranslateOpt
 	tr := translate.NewTranslator("yaml", "json", options)
 	// Discard field is handled by the caller because it doesn't go
 	// into types.Cex
-	tm, r = translate.Prefixed(tr, "enabled", &from.Cex.Enabled, &to.Enabled)
-	translate.MergeP(tr, tm, &r, "enabled", &from.Cex.Enabled, &to.Enabled)
+	tm, r = translate.Prefixed(tr, "cex", &from.Cex, &to)
 	// we're being called manually, not via the translate package's
 	// custom translator mechanism, so we have to add the base
 	// translation ourselves

--- a/butane/config/fcos/v1_8_exp/translate.go
+++ b/butane/config/fcos/v1_8_exp/translate.go
@@ -360,8 +360,7 @@ func translateBootDeviceLuksCex(from BootDeviceLuks, options common.TranslateOpt
 	tr := translate.NewTranslator("yaml", "json", options)
 	// Discard field is handled by the caller because it doesn't go
 	// into types.Cex
-	tm, r = translate.Prefixed(tr, "enabled", &from.Cex.Enabled, &to.Enabled)
-	translate.MergeP(tr, tm, &r, "enabled", &from.Cex.Enabled, &to.Enabled)
+	tm, r = translate.Prefixed(tr, "cex", &from.Cex, &to)
 	// we're being called manually, not via the translate package's
 	// custom translator mechanism, so we have to add the base
 	// translation ourselves


### PR DESCRIPTION
Removes a redundant translation merge call in `translateBootDeviceLuksCex` that was causing duplicate translation registrations for the `enabled` field.

The function `translateBootDeviceLuksCex` was previously calling both `translate.Prefixed` and `translate.MergeP` for the exact same `enabled` field in `BootDeviceLuks.Cex`. This PR updates the logic to simply translate the entire `Cex` struct using `translate.Prefixed`, which is sufficient and correctly maintains the `TranslationSet`.

This fix is applied across all experimental and stable FCOS Butane specs that support CEX (`v1_6`, `v1_7`, and `v1_8_exp`), preventing incorrect path tracking and duplicate entries for CEX-enabled LUKS configurations.