### PR TITLE
butane/util: use yaml instead of json for unmarhal

### DIFF
--- a/butane/config/config_test.go
+++ b/butane/config/config_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/coreos/ignition/v2/butane/config/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensures that large sizeMiB values are rendered as normal integers in
+// the generated MachineConfig YAML, rather than being formatted with
+// scientific notation (e.g. "1e+06" instead of "1000000").
+// See: https://github.com/coreos/ignition/issues/2309
+func TestOpenShiftSizeMiBFormatting(t *testing.T) {
+	input := []byte(`
+variant: openshift
+version: 4.19.0
+metadata:
+  name: test
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  disks:
+    - device: /dev/sda
+      partitions:
+        - number: 1
+          size_mib: 17179869184
+`)
+	out, r, err := TranslateBytes(input, common.TranslateBytesOptions{})
+	assert.NoError(t, err)
+	assert.False(t, r.IsFatal())
+
+	strOut := string(out)
+	assert.Contains(t, strOut, "sizeMiB: 17179869184")
+	assert.NotContains(t, strOut, "e+")
+}

--- a/butane/config/util/util.go
+++ b/butane/config/util/util.go
@@ -156,7 +156,7 @@ func TranslateBytesYAML(input []byte, container interface{}, translateMethod str
 	}
 
 	var ifaceCfg interface{}
-	if err := json.Unmarshal(jsonCfg, &ifaceCfg); err != nil {
+	if err := yaml.Unmarshal(jsonCfg, &ifaceCfg); err != nil {
 		return []byte{}, r, err
 	}
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,8 @@ nav_order: 9
 ### Bug fixes
 
 - Resolve intermediate symlinks in relabel paths, fixing SELinux relabeling failures for users with `home_dir` on OSTree platforms after policycoreutils 3.11 ([#2316](https://github.com/coreos/ignition/pull/2316))
+- Fix Butane rendering large `sizeMiB`/`startMiB` values in scientific
+  notation when generating OpenShift MachineConfig YAML ([#2310](https://github.com/coreos/ignition/pull/2310))
 
 ## Ignition 2.27.0 (2026-08-26)
 


### PR DESCRIPTION
Since yaml is a superset of json, we can use the yaml unmarshal function instead of the json one.

This unmarshalling will be more accurate, as it does not convert numbers to floats (which would lead to awkward formatting of the generated MCO)

Adding test and release note is still needed

closes: #2309