### PR TITLE
butane/util: emit large MachineConfig integers as decimals

### DIFF
--- a/butane/config/openshift/v4_18/translate_test.go
+++ b/butane/config/openshift/v4_18/translate_test.go
@@ -513,3 +513,38 @@ func TestValidateSupport(t *testing.T) {
 		})
 	}
 }
+// Append this test to butane/config/openshift/v4_18/translate_test.go
+
+func TestMachineConfigYAMLLargeSizeMiB(t *testing.T) {
+	in := `variant: openshift
+version: 4.18.0
+metadata:
+  name: 98-master-partition
+  labels:
+    machineconfiguration.openshift.io/role: master
+storage:
+  disks:
+    - device: /dev/disk/by-id/virtio-targetdisk
+      partitions:
+        - number: 4
+          label: root
+          size_mib: 8389000
+          resize: true
+        - number: 5
+          label: var
+          size_mib: 0
+        - number: 6
+          label: odf-1
+          size_mib: 1231872
+`
+	out, r, err := ToConfigBytes([]byte(in), common.TranslateBytesOptions{})
+	assert.NoError(t, err)
+	assert.False(t, r.IsFatal())
+	got := string(out)
+	assert.Contains(t, got, "sizeMiB: 8389000")
+	assert.Contains(t, got, "sizeMiB: 1231872")
+	assert.Contains(t, got, "sizeMiB: 0")
+	assert.NotContains(t, got, "8.389e+06")
+	assert.NotContains(t, got, "1.231872e+06")
+	assert.NotContains(t, got, "e+")
+}

--- a/butane/config/util/util.go
+++ b/butane/config/util/util.go
@@ -155,8 +155,8 @@ func TranslateBytesYAML(input []byte, container interface{}, translateMethod str
 		return jsonCfg, r, err
 	}
 
-	var ifaceCfg interface{}
-	if err := json.Unmarshal(jsonCfg, &ifaceCfg); err != nil {
+	ifaceCfg, err := unmarshalJSONForYAML(jsonCfg)
+	if err != nil {
 		return []byte{}, r, err
 	}
 

--- a/butane/config/util/yaml_integers.go
+++ b/butane/config/util/yaml_integers.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+
+	"github.com/clarketm/json"
+)
+
+// unmarshalJSONForYAML decodes JSON into a generic structure suitable for
+// YAML encoding. Integers are preserved as int64 so yaml.v3 does not emit
+// scientific notation for values >= 1e6 (e.g. sizeMiB: 8.389e+06).
+func unmarshalJSONForYAML(jsonCfg []byte) (interface{}, error) {
+	dec := json.NewDecoder(bytes.NewReader(jsonCfg))
+	dec.UseNumber()
+	var ifaceCfg interface{}
+	if err := dec.Decode(&ifaceCfg); err != nil {
+		return nil, err
+	}
+	return convertJSONNumbers(ifaceCfg), nil
+}
+
+// convertJSONNumbers walks a decoded JSON tree and replaces json.Number
+// values with int64 when possible, otherwise float64. json.Unmarshal into
+// interface{} otherwise uses float64, and yaml.v3 then formats values >= 1e6
+// with strconv.FormatFloat 'g' as scientific notation.
+func convertJSONNumbers(v interface{}) interface{} {
+	switch x := v.(type) {
+	case map[string]interface{}:
+		for k, val := range x {
+			x[k] = convertJSONNumbers(val)
+		}
+		return x
+	case []interface{}:
+		for i, val := range x {
+			x[i] = convertJSONNumbers(val)
+		}
+		return x
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return i
+		}
+		f, err := x.Float64()
+		if err != nil {
+			return x.String()
+		}
+		return f
+	default:
+		return v
+	}
+}

--- a/butane/config/util/yaml_integers_test.go
+++ b/butane/config/util/yaml_integers_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestUnmarshalJSONForYAMLIntegers(t *testing.T) {
+	jsonCfg := []byte(`{"sizeMiB":8389000,"startMiB":2048,"values":[1000000],"ratio":1.5}`)
+	v, err := unmarshalJSONForYAML(jsonCfg)
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	assert.NoError(t, enc.Encode(v))
+	assert.NoError(t, enc.Close())
+	out := buf.String()
+
+	assert.Contains(t, out, "sizeMiB: 8389000")
+	assert.Contains(t, out, "startMiB: 2048")
+	assert.Contains(t, out, "- 1000000")
+	assert.Contains(t, out, "ratio: 1.5")
+	assert.False(t, strings.Contains(out, "e+"), "YAML must not use scientific notation: %s", out)
+}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,9 @@ nav_order: 9
 
 ### Bug fixes
 
+- Encode large integer fields such as `sizeMiB` as decimal numbers in
+  MachineConfig YAML, instead of scientific notation
+  ([#2309](https://github.com/coreos/ignition/issues/2309))
 
 ## Ignition 2.27.0 (2026-08-26)
 


### PR DESCRIPTION
## Summary
- Fix MachineConfig YAML encoding of large integers such as `sizeMiB`/`startMiB` so values >= 1e6 are written as decimals (`8389000`) instead of scientific notation (`8.389e+06`).
- Add `yaml_integers.go` to preserve JSON numbers as `int64` before YAML encoding in `TranslateBytesYAML`.
- Add unit and OpenShift 4.18 regression tests plus release note.

Fixes #2309

Bug workspace: https://github.com/butcher-pudge-0/OCPBUGS-114735

## Test plan
- [x] `go test -mod=vendor ./butane/config/util ./butane/config/openshift/v4_18`
- [ ] Transpile `reproduction/sample.bu` without `--raw` and confirm `sizeMiB: 8389000`


Made with [Cursor](https://cursor.com)