### PR TITLE
ci/tmt-tests: fix verbosity flag

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -76,5 +76,5 @@ jobs:
           fi
           # eval is used to allow the use of variables in the command
           # and to avoid issues withe the tmt --filter option
-          eval "tmt $CONTEXT_PARAM run --all --debug -vvvv provision $TMT_PROVISION_OPTS $PLAN_FILTER_PARAM"
+          eval "tmt $CONTEXT_PARAM run --all --debug -vvv provision $TMT_PROVISION_OPTS $PLAN_FILTER_PARAM"
 


### PR DESCRIPTION
Only verbosity level 1-3 are supported, level 4 (-vvvv) is not. Let's drop it back to 3.

Same as https://github.com/coreos/afterburn/pull/1300, since these aren't in `repo-templates`